### PR TITLE
feat: add clickable follower notifications

### DIFF
--- a/app/NotificationsScreen.tsx
+++ b/app/NotificationsScreen.tsx
@@ -44,11 +44,6 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
   // Parse as UTC and let JS handle local conversion
   const localDate = typeof rawTimestamp === 'string' ? new Date(rawTimestamp + 'Z') : new Date(rawTimestamp);
   const translatedTimestamp = formatNotificationTime(localDate.toISOString());
-  // Log both to console for inspection
-  console.log(`Notification ID: ${notification.id}`);
-  console.log(`Raw timestamp:`, rawTimestamp);
-  console.log(`Local date:`, localDate);
-  console.log(`Translated timestamp:`, translatedTimestamp);
 
   const handlePress = () => {
     if (!notification.read) {
@@ -69,7 +64,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
         },
       ]}
       onPress={handlePress}
-      disabled={!isActionableNotification(notification)}
+      disabled={!isActionableNotification(notification) && notification.type !== 'follow'}
     >
       <View style={styles.notificationHeader}>
         <View style={[styles.iconContainer, { backgroundColor: notification.color + '20' }]}>
@@ -96,10 +91,6 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
           <View style={styles.notificationBottom}>
             <Text style={[styles.timeText, { color: isDark ? '#8899A6' : '#657786' }]}>
               {translatedTimestamp}
-            </Text>
-            {/* Debug: show raw timestamp in UI for now */}
-            <Text style={[styles.timeText, { color: '#E74C3C', fontSize: 11 }]}>
-              {String(rawTimestamp)}
             </Text>
             {notification.amount && (
               <Text style={[styles.amountText, { color: '#17BF63' }]}>
@@ -166,8 +157,19 @@ const NotificationsScreen = () => {
   // The useNotifications hook handles loading notifications when username changes
 
   const handleNotificationPress = (notification: ParsedNotification) => {
+    // Handle follower notifications - navigate to the follower's profile
+    if (notification.type === 'follow' && notification.actionUser) {
+      router.push({
+        pathname: '/ProfileScreen',
+        params: {
+          username: notification.actionUser,
+        },
+      });
+      return;
+    }
+    
+    // Handle other actionable notifications - navigate to post/comment
     if (isActionableNotification(notification) && notification.targetContent) {
-      // Navigate to the post/comment
       router.push({
         pathname: '/ConversationScreen',
         params: {

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -114,10 +114,13 @@ export function parseNotification(notification: HiveNotification): ParsedNotific
       parsed.color = '#1DA1F2';
       parsed.actionText = 'Started following you';
       
-      // Extract follower from message like "@dave started following you"
-      const followMatch = notification.msg.match(/@(\w+) started following you/);
+      // Extract follower from message like "@dave followed you" or "@dave started following you"
+      const followMatch = notification.msg.match(/@(\w+) (?:followed|started following) you/);
       if (followMatch) {
         parsed.actionUser = followMatch[1];
+      } else if (notification.url && notification.url.startsWith('@')) {
+        // Fallback: extract username from URL field like "@ankapolo"
+        parsed.actionUser = notification.url.substring(1);
       }
       break;
 


### PR DESCRIPTION
- Make follower notifications clickable and navigate to user profile
- Fix regex pattern in notifications parser to handle 'followed you' message format
- Add fallback to extract username from URL field when regex fails
- Update TouchableOpacity disabled logic to enable follow notifications
- Navigate to ProfileScreen with follower's username when notification is tapped

Resolves: Users can now tap on follower notifications to view the profile of the person who followed them, improving user engagement and discoverability.