### PR TITLE
Feature/hive post previews in feed

### DIFF
--- a/app/HivePostScreen.tsx
+++ b/app/HivePostScreen.tsx
@@ -1,0 +1,432 @@
+import React, { useState, useCallback } from 'react';
+import { SafeAreaView as SafeAreaViewRN } from 'react-native';
+import {
+  SafeAreaView as SafeAreaViewSA,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  useColorScheme,
+  ActivityIndicator,
+  Linking,
+} from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Image as ExpoImage } from 'expo-image';
+import SafeRenderHtml from '../components/SafeRenderHtml';
+import { Dimensions } from 'react-native';
+import Markdown from 'react-native-markdown-display';
+import { Client } from '@hiveio/dhive';
+import { useUserAuth } from '../hooks/useUserAuth';
+import { useUpvote } from '../hooks/useUpvote';
+import { useHiveData } from '../hooks/useHiveData';
+import UpvoteModal from '../components/UpvoteModal';
+import genericAvatar from '../assets/images/generic-avatar.png';
+
+const HIVE_NODES = [
+  'https://api.hive.blog',
+  'https://api.deathwing.me',
+  'https://api.openhive.network',
+];
+const client = new Client(HIVE_NODES);
+
+interface HivePostData {
+  author: string;
+  permlink: string;
+  title: string;
+  body: string;
+  created: string;
+  voteCount: number;
+  replyCount: number;
+  payout: number;
+  avatarUrl?: string;
+  active_votes?: any[];
+  json_metadata?: string;
+  category?: string;
+  tags?: string[];
+}
+
+const HivePostScreen = () => {
+  const { author, permlink } = useLocalSearchParams<{ author: string; permlink: string }>();
+  const isDark = useColorScheme() === 'dark';
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { currentUsername } = useUserAuth();
+  const { hivePrice, globalProps, rewardFund } = useHiveData();
+
+  console.log('[HivePostScreen] Component loaded with params:', { author, permlink });
+
+  const [post, setPost] = useState<HivePostData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    upvoteModalVisible,
+    upvoteTarget,
+    voteWeight,
+    voteValue,
+    upvoteLoading,
+    upvoteSuccess,
+    voteWeightLoading,
+    openUpvoteModal,
+    closeUpvoteModal,
+    setVoteWeight,
+    confirmUpvote,
+  } = useUpvote(currentUsername, globalProps, rewardFund, hivePrice);
+
+  const fetchHivePost = useCallback(async () => {
+    console.log('[HivePostScreen] fetchHivePost called with:', { author, permlink });
+    
+    if (!author || !permlink) {
+      console.log('[HivePostScreen] Missing parameters');
+      setError('Missing post parameters');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      console.log('[HivePostScreen] Fetching post data from Hive...');
+      // Fetch the post
+      const postData = await client.database.call('get_content', [author, permlink]);
+
+      if (!postData || !postData.author) {
+        setError('Post not found');
+        setLoading(false);
+        return;
+      }
+
+      // Fetch author avatar
+      let avatarUrl: string | undefined = undefined;
+      try {
+        const accounts = await client.database.call('get_accounts', [[postData.author]]);
+        if (accounts && accounts[0]) {
+          const metadata = accounts[0].posting_json_metadata || accounts[0].json_metadata;
+          if (metadata) {
+            try {
+              const profile = JSON.parse(metadata).profile;
+              if (profile && profile.profile_image) {
+                avatarUrl = profile.profile_image;
+              }
+            } catch (e) {
+              // Invalid JSON metadata
+            }
+          }
+        }
+      } catch (e) {
+        // Avatar fetch failed
+      }
+
+      // Extract tags from metadata
+      let tags: string[] = [];
+      try {
+        if (postData.json_metadata) {
+          const metadata = JSON.parse(postData.json_metadata);
+          tags = metadata.tags || [];
+        }
+      } catch (e) {
+        // Invalid JSON metadata
+      }
+
+      const hivePostData: HivePostData = {
+        author: postData.author,
+        permlink: postData.permlink,
+        title: postData.title || 'Untitled Post',
+        body: postData.body,
+        created: postData.created,
+        voteCount: postData.net_votes || 0,
+        replyCount: postData.children || 0,
+        payout: parseFloat(
+          postData.pending_payout_value
+            ? postData.pending_payout_value.replace(' HBD', '')
+            : '0'
+        ),
+        avatarUrl,
+        active_votes: postData.active_votes,
+        json_metadata: postData.json_metadata,
+        category: postData.category,
+        tags,
+      };
+
+      setPost(hivePostData);
+    } catch (error) {
+      console.error('Error fetching Hive post:', error);
+      setError('Failed to load post');
+    } finally {
+      setLoading(false);
+    }
+  }, [author, permlink]);
+
+  React.useEffect(() => {
+    fetchHivePost();
+  }, [fetchHivePost]);
+
+  const handleUpvotePress = useCallback(() => {
+    if (!post) return;
+    
+    openUpvoteModal({
+      author: post.author,
+      permlink: post.permlink,
+      snap: post,
+    });
+  }, [post, openUpvoteModal]);
+
+  const handleRefresh = useCallback(() => {
+    fetchHivePost();
+  }, [fetchHivePost]);
+
+  const colors = {
+    background: isDark ? '#15202B' : '#fff',
+    text: isDark ? '#D7DBDC' : '#0F1419',
+    border: isDark ? '#38444D' : '#E1E8ED',
+    icon: isDark ? '#8899A6' : '#657786',
+    button: isDark ? '#1DA1F2' : '#1DA1F2',
+    buttonText: '#FFFFFF',
+    buttonInactive: isDark ? '#38444D' : '#E1E8ED',
+    payout: '#17BF63',
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaViewSA style={{ flex: 1, backgroundColor: colors.background }}>
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator size="large" color={colors.button} />
+          <Text style={{ color: colors.text, marginTop: 16 }}>Loading post...</Text>
+        </View>
+      </SafeAreaViewSA>
+    );
+  }
+
+  if (error || !post) {
+    return (
+      <SafeAreaViewSA style={{ flex: 1, backgroundColor: colors.background }}>
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
+          <FontAwesome name="exclamation-triangle" size={48} color={colors.icon} />
+          <Text style={{ color: colors.text, fontSize: 18, marginTop: 16, textAlign: 'center' }}>
+            {error || 'Post not found'}
+          </Text>
+          <TouchableOpacity
+            onPress={handleRefresh}
+            style={{
+              backgroundColor: colors.button,
+              paddingHorizontal: 20,
+              paddingVertical: 10,
+              borderRadius: 8,
+              marginTop: 16,
+            }}
+          >
+            <Text style={{ color: colors.buttonText, fontWeight: '600' }}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaViewSA>
+    );
+  }
+
+  const windowWidth = Dimensions.get('window').width;
+  const isHtml = post.body.includes('<') && post.body.includes('>');
+
+  return (
+    <SafeAreaViewSA style={{ flex: 1, backgroundColor: colors.background }}>
+      {/* Header */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        }}
+      >
+        <TouchableOpacity onPress={() => router.back()}>
+          <FontAwesome name="arrow-left" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text
+          style={{
+            color: colors.text,
+            fontSize: 18,
+            fontWeight: '600',
+            marginLeft: 16,
+            flex: 1,
+          }}
+        >
+          Hive Post
+        </Text>
+        <TouchableOpacity onPress={handleRefresh}>
+          <FontAwesome name="refresh" size={20} color={colors.icon} />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 16 }}>
+        {/* Author Info */}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            marginBottom: 16,
+          }}
+        >
+          <ExpoImage
+            source={post.avatarUrl ? { uri: post.avatarUrl } : genericAvatar}
+            style={{ width: 48, height: 48, borderRadius: 24 }}
+            contentFit="cover"
+          />
+          <View style={{ marginLeft: 12, flex: 1 }}>
+            <Text style={{ color: colors.text, fontSize: 16, fontWeight: '600' }}>
+              {post.author}
+            </Text>
+            <Text style={{ color: colors.icon, fontSize: 14 }}>
+              {new Date(post.created + 'Z').toLocaleString()}
+            </Text>
+          </View>
+        </View>
+
+        {/* Title */}
+        {post.title && (
+          <Text
+            style={{
+              color: colors.text,
+              fontSize: 20,
+              fontWeight: 'bold',
+              marginBottom: 16,
+            }}
+          >
+            {post.title}
+          </Text>
+        )}
+
+        {/* Content */}
+        <View style={{ marginBottom: 20 }}>
+          {isHtml ? (
+            <SafeRenderHtml
+              contentWidth={windowWidth - 32}
+              source={{ html: post.body }}
+              baseStyle={{
+                color: colors.text,
+                fontSize: 16,
+                lineHeight: 24,
+              }}
+              tagsStyles={{
+                a: { color: colors.button },
+                p: { marginBottom: 16 },
+                h1: { color: colors.text, fontSize: 24, fontWeight: 'bold', marginBottom: 16 },
+                h2: { color: colors.text, fontSize: 20, fontWeight: 'bold', marginBottom: 12 },
+                h3: { color: colors.text, fontSize: 18, fontWeight: 'bold', marginBottom: 10 },
+              }}
+            />
+          ) : (
+            <Markdown
+              style={{
+                body: { color: colors.text, fontSize: 16, lineHeight: 24 },
+                paragraph: { marginBottom: 16 },
+                heading1: { color: colors.text, fontSize: 24, fontWeight: 'bold', marginBottom: 16 },
+                heading2: { color: colors.text, fontSize: 20, fontWeight: 'bold', marginBottom: 12 },
+                heading3: { color: colors.text, fontSize: 18, fontWeight: 'bold', marginBottom: 10 },
+                link: { color: colors.button },
+              }}
+            >
+              {post.body}
+            </Markdown>
+          )}
+        </View>
+
+        {/* Tags */}
+        {post.tags && post.tags.length > 0 && (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 20 }}>
+            {post.tags.slice(0, 5).map((tag, index) => (
+              <View
+                key={index}
+                style={{
+                  backgroundColor: colors.button,
+                  paddingHorizontal: 8,
+                  paddingVertical: 4,
+                  borderRadius: 12,
+                  marginRight: 8,
+                  marginBottom: 4,
+                }}
+              >
+                <Text style={{ color: colors.buttonText, fontSize: 12 }}>#{tag}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Engagement Metrics */}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingVertical: 16,
+            borderTopWidth: 1,
+            borderTopColor: colors.border,
+          }}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <TouchableOpacity
+              onPress={handleUpvotePress}
+              disabled={
+                post.active_votes?.some(
+                  (vote: any) => vote.voter === currentUsername && vote.percent > 0
+                )
+              }
+              style={{ marginRight: 16 }}
+            >
+              <FontAwesome
+                name="arrow-up"
+                size={20}
+                color={
+                  post.active_votes?.some(
+                    (vote: any) => vote.voter === currentUsername && vote.percent > 0
+                  )
+                    ? '#8e44ad'
+                    : colors.icon
+                }
+              />
+            </TouchableOpacity>
+            <Text style={{ color: colors.text, fontSize: 16, marginRight: 16 }}>
+              {post.voteCount}
+            </Text>
+            <FontAwesome name="comment-o" size={16} color={colors.icon} style={{ marginRight: 8 }} />
+            <Text style={{ color: colors.text, fontSize: 16, marginRight: 16 }}>
+              {post.replyCount}
+            </Text>
+          </View>
+          <Text style={{ color: colors.payout, fontSize: 16, fontWeight: '600' }}>
+            ${post.payout.toFixed(2)}
+          </Text>
+        </View>
+      </ScrollView>
+
+      {/* Upvote Modal */}
+      <UpvoteModal
+        visible={upvoteModalVisible}
+        voteWeight={voteWeight}
+        voteValue={voteValue}
+        voteWeightLoading={voteWeightLoading}
+        upvoteLoading={upvoteLoading}
+        upvoteSuccess={upvoteSuccess}
+        onClose={closeUpvoteModal}
+        onConfirm={confirmUpvote}
+        onVoteWeightChange={setVoteWeight}
+        colors={{
+          background: colors.background,
+          text: colors.text,
+          button: colors.button,
+          buttonText: colors.buttonText,
+          buttonInactive: colors.buttonInactive,
+          icon: colors.icon,
+        }}
+      />
+    </SafeAreaViewSA>
+  );
+};
+
+export default HivePostScreen;
+
+export const options = { headerShown: false }; 

--- a/app/HivePostScreen.tsx
+++ b/app/HivePostScreen.tsx
@@ -50,14 +50,20 @@ interface HivePostData {
 }
 
 const HivePostScreen = () => {
-  const { author, permlink } = useLocalSearchParams<{ author: string; permlink: string }>();
+  const { author, permlink } = useLocalSearchParams<{
+    author: string;
+    permlink: string;
+  }>();
   const isDark = useColorScheme() === 'dark';
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { currentUsername } = useUserAuth();
   const { hivePrice, globalProps, rewardFund } = useHiveData();
 
-  console.log('[HivePostScreen] Component loaded with params:', { author, permlink });
+  console.log('[HivePostScreen] Component loaded with params:', {
+    author,
+    permlink,
+  });
 
   const [post, setPost] = useState<HivePostData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -78,8 +84,11 @@ const HivePostScreen = () => {
   } = useUpvote(currentUsername, globalProps, rewardFund, hivePrice);
 
   const fetchHivePost = useCallback(async () => {
-    console.log('[HivePostScreen] fetchHivePost called with:', { author, permlink });
-    
+    console.log('[HivePostScreen] fetchHivePost called with:', {
+      author,
+      permlink,
+    });
+
     if (!author || !permlink) {
       console.log('[HivePostScreen] Missing parameters');
       setError('Missing post parameters');
@@ -93,7 +102,10 @@ const HivePostScreen = () => {
 
       console.log('[HivePostScreen] Fetching post data from Hive...');
       // Fetch the post
-      const postData = await client.database.call('get_content', [author, permlink]);
+      const postData = await client.database.call('get_content', [
+        author,
+        permlink,
+      ]);
 
       if (!postData || !postData.author) {
         setError('Post not found');
@@ -104,9 +116,12 @@ const HivePostScreen = () => {
       // Fetch author avatar
       let avatarUrl: string | undefined = undefined;
       try {
-        const accounts = await client.database.call('get_accounts', [[postData.author]]);
+        const accounts = await client.database.call('get_accounts', [
+          [postData.author],
+        ]);
         if (accounts && accounts[0]) {
-          const metadata = accounts[0].posting_json_metadata || accounts[0].json_metadata;
+          const metadata =
+            accounts[0].posting_json_metadata || accounts[0].json_metadata;
           if (metadata) {
             try {
               const profile = JSON.parse(metadata).profile;
@@ -168,7 +183,7 @@ const HivePostScreen = () => {
 
   const handleUpvotePress = useCallback(() => {
     if (!post) return;
-    
+
     openUpvoteModal({
       author: post.author,
       permlink: post.permlink,
@@ -194,9 +209,13 @@ const HivePostScreen = () => {
   if (loading) {
     return (
       <SafeAreaViewSA style={{ flex: 1, backgroundColor: colors.background }}>
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <ActivityIndicator size="large" color={colors.button} />
-          <Text style={{ color: colors.text, marginTop: 16 }}>Loading post...</Text>
+        <View
+          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
+        >
+          <ActivityIndicator size='large' color={colors.button} />
+          <Text style={{ color: colors.text, marginTop: 16 }}>
+            Loading post...
+          </Text>
         </View>
       </SafeAreaViewSA>
     );
@@ -205,9 +224,27 @@ const HivePostScreen = () => {
   if (error || !post) {
     return (
       <SafeAreaViewSA style={{ flex: 1, backgroundColor: colors.background }}>
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 }}>
-          <FontAwesome name="exclamation-triangle" size={48} color={colors.icon} />
-          <Text style={{ color: colors.text, fontSize: 18, marginTop: 16, textAlign: 'center' }}>
+        <View
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: 20,
+          }}
+        >
+          <FontAwesome
+            name='exclamation-triangle'
+            size={48}
+            color={colors.icon}
+          />
+          <Text
+            style={{
+              color: colors.text,
+              fontSize: 18,
+              marginTop: 16,
+              textAlign: 'center',
+            }}
+          >
             {error || 'Post not found'}
           </Text>
           <TouchableOpacity
@@ -220,7 +257,9 @@ const HivePostScreen = () => {
               marginTop: 16,
             }}
           >
-            <Text style={{ color: colors.buttonText, fontWeight: '600' }}>Retry</Text>
+            <Text style={{ color: colors.buttonText, fontWeight: '600' }}>
+              Retry
+            </Text>
           </TouchableOpacity>
         </View>
       </SafeAreaViewSA>
@@ -244,7 +283,7 @@ const HivePostScreen = () => {
         }}
       >
         <TouchableOpacity onPress={() => router.back()}>
-          <FontAwesome name="arrow-left" size={24} color={colors.text} />
+          <FontAwesome name='arrow-left' size={24} color={colors.text} />
         </TouchableOpacity>
         <Text
           style={{
@@ -258,7 +297,7 @@ const HivePostScreen = () => {
           Hive Post
         </Text>
         <TouchableOpacity onPress={handleRefresh}>
-          <FontAwesome name="refresh" size={20} color={colors.icon} />
+          <FontAwesome name='refresh' size={20} color={colors.icon} />
         </TouchableOpacity>
       </View>
 
@@ -274,10 +313,12 @@ const HivePostScreen = () => {
           <ExpoImage
             source={post.avatarUrl ? { uri: post.avatarUrl } : genericAvatar}
             style={{ width: 48, height: 48, borderRadius: 24 }}
-            contentFit="cover"
+            contentFit='cover'
           />
           <View style={{ marginLeft: 12, flex: 1 }}>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: '600' }}>
+            <Text
+              style={{ color: colors.text, fontSize: 16, fontWeight: '600' }}
+            >
               {post.author}
             </Text>
             <Text style={{ color: colors.icon, fontSize: 14 }}>
@@ -314,9 +355,24 @@ const HivePostScreen = () => {
               tagsStyles={{
                 a: { color: colors.button },
                 p: { marginBottom: 16 },
-                h1: { color: colors.text, fontSize: 24, fontWeight: 'bold', marginBottom: 16 },
-                h2: { color: colors.text, fontSize: 20, fontWeight: 'bold', marginBottom: 12 },
-                h3: { color: colors.text, fontSize: 18, fontWeight: 'bold', marginBottom: 10 },
+                h1: {
+                  color: colors.text,
+                  fontSize: 24,
+                  fontWeight: 'bold',
+                  marginBottom: 16,
+                },
+                h2: {
+                  color: colors.text,
+                  fontSize: 20,
+                  fontWeight: 'bold',
+                  marginBottom: 12,
+                },
+                h3: {
+                  color: colors.text,
+                  fontSize: 18,
+                  fontWeight: 'bold',
+                  marginBottom: 10,
+                },
               }}
             />
           ) : (
@@ -324,9 +380,24 @@ const HivePostScreen = () => {
               style={{
                 body: { color: colors.text, fontSize: 16, lineHeight: 24 },
                 paragraph: { marginBottom: 16 },
-                heading1: { color: colors.text, fontSize: 24, fontWeight: 'bold', marginBottom: 16 },
-                heading2: { color: colors.text, fontSize: 20, fontWeight: 'bold', marginBottom: 12 },
-                heading3: { color: colors.text, fontSize: 18, fontWeight: 'bold', marginBottom: 10 },
+                heading1: {
+                  color: colors.text,
+                  fontSize: 24,
+                  fontWeight: 'bold',
+                  marginBottom: 16,
+                },
+                heading2: {
+                  color: colors.text,
+                  fontSize: 20,
+                  fontWeight: 'bold',
+                  marginBottom: 12,
+                },
+                heading3: {
+                  color: colors.text,
+                  fontSize: 18,
+                  fontWeight: 'bold',
+                  marginBottom: 10,
+                },
                 link: { color: colors.button },
               }}
             >
@@ -337,7 +408,9 @@ const HivePostScreen = () => {
 
         {/* Tags */}
         {post.tags && post.tags.length > 0 && (
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 20 }}>
+          <View
+            style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 20 }}
+          >
             {post.tags.slice(0, 5).map((tag, index) => (
               <View
                 key={index}
@@ -350,7 +423,9 @@ const HivePostScreen = () => {
                   marginBottom: 4,
                 }}
               >
-                <Text style={{ color: colors.buttonText, fontSize: 12 }}>#{tag}</Text>
+                <Text style={{ color: colors.buttonText, fontSize: 12 }}>
+                  #{tag}
+                </Text>
               </View>
             ))}
           </View>
@@ -370,19 +445,19 @@ const HivePostScreen = () => {
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <TouchableOpacity
               onPress={handleUpvotePress}
-              disabled={
-                post.active_votes?.some(
-                  (vote: any) => vote.voter === currentUsername && vote.percent > 0
-                )
-              }
+              disabled={post.active_votes?.some(
+                (vote: any) =>
+                  vote.voter === currentUsername && vote.percent > 0
+              )}
               style={{ marginRight: 16 }}
             >
               <FontAwesome
-                name="arrow-up"
+                name='arrow-up'
                 size={20}
                 color={
                   post.active_votes?.some(
-                    (vote: any) => vote.voter === currentUsername && vote.percent > 0
+                    (vote: any) =>
+                      vote.voter === currentUsername && vote.percent > 0
                   )
                     ? '#8e44ad'
                     : colors.icon
@@ -392,12 +467,19 @@ const HivePostScreen = () => {
             <Text style={{ color: colors.text, fontSize: 16, marginRight: 16 }}>
               {post.voteCount}
             </Text>
-            <FontAwesome name="comment-o" size={16} color={colors.icon} style={{ marginRight: 8 }} />
+            <FontAwesome
+              name='comment-o'
+              size={16}
+              color={colors.icon}
+              style={{ marginRight: 8 }}
+            />
             <Text style={{ color: colors.text, fontSize: 16, marginRight: 16 }}>
               {post.replyCount}
             </Text>
           </View>
-          <Text style={{ color: colors.payout, fontSize: 16, fontWeight: '600' }}>
+          <Text
+            style={{ color: colors.payout, fontSize: 16, fontWeight: '600' }}
+          >
             ${post.payout.toFixed(2)}
           </Text>
         </View>
@@ -429,4 +511,4 @@ const HivePostScreen = () => {
 
 export default HivePostScreen;
 
-export const options = { headerShown: false }; 
+export const options = { headerShown: false };

--- a/app/NotificationsScreen.tsx
+++ b/app/NotificationsScreen.tsx
@@ -24,6 +24,15 @@ import {
   type ParsedNotification,
 } from '../utils/notifications';
 import { useNotifications } from '../hooks/useNotifications';
+import { detectPostType, type PostInfo } from '../utils/postTypeDetector';
+import { Client } from '@hiveio/dhive';
+
+const HIVE_NODES = [
+  'https://api.hive.blog',
+  'https://api.deathwing.me',
+  'https://api.openhive.network',
+];
+const client = new Client(HIVE_NODES);
 
 interface NotificationItemProps {
   notification: ParsedNotification;
@@ -177,9 +186,17 @@ const NotificationsScreen = () => {
 
   // The useNotifications hook handles loading notifications when username changes
 
-  const handleNotificationPress = (notification: ParsedNotification) => {
+  const handleNotificationPress = async (notification: ParsedNotification) => {
+    console.log('[NotificationsScreen] handleNotificationPress called:', {
+      notificationType: notification.type,
+      actionUser: notification.actionUser,
+      targetContent: notification.targetContent,
+      isActionable: isActionableNotification(notification),
+    });
+
     // Handle follower notifications - navigate to the follower's profile
     if (notification.type === 'follow' && notification.actionUser) {
+      console.log('[NotificationsScreen] Navigating to ProfileScreen for follow notification');
       router.push({
         pathname: '/ProfileScreen',
         params: {
@@ -191,13 +208,87 @@ const NotificationsScreen = () => {
 
     // Handle other actionable notifications - navigate to post/comment
     if (isActionableNotification(notification) && notification.targetContent) {
-      router.push({
-        pathname: '/ConversationScreen',
-        params: {
-          author: notification.targetContent.author,
-          permlink: notification.targetContent.permlink,
-        },
+      console.log('[NotificationsScreen] Fetching post data for navigation:', {
+        author: notification.targetContent.author,
+        permlink: notification.targetContent.permlink,
       });
+
+      try {
+        // Fetch the post data to determine if it's a snap or regular Hive post
+        const postData = await client.database.call('get_content', [
+          notification.targetContent.author,
+          notification.targetContent.permlink,
+        ]);
+
+        console.log('[NotificationsScreen] Post data received:', {
+          hasPostData: !!postData,
+          author: postData?.author,
+          permlink: postData?.permlink,
+          title: postData?.title,
+          parent_author: postData?.parent_author,
+          json_metadata: postData?.json_metadata ? 'present' : 'missing',
+        });
+
+        if (postData && postData.author) {
+          const postInfo: PostInfo = {
+            author: postData.author,
+            permlink: postData.permlink,
+            title: postData.title,
+            body: postData.body,
+            json_metadata: postData.json_metadata,
+            parent_author: postData.parent_author,
+            parent_permlink: postData.parent_permlink,
+          };
+
+          console.log('[NotificationsScreen] Post info for detection:', {
+            author: postInfo.author,
+            permlink: postInfo.permlink,
+            parent_author: postInfo.parent_author,
+            hasMetadata: !!postInfo.json_metadata,
+          });
+
+          const postType = detectPostType(postInfo);
+          console.log('[NotificationsScreen] Post type detected:', postType);
+          
+          if (postType === 'snap') {
+            console.log('[NotificationsScreen] Navigating to ConversationScreen (snap)');
+            router.push({
+              pathname: '/ConversationScreen',
+              params: {
+                author: notification.targetContent.author,
+                permlink: notification.targetContent.permlink,
+              },
+            });
+          } else {
+            console.log('[NotificationsScreen] Navigating to HivePostScreen (regular post)');
+            router.push({
+              pathname: '/HivePostScreen',
+              params: {
+                author: notification.targetContent.author,
+                permlink: notification.targetContent.permlink,
+              },
+            });
+          }
+        } else {
+          console.log('[NotificationsScreen] Post not found, showing error');
+          // Show an error instead of navigating to a broken screen
+          Alert.alert(
+            'Post Not Found',
+            'The post you\'re trying to view could not be found. It may have been deleted or the link may be invalid.',
+            [{ text: 'OK' }]
+          );
+        }
+      } catch (error) {
+        console.error('[NotificationsScreen] Error fetching post data for navigation:', error);
+        // Show an error instead of navigating to a broken screen
+        Alert.alert(
+          'Error Loading Post',
+          'There was an error loading the post. Please try again later.',
+          [{ text: 'OK' }]
+        );
+      }
+    } else {
+      console.log('[NotificationsScreen] Notification not actionable or missing target content');
     }
   };
 

--- a/app/NotificationsScreen.tsx
+++ b/app/NotificationsScreen.tsx
@@ -196,7 +196,9 @@ const NotificationsScreen = () => {
 
     // Handle follower notifications - navigate to the follower's profile
     if (notification.type === 'follow' && notification.actionUser) {
-      console.log('[NotificationsScreen] Navigating to ProfileScreen for follow notification');
+      console.log(
+        '[NotificationsScreen] Navigating to ProfileScreen for follow notification'
+      );
       router.push({
         pathname: '/ProfileScreen',
         params: {
@@ -249,9 +251,11 @@ const NotificationsScreen = () => {
 
           const postType = detectPostType(postInfo);
           console.log('[NotificationsScreen] Post type detected:', postType);
-          
+
           if (postType === 'snap') {
-            console.log('[NotificationsScreen] Navigating to ConversationScreen (snap)');
+            console.log(
+              '[NotificationsScreen] Navigating to ConversationScreen (snap)'
+            );
             router.push({
               pathname: '/ConversationScreen',
               params: {
@@ -260,7 +264,9 @@ const NotificationsScreen = () => {
               },
             });
           } else {
-            console.log('[NotificationsScreen] Navigating to HivePostScreen (regular post)');
+            console.log(
+              '[NotificationsScreen] Navigating to HivePostScreen (regular post)'
+            );
             router.push({
               pathname: '/HivePostScreen',
               params: {
@@ -274,12 +280,15 @@ const NotificationsScreen = () => {
           // Show an error instead of navigating to a broken screen
           Alert.alert(
             'Post Not Found',
-            'The post you\'re trying to view could not be found. It may have been deleted or the link may be invalid.',
+            "The post you're trying to view could not be found. It may have been deleted or the link may be invalid.",
             [{ text: 'OK' }]
           );
         }
       } catch (error) {
-        console.error('[NotificationsScreen] Error fetching post data for navigation:', error);
+        console.error(
+          '[NotificationsScreen] Error fetching post data for navigation:',
+          error
+        );
         // Show an error instead of navigating to a broken screen
         Alert.alert(
           'Error Loading Post',
@@ -288,7 +297,9 @@ const NotificationsScreen = () => {
         );
       }
     } else {
-      console.log('[NotificationsScreen] Notification not actionable or missing target content');
+      console.log(
+        '[NotificationsScreen] Notification not actionable or missing target content'
+      );
     }
   };
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -67,6 +67,7 @@ function RootLayoutNav() {
               <Stack.Screen name='FeedScreen' />
               <Stack.Screen name='NotificationsScreen' />
               <Stack.Screen name='ConversationScreen' />
+              <Stack.Screen name='HivePostScreen' />
               <Stack.Screen name='ProfileScreen' />
               <Stack.Screen name='ComposeScreen' />
               <Stack.Screen name='modal' options={{ presentation: 'modal' }} />

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -35,6 +35,8 @@ import SpoilerText from './SpoilerText';
 import TwitterEmbed from './TwitterEmbed';
 import YouTubeEmbed from './YouTubeEmbed';
 import ThreeSpeakEmbed from './ThreeSpeakEmbed';
+import { extractHivePostUrls } from '../../utils/extractHivePostInfo';
+import { OptimizedHivePostPreviewRenderer } from '../../components/OptimizedHivePostPreviewRenderer';
 
 const twitterColors = {
   light: {
@@ -432,6 +434,7 @@ const Snap: React.FC<SnapProps> = ({
   const imageUrls = extractImageUrls(body);
   const rawImageUrls = extractRawImageUrls(body);
   const embeddedContent = extractVideoInfo(body); // Renamed from videoInfo to be more accurate
+  const hivePostUrls = extractHivePostUrls(body); // Extract Hive post URLs for previews
 
   // Remove embedded content URLs and image URLs from text body if present
   let textBody = stripImageTags(body);
@@ -440,6 +443,15 @@ const Snap: React.FC<SnapProps> = ({
   }
   if (rawImageUrls.length > 0) {
     textBody = removeRawImageUrls(textBody);
+  }
+
+  // Remove Hive post URLs from text body to avoid showing raw URLs
+  if (hivePostUrls.length > 0) {
+    hivePostUrls.forEach(url => {
+      textBody = textBody.replace(url, '').trim();
+    });
+    // Clean up any double spaces
+    textBody = textBody.replace(/\s{2,}/g, ' ').trim();
   }
 
   // Process spoiler syntax first, before other text processing
@@ -550,6 +562,7 @@ const Snap: React.FC<SnapProps> = ({
           ) : null}
         </View>
       )}
+
       {/* Images from markdown/html */}
       {imageUrls.length > 0 && (
         <View style={{ marginBottom: 8 }}>
@@ -773,6 +786,23 @@ const Snap: React.FC<SnapProps> = ({
           ${payout.toFixed(2)}
         </Text>
       </View>
+
+      {/* Hive Post Previews - Footer Style */}
+      {hivePostUrls.length > 0 && (
+        <View style={{ marginTop: 12 }}>
+          <OptimizedHivePostPreviewRenderer
+            postUrls={hivePostUrls}
+            colors={{
+              bubble: colors.bubble,
+              icon: colors.icon,
+              text: colors.text,
+            }}
+            onError={(error) => {
+              console.warn('[Snap] Hive post preview error:', error);
+            }}
+          />
+        </View>
+      )}
     </View>
   );
 };

--- a/components/SafeRenderHtml.tsx
+++ b/components/SafeRenderHtml.tsx
@@ -5,13 +5,18 @@ interface SafeRenderHtmlProps extends Omit<RenderHTMLProps, 'key'> {
   key?: string | number;
 }
 
-const SafeRenderHtml: React.FC<SafeRenderHtmlProps> = (props) => {
+const SafeRenderHtml: React.FC<SafeRenderHtmlProps> = props => {
   // Suppress the specific warning about key prop spreading
   useEffect(() => {
     const originalWarn = console.warn;
     console.warn = (...args) => {
       const message = args[0];
-      if (typeof message === 'string' && message.includes('A props object containing a "key" prop is being spread into JSX')) {
+      if (
+        typeof message === 'string' &&
+        message.includes(
+          'A props object containing a "key" prop is being spread into JSX'
+        )
+      ) {
         return; // Suppress this specific warning
       }
       originalWarn.apply(console, args);
@@ -24,13 +29,8 @@ const SafeRenderHtml: React.FC<SafeRenderHtmlProps> = (props) => {
 
   // Extract key from props to pass it directly
   const { key, ...otherProps } = props;
-  
-  return (
-    <RenderHtml
-      key={key}
-      {...otherProps}
-    />
-  );
+
+  return <RenderHtml key={key} {...otherProps} />;
 };
 
-export default SafeRenderHtml; 
+export default SafeRenderHtml;

--- a/components/SafeRenderHtml.tsx
+++ b/components/SafeRenderHtml.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import RenderHtml, { RenderHTMLProps } from 'react-native-render-html';
+
+interface SafeRenderHtmlProps extends Omit<RenderHTMLProps, 'key'> {
+  key?: string | number;
+}
+
+const SafeRenderHtml: React.FC<SafeRenderHtmlProps> = (props) => {
+  // Suppress the specific warning about key prop spreading
+  useEffect(() => {
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+      const message = args[0];
+      if (typeof message === 'string' && message.includes('A props object containing a "key" prop is being spread into JSX')) {
+        return; // Suppress this specific warning
+      }
+      originalWarn.apply(console, args);
+    };
+
+    return () => {
+      console.warn = originalWarn;
+    };
+  }, []);
+
+  // Extract key from props to pass it directly
+  const { key, ...otherProps } = props;
+  
+  return (
+    <RenderHtml
+      key={key}
+      {...otherProps}
+    />
+  );
+};
+
+export default SafeRenderHtml; 

--- a/context/HivePostPreviewContext.tsx
+++ b/context/HivePostPreviewContext.tsx
@@ -125,14 +125,20 @@ const HivePostPreviewProvider: React.FC<{ children: ReactNode }> = ({
       }
 
       // Create new loading promise with error handling
-      const loadingPromise = fetchMultipleHivePostInfos(validUrls).catch(error => {
-        console.error('[HivePostPreviewContext] Error fetching post previews:', {
-          error,
-          urls: validUrls,
-          errorMessage: error instanceof Error ? error.message : 'Unknown error',
-        });
-        return []; // Return empty array on error
-      });
+      const loadingPromise = fetchMultipleHivePostInfos(validUrls).catch(
+        error => {
+          console.error(
+            '[HivePostPreviewContext] Error fetching post previews:',
+            {
+              error,
+              urls: validUrls,
+              errorMessage:
+                error instanceof Error ? error.message : 'Unknown error',
+            }
+          );
+          return []; // Return empty array on error
+        }
+      );
 
       // Set cache entry with loading promise
       cache.set(cacheKey, {
@@ -153,7 +159,10 @@ const HivePostPreviewProvider: React.FC<{ children: ReactNode }> = ({
 
         return result;
       } catch (error) {
-        console.error('[HivePostPreviewContext] Error in loading promise:', error);
+        console.error(
+          '[HivePostPreviewContext] Error in loading promise:',
+          error
+        );
 
         // Remove loading state on error
         const currentEntry = cache.get(cacheKey);

--- a/context/HivePostPreviewContext.tsx
+++ b/context/HivePostPreviewContext.tsx
@@ -76,8 +76,28 @@ const HivePostPreviewProvider: React.FC<{ children: ReactNode }> = ({
     async (urls: string[]): Promise<HivePostInfo[]> => {
       if (urls.length === 0) return [];
 
+      // Filter out invalid URLs before processing
+      const validUrls = urls.filter(url => {
+        if (!url || typeof url !== 'string') return false;
+        if (url.length < 10) return false; // Too short to be valid
+        if (!url.includes('@') || !url.includes('/')) return false; // Missing required parts
+        return true;
+      });
+
+      if (validUrls.length === 0) {
+        console.log('[HivePostPreviewContext] No valid URLs to fetch');
+        return [];
+      }
+
+      if (validUrls.length !== urls.length) {
+        console.log('[HivePostPreviewContext] Filtered out invalid URLs:', {
+          original: urls.length,
+          valid: validUrls.length,
+        });
+      }
+
       const cache = cacheRef.current;
-      const cacheKey = urls.sort().join('|');
+      const cacheKey = validUrls.sort().join('|');
       const now = Date.now();
 
       // Check if we have cached data
@@ -104,8 +124,15 @@ const HivePostPreviewProvider: React.FC<{ children: ReactNode }> = ({
         }
       }
 
-      // Create new loading promise
-      const loadingPromise = fetchMultipleHivePostInfos(urls);
+      // Create new loading promise with error handling
+      const loadingPromise = fetchMultipleHivePostInfos(validUrls).catch(error => {
+        console.error('[HivePostPreviewContext] Error fetching post previews:', {
+          error,
+          urls: validUrls,
+          errorMessage: error instanceof Error ? error.message : 'Unknown error',
+        });
+        return []; // Return empty array on error
+      });
 
       // Set cache entry with loading promise
       cache.set(cacheKey, {
@@ -126,7 +153,7 @@ const HivePostPreviewProvider: React.FC<{ children: ReactNode }> = ({
 
         return result;
       } catch (error) {
-        console.error('Error fetching post previews:', error);
+        console.error('[HivePostPreviewContext] Error in loading promise:', error);
 
         // Remove loading state on error
         const currentEntry = cache.get(cacheKey);

--- a/hooks/useOptimisticUpdates.ts
+++ b/hooks/useOptimisticUpdates.ts
@@ -48,7 +48,10 @@ export const useOptimisticUpdates = () => {
             return { ...reply, ...updates };
           }
           if (reply.replies) {
-            return { ...reply, replies: updateReplyRecursive(reply.replies as T[]) };
+            return {
+              ...reply,
+              replies: updateReplyRecursive(reply.replies as T[]),
+            };
           }
           return reply;
         });

--- a/hooks/useUserProfile.ts
+++ b/hooks/useUserProfile.ts
@@ -53,9 +53,9 @@ export const useUserProfile = (username: string | null) => {
         setAvatarUrl(avatar);
 
         // Check for unclaimed rewards
-        const unclaimedHbd = parseFloat(account.reward_hbd_balance || '0');
-        const unclaimedHive = parseFloat(account.reward_vesting_balance || '0');
-        const unclaimedVests = parseFloat(account.reward_vesting_steem || '0');
+        const unclaimedHbd = parseFloat(String(account.reward_hbd_balance || '0'));
+        const unclaimedHive = parseFloat(String(account.reward_vesting_balance || '0'));
+        const unclaimedVests = parseFloat(String(account.reward_vesting_hive || '0'));
 
         const hasRewards =
           unclaimedHbd > 0 || unclaimedHive > 0 || unclaimedVests > 0;

--- a/hooks/useUserProfile.ts
+++ b/hooks/useUserProfile.ts
@@ -53,9 +53,15 @@ export const useUserProfile = (username: string | null) => {
         setAvatarUrl(avatar);
 
         // Check for unclaimed rewards
-        const unclaimedHbd = parseFloat(String(account.reward_hbd_balance || '0'));
-        const unclaimedHive = parseFloat(String(account.reward_vesting_balance || '0'));
-        const unclaimedVests = parseFloat(String(account.reward_vesting_hive || '0'));
+        const unclaimedHbd = parseFloat(
+          String(account.reward_hbd_balance || '0')
+        );
+        const unclaimedHive = parseFloat(
+          String(account.reward_vesting_balance || '0')
+        );
+        const unclaimedVests = parseFloat(
+          String(account.reward_vesting_hive || '0')
+        );
 
         const hasRewards =
           unclaimedHbd > 0 || unclaimedHive > 0 || unclaimedVests > 0;

--- a/hooks/useUserSnaps.ts
+++ b/hooks/useUserSnaps.ts
@@ -140,7 +140,7 @@ export const useUserSnaps = (username: string | undefined) => {
       );
 
       // Fetch all replies in parallel instead of sequentially
-      const replyPromises = discussions.map(async post => {
+      const replyPromises = discussions.map(async (post: any) => {
         try {
           const replies: UserSnap[] = await client.database.call(
             'get_content_replies',

--- a/utils/extractHivePostInfo.ts
+++ b/utils/extractHivePostInfo.ts
@@ -4,6 +4,7 @@
  */
 
 import { Client } from '@hiveio/dhive';
+import { detectPostType, type PostInfo } from './postTypeDetector';
 
 const client = new Client([
   'https://api.hive.blog',
@@ -316,10 +317,34 @@ export async function fetchHivePostInfo(
     // Generate summary
     const summary = generateSummary(post.body);
 
+    // Smart title function - determines title based on post type
+    const getSmartTitle = (postData: any): string => {
+      // If it has a title, use it
+      if (postData.title && postData.title.trim()) {
+        return postData.title;
+      }
+      
+      // Use post type detection logic for untitled posts
+      const postInfo: PostInfo = {
+        author: postData.author,
+        permlink: postData.permlink,
+        title: postData.title,
+        body: postData.body,
+        json_metadata: postData.json_metadata,
+        parent_author: postData.parent_author,
+        parent_permlink: postData.parent_permlink,
+      };
+      
+      const postType = detectPostType(postInfo);
+      
+      // Return appropriate label based on type
+      return postType === 'snap' ? 'Resnap' : 'Untitled Post';
+    };
+
     return {
       author: post.author,
       permlink: post.permlink,
-      title: post.title || 'Untitled Post',
+      title: getSmartTitle(post),
       body: post.body,
       created: post.created,
       voteCount: post.net_votes || 0,

--- a/utils/extractHivePostInfo.ts
+++ b/utils/extractHivePostInfo.ts
@@ -73,7 +73,7 @@ export function parseHivePostUrl(
 ): { author: string; permlink: string } | null {
   try {
     console.log('[extractHivePostInfo] parseHivePostUrl called with:', url);
-    
+
     // Remove protocol and www if present
     const cleanUrl = url.replace(/^https?:\/\/(?:www\.)?/, '');
 
@@ -82,7 +82,10 @@ export function parseHivePostUrl(
       /^(?:ecency\.com|peakd\.com|hive\.blog)\/(.+)$/
     );
     if (!pathMatch) {
-      console.log('[extractHivePostInfo] URL does not match expected domain pattern:', cleanUrl);
+      console.log(
+        '[extractHivePostInfo] URL does not match expected domain pattern:',
+        cleanUrl
+      );
       return null;
     }
 
@@ -104,30 +107,37 @@ export function parseHivePostUrl(
         console.log('[extractHivePostInfo] Rejecting short permlink:', {
           permlink,
           length: permlink.length,
-          url
+          url,
         });
         return null;
       }
 
       // Check if permlink looks like a valid post permlink (not just a category/page)
-      const validPermlinkPattern = /^[a-z0-9-]+(?:-\d{4}-\d{2}-\d{2}|-\d{10,}|-[a-z0-9-]{8,})$/;
+      const validPermlinkPattern =
+        /^[a-z0-9-]+(?:-\d{4}-\d{2}-\d{2}|-\d{10,}|-[a-z0-9-]{8,})$/;
       if (!validPermlinkPattern.test(permlink)) {
-        console.log('[extractHivePostInfo] Rejecting invalid permlink format:', {
-          permlink,
-          url
-        });
+        console.log(
+          '[extractHivePostInfo] Rejecting invalid permlink format:',
+          {
+            permlink,
+            url,
+          }
+        );
         return null;
       }
 
       console.log('[extractHivePostInfo] Successfully parsed URL:', {
         author,
         permlink,
-        url
+        url,
       });
       return { author, permlink };
     }
-    
-    console.log('[extractHivePostInfo] URL does not match author/permlink pattern:', path);
+
+    console.log(
+      '[extractHivePostInfo] URL does not match author/permlink pattern:',
+      path
+    );
     return null;
   } catch (error) {
     console.error('[extractHivePostInfo] Error parsing Hive post URL:', error);
@@ -261,7 +271,10 @@ export async function fetchHivePostInfo(
 
     // Validate parameters before making API call
     if (!author || !permlink || author.length < 3 || permlink.length < 5) {
-      console.warn('[extractHivePostInfo] Invalid parameters:', { author, permlink });
+      console.warn('[extractHivePostInfo] Invalid parameters:', {
+        author,
+        permlink,
+      });
       return null;
     }
 
@@ -327,16 +340,22 @@ export async function fetchHivePostInfo(
       originalUrl,
       errorMessage: error instanceof Error ? error.message : 'Unknown error',
     });
-    
+
     // Specific warning for "Invalid parameters" - likely malformed URL
-    if (error instanceof Error && error.message.includes('Invalid parameters')) {
-      console.warn('[extractHivePostInfo] Invalid parameters detected - likely malformed URL or non-existent post:', {
-        author,
-        permlink,
-        originalUrl,
-      });
+    if (
+      error instanceof Error &&
+      error.message.includes('Invalid parameters')
+    ) {
+      console.warn(
+        '[extractHivePostInfo] Invalid parameters detected - likely malformed URL or non-existent post:',
+        {
+          author,
+          permlink,
+          originalUrl,
+        }
+      );
     }
-    
+
     return null;
   }
 }
@@ -363,7 +382,11 @@ export async function fetchMultipleHivePostInfos(
 
         return await fetchHivePostInfo(parsed.author, parsed.permlink, url);
       } catch (error) {
-        console.error('[extractHivePostInfo] Error processing URL:', url, error);
+        console.error(
+          '[extractHivePostInfo] Error processing URL:',
+          url,
+          error
+        );
         return null;
       }
     })

--- a/utils/postTypeDetector.ts
+++ b/utils/postTypeDetector.ts
@@ -41,29 +41,33 @@ export function detectPostType(post: PostInfo): PostType {
         tags: metadata.tags,
         tagsCount: metadata.tags?.length || 0,
       });
-      
+
       // Check for snap-specific metadata
       if (metadata.app && metadata.app.includes('hivesnaps')) {
         console.log('[postTypeDetector] Detected snap by app metadata');
         return 'snap';
       }
-      
+
       // Check for snap-specific tags - be more specific
       if (metadata.tags && Array.isArray(metadata.tags)) {
         // Only detect as snap if it has the specific hivesnaps tag AND other snap indicators
         if (metadata.tags.includes('hivesnaps')) {
           // Additional check: only detect as snap if it also has other snap indicators
           // This prevents regular posts that happen to have 'hivesnaps' as a tag
-          const hasOtherSnapIndicators = 
+          const hasOtherSnapIndicators =
             (metadata.app && metadata.app.includes('hivesnaps')) ||
             (post.permlink && post.permlink.startsWith('snap-')) ||
-            (post.parent_author === 'peak.snaps');
-          
+            post.parent_author === 'peak.snaps';
+
           if (hasOtherSnapIndicators) {
-            console.log('[postTypeDetector] Detected snap by hivesnaps tag + other indicators');
+            console.log(
+              '[postTypeDetector] Detected snap by hivesnaps tag + other indicators'
+            );
             return 'snap';
           } else {
-            console.log('[postTypeDetector] Has hivesnaps tag but no other snap indicators - treating as regular post');
+            console.log(
+              '[postTypeDetector] Has hivesnaps tag but no other snap indicators - treating as regular post'
+            );
           }
         }
         // Don't detect as snap just because it has 'snap' in tags - that's too broad
@@ -98,13 +102,13 @@ export function detectPostType(post: PostInfo): PostType {
   // Check if it's a snap based on content patterns
   if (post.body) {
     const body = post.body.toLowerCase();
-    
+
     // Look for snap-specific content patterns - be more specific
     if (body.includes('#hivesnaps')) {
       console.log('[postTypeDetector] Detected snap by #hivesnaps hashtag');
       return 'snap';
     }
-    
+
     // Don't detect as snap just because it mentions 'snapie' or 'snap-' in content
     // This is too broad and catches regular posts that mention these words
     // Only detect if it has specific snap formatting or patterns
@@ -120,7 +124,7 @@ export function detectPostType(post: PostInfo): PostType {
  */
 export function getPostScreenRoute(post: PostInfo): string {
   const postType = detectPostType(post);
-  
+
   if (postType === 'snap') {
     return '/ConversationScreen';
   } else {
@@ -133,7 +137,7 @@ export function getPostScreenRoute(post: PostInfo): string {
  */
 export function getPostNavigationParams(post: PostInfo) {
   const route = getPostScreenRoute(post);
-  
+
   return {
     route,
     params: {
@@ -141,4 +145,4 @@ export function getPostNavigationParams(post: PostInfo) {
       permlink: post.permlink,
     },
   };
-} 
+}

--- a/utils/postTypeDetector.ts
+++ b/utils/postTypeDetector.ts
@@ -1,0 +1,144 @@
+/**
+ * Utility to detect post types (snap vs regular Hive post)
+ */
+
+export interface PostInfo {
+  author: string;
+  permlink: string;
+  title?: string;
+  body?: string;
+  json_metadata?: string;
+  parent_author?: string;
+  parent_permlink?: string;
+}
+
+export type PostType = 'snap' | 'hive_post';
+
+/**
+ * Detect if a post is a snap based on its metadata and content
+ */
+export function detectPostType(post: PostInfo): PostType {
+  console.log('[postTypeDetector] detectPostType called with:', {
+    author: post.author,
+    permlink: post.permlink,
+    parent_author: post.parent_author,
+    hasMetadata: !!post.json_metadata,
+    hasBody: !!post.body,
+  });
+
+  // Check for invalid/short permlinks that are likely not real posts
+  if (post.permlink && post.permlink.length < 5) {
+    console.log('[postTypeDetector] Very short permlink, likely invalid post');
+    return 'hive_post'; // Default to regular post for invalid ones
+  }
+
+  // Check if it's a snap based on metadata
+  if (post.json_metadata) {
+    try {
+      const metadata = JSON.parse(post.json_metadata);
+      console.log('[postTypeDetector] Parsed metadata:', {
+        app: metadata.app,
+        tags: metadata.tags,
+        tagsCount: metadata.tags?.length || 0,
+      });
+      
+      // Check for snap-specific metadata
+      if (metadata.app && metadata.app.includes('hivesnaps')) {
+        console.log('[postTypeDetector] Detected snap by app metadata');
+        return 'snap';
+      }
+      
+      // Check for snap-specific tags - be more specific
+      if (metadata.tags && Array.isArray(metadata.tags)) {
+        // Only detect as snap if it has the specific hivesnaps tag AND other snap indicators
+        if (metadata.tags.includes('hivesnaps')) {
+          // Additional check: only detect as snap if it also has other snap indicators
+          // This prevents regular posts that happen to have 'hivesnaps' as a tag
+          const hasOtherSnapIndicators = 
+            (metadata.app && metadata.app.includes('hivesnaps')) ||
+            (post.permlink && post.permlink.startsWith('snap-')) ||
+            (post.parent_author === 'peak.snaps');
+          
+          if (hasOtherSnapIndicators) {
+            console.log('[postTypeDetector] Detected snap by hivesnaps tag + other indicators');
+            return 'snap';
+          } else {
+            console.log('[postTypeDetector] Has hivesnaps tag but no other snap indicators - treating as regular post');
+          }
+        }
+        // Don't detect as snap just because it has 'snap' in tags - that's too broad
+        // Many regular posts might have 'snap' as a tag but aren't actually snaps
+      }
+    } catch (e) {
+      console.log('[postTypeDetector] Invalid JSON metadata:', e);
+      // Invalid JSON metadata, continue with other checks
+    }
+  }
+
+  // Check if it's a snap based on permlink pattern
+  // Snaps typically have permlinks that start with "snap-" followed by a timestamp
+  if (post.permlink && post.permlink.startsWith('snap-')) {
+    console.log('[postTypeDetector] Detected snap by permlink pattern');
+    return 'snap';
+  }
+
+  // Check if it's a snap based on parent_author
+  // Snaps are typically replies to a container post by 'peak.snaps'
+  if (post.parent_author === 'peak.snaps') {
+    console.log('[postTypeDetector] Detected snap by parent_author');
+    return 'snap';
+  }
+
+  // Additional check: if parent_author is empty or null, it's likely a regular post
+  if (!post.parent_author || post.parent_author === '') {
+    console.log('[postTypeDetector] No parent_author, likely regular post');
+    // Continue with other checks, but this is a good indicator
+  }
+
+  // Check if it's a snap based on content patterns
+  if (post.body) {
+    const body = post.body.toLowerCase();
+    
+    // Look for snap-specific content patterns - be more specific
+    if (body.includes('#hivesnaps')) {
+      console.log('[postTypeDetector] Detected snap by #hivesnaps hashtag');
+      return 'snap';
+    }
+    
+    // Don't detect as snap just because it mentions 'snapie' or 'snap-' in content
+    // This is too broad and catches regular posts that mention these words
+    // Only detect if it has specific snap formatting or patterns
+  }
+
+  console.log('[postTypeDetector] Defaulting to regular Hive post');
+  // Default to regular Hive post
+  return 'hive_post';
+}
+
+/**
+ * Get the appropriate screen route based on post type
+ */
+export function getPostScreenRoute(post: PostInfo): string {
+  const postType = detectPostType(post);
+  
+  if (postType === 'snap') {
+    return '/ConversationScreen';
+  } else {
+    return '/HivePostScreen';
+  }
+}
+
+/**
+ * Get navigation parameters for the appropriate screen
+ */
+export function getPostNavigationParams(post: PostInfo) {
+  const route = getPostScreenRoute(post);
+  
+  return {
+    route,
+    params: {
+      author: post.author,
+      permlink: post.permlink,
+    },
+  };
+} 


### PR DESCRIPTION
New implementation for Post Previews on the FeedScreen - this solves the re-rendering issue we had before. 

* Removes raw url, after detecting the three main front ends of hive
* Adds preview as a footer of the snap
* detects if preview is a Hive Post, or a Resnap and Displays the Title Properly (implemented a new function for this)
*
