### PR TITLE
fix: Handle usernames with dots in notification parsing

### DIFF
--- a/test/test-username-regex.js
+++ b/test/test-username-regex.js
@@ -1,0 +1,83 @@
+// Simple test to verify username regex patterns handle dots correctly
+// This is a quick test to verify the fix for @atma.love and similar usernames
+
+// Test the updated regex patterns
+const testUsernames = [
+  'atma.love',
+  'alice',
+  'bob.test',
+  'charlie-123',
+  'user.with.dots',
+  'simple',
+  'test-user.123'
+];
+
+const testMessages = [
+  '@atma.love voted on your post ($0.013)',
+  '@atma.love replied to your post',
+  '@atma.love reblogged your post',
+  '@atma.love followed you',
+  '@atma.love mentioned you in a post',
+  '@alice voted on your post ($1.25)',
+  '@bob.test replied to your comment',
+  '@charlie-123 started following you'
+];
+
+const testUrls = [
+  '@atma.love/sample-post-123',
+  '@alice/another-post',
+  '@bob.test/test-post-456',
+  '@user.with.dots/my-awesome-post'
+];
+
+console.log('Testing username regex patterns...\n');
+
+// Test vote pattern
+const voteRegex = /@([a-z0-9.-]+) voted on your post \(\$([0-9.]+)\)/;
+console.log('Vote pattern tests:');
+testMessages.filter(msg => msg.includes('voted')).forEach(msg => {
+  const match = msg.match(voteRegex);
+  console.log(`  "${msg}" -> ${match ? `username: ${match[1]}, amount: $${match[2]}` : 'NO MATCH'}`);
+});
+
+// Test reply pattern
+const replyRegex = /@([a-z0-9.-]+) replied to your/;
+console.log('\nReply pattern tests:');
+testMessages.filter(msg => msg.includes('replied')).forEach(msg => {
+  const match = msg.match(replyRegex);
+  console.log(`  "${msg}" -> ${match ? `username: ${match[1]}` : 'NO MATCH'}`);
+});
+
+// Test reblog pattern
+const reblogRegex = /@([a-z0-9.-]+) reblogged your/;
+console.log('\nReblog pattern tests:');
+testMessages.filter(msg => msg.includes('reblogged')).forEach(msg => {
+  const match = msg.match(reblogRegex);
+  console.log(`  "${msg}" -> ${match ? `username: ${match[1]}` : 'NO MATCH'}`);
+});
+
+// Test follow pattern
+const followRegex = /@([a-z0-9.-]+) (?:followed|started following) you/;
+console.log('\nFollow pattern tests:');
+testMessages.filter(msg => msg.includes('follow')).forEach(msg => {
+  const match = msg.match(followRegex);
+  console.log(`  "${msg}" -> ${match ? `username: ${match[1]}` : 'NO MATCH'}`);
+});
+
+// Test mention pattern
+const mentionRegex = /@([a-z0-9.-]+) mentioned you/;
+console.log('\nMention pattern tests:');
+testMessages.filter(msg => msg.includes('mentioned')).forEach(msg => {
+  const match = msg.match(mentionRegex);
+  console.log(`  "${msg}" -> ${match ? `username: ${match[1]}` : 'NO MATCH'}`);
+});
+
+// Test URL pattern
+const urlRegex = /@([a-z0-9.-]+)\/([a-z0-9-]+)/;
+console.log('\nURL pattern tests:');
+testUrls.forEach(url => {
+  const match = url.match(urlRegex);
+  console.log(`  "${url}" -> ${match ? `author: ${match[1]}, permlink: ${match[2]}` : 'NO MATCH'}`);
+});
+
+console.log('\nAll tests completed! ✅');

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -81,7 +81,7 @@ export function parseNotification(
 
       // Extract voter and amount from message like "@alice voted on your post ($0.013)"
       const voteMatch = notification.msg.match(
-        /@(\w+) voted on your post \(\$([0-9.]+)\)/
+        /@([a-z0-9.-]+) voted on your post \(\$([0-9.]+)\)/
       );
       if (voteMatch) {
         parsed.actionUser = voteMatch[1];
@@ -95,7 +95,7 @@ export function parseNotification(
       parsed.actionText = 'Replied to';
 
       // Extract replier from message like "@bob replied to your post"
-      const replyMatch = notification.msg.match(/@(\w+) replied to your/);
+      const replyMatch = notification.msg.match(/@([a-z0-9.-]+) replied to your/);
       if (replyMatch) {
         parsed.actionUser = replyMatch[1];
       }
@@ -107,7 +107,7 @@ export function parseNotification(
       parsed.actionText = 'Reblogged';
 
       // Extract reblogger from message like "@charlie reblogged your post"
-      const reblogMatch = notification.msg.match(/@(\w+) reblogged your/);
+      const reblogMatch = notification.msg.match(/@([a-z0-9.-]+) reblogged your/);
       if (reblogMatch) {
         parsed.actionUser = reblogMatch[1];
       }
@@ -120,7 +120,7 @@ export function parseNotification(
 
       // Extract follower from message like "@dave followed you" or "@dave started following you"
       const followMatch = notification.msg.match(
-        /@(\w+) (?:followed|started following) you/
+        /@([a-z0-9.-]+) (?:followed|started following) you/
       );
       if (followMatch) {
         parsed.actionUser = followMatch[1];
@@ -136,7 +136,7 @@ export function parseNotification(
       parsed.actionText = 'Mentioned you';
 
       // Extract mentioner from message like "@eve mentioned you in a post"
-      const mentionMatch = notification.msg.match(/@(\w+) mentioned you/);
+      const mentionMatch = notification.msg.match(/@([a-z0-9.-]+) mentioned you/);
       if (mentionMatch) {
         parsed.actionUser = mentionMatch[1];
       }
@@ -175,7 +175,7 @@ export function parseNotification(
 
   // Extract target content information from URL
   if (notification.url) {
-    const urlMatch = notification.url.match(/@(\w+)\/([a-z0-9-]+)/);
+    const urlMatch = notification.url.match(/@([a-z0-9.-]+)\/([a-z0-9-]+)/);
     if (urlMatch) {
       parsed.targetContent = {
         author: urlMatch[1],


### PR DESCRIPTION
 Fixed regex patterns in utils/notifications.ts to support Hive usernames containing dots
 Changed \w+ patterns to [a-z0-9.-]+ to match valid Hive username format
 Resolves issue where notifications from users like @atma.love were not clickable
 Added test file to verify regex patterns work correctly with dot-containing usernames

Before: @atma.love -> extracted as 'atma' (broken)
After: @atma.love -> extracted as 'atma.love' (correct)

Patterns updated:
- Vote notifications: /@([a-z0-9.-]+) voted on your post/
- Reply notifications: /@([a-z0-9.-]+) replied to your/
- Reblog notifications: /@([a-z0-9.-]+) reblogged your/
- Follow notifications: /@([a-z0-9.-]+) (?:followed|started following) you/
- Mention notifications: /@([a-z0-9.-]+) mentioned you/
- URL parsing: /@([a-z0-9.-]+)\/([a-z0-9-]+)/