### PR TITLE
fix: edit modal covered by keyboard

### DIFF
--- a/app/ConversationScreen.tsx
+++ b/app/ConversationScreen.tsx
@@ -2588,6 +2588,7 @@ const ConversationScreen = () => {
         onBackButtonPress={editing ? undefined : handleCloseEditModal}
         style={{ justifyContent: 'flex-end', margin: 0 }}
         useNativeDriver
+        avoidKeyboard={true}
       >
         <View style={{ 
           backgroundColor: colors.background, 


### PR DESCRIPTION
Fix keyboard covering the edit modal in Conversation Screen