### PR TITLE
feat: implement Resource Credits (RC) display alongside Voting Power

### DIFF
--- a/app/FeedScreen.tsx
+++ b/app/FeedScreen.tsx
@@ -360,7 +360,9 @@ const FeedScreenRefactored = () => {
                 </View>
               )}
               <Text style={[styles.username, { color: colors.text }]}>
-                {username && username.length > 8 ? username.slice(0, 8) + '...' : username}
+                {username && username.length > 8
+                  ? username.slice(0, 8) + '...'
+                  : username}
               </Text>
             </Pressable>
 
@@ -371,7 +373,13 @@ const FeedScreenRefactored = () => {
                 style={{ marginLeft: 8 }}
               />
             ) : username ? (
-              <View style={{ flexDirection: 'row', alignItems: 'center', marginLeft: 8 }}>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  marginLeft: 8,
+                }}
+              >
                 {/* Voting Power */}
                 <Pressable
                   onPress={() => setVpInfoModalVisible(true)}
@@ -398,7 +406,11 @@ const FeedScreenRefactored = () => {
                       fontWeight: 'bold',
                     }}
                   >
-                    VP: {votingPower !== null ? (votingPower / 100).toFixed(1) : '--'}%
+                    VP:{' '}
+                    {votingPower !== null
+                      ? (votingPower / 100).toFixed(1)
+                      : '--'}
+                    %
                   </Text>
                   <FontAwesome
                     name='question-circle'
@@ -409,7 +421,15 @@ const FeedScreenRefactored = () => {
                 </Pressable>
 
                 {/* Separator */}
-                <Text style={{ color: colors.text, fontSize: 12, marginHorizontal: 4 }}>|</Text>
+                <Text
+                  style={{
+                    color: colors.text,
+                    fontSize: 12,
+                    marginHorizontal: 4,
+                  }}
+                >
+                  |
+                </Text>
 
                 {/* Resource Credits */}
                 <Pressable
@@ -437,7 +457,11 @@ const FeedScreenRefactored = () => {
                       fontWeight: 'bold',
                     }}
                   >
-                    RC: {resourceCredits !== null ? resourceCredits.toFixed(1) : '--'}%
+                    RC:{' '}
+                    {resourceCredits !== null
+                      ? resourceCredits.toFixed(1)
+                      : '--'}
+                    %
                   </Text>
                   <FontAwesome
                     name='question-circle'
@@ -505,12 +529,12 @@ const FeedScreenRefactored = () => {
                 >
                   Voting Power (VP) is a measure of your ability to upvote posts
                   and comments on the Hive blockchain. The higher your VP, the
-                  more influence your votes have.{'\n\n'}- VP decreases each time
-                  you upvote.{'\n'}- VP regenerates automatically over time (about
-                  20% per day).{'\n'}- Keeping your VP high means your votes have
-                  more impact.{'\n\n'}
-                  You can see your current VP in the top bar. After upvoting, your
-                  VP will drop slightly and recharge over time.
+                  more influence your votes have.{'\n\n'}- VP decreases each
+                  time you upvote.{'\n'}- VP regenerates automatically over time
+                  (about 20% per day).{'\n'}- Keeping your VP high means your
+                  votes have more impact.{'\n\n'}
+                  You can see your current VP in the top bar. After upvoting,
+                  your VP will drop slightly and recharge over time.
                 </Text>
                 <Pressable
                   style={{
@@ -590,13 +614,33 @@ const FeedScreenRefactored = () => {
                     textAlign: 'left',
                   }}
                 >
-                  Resource Credits are like digital fuel. You need them to do things on Hive, like posting, voting, or making transactions. Every account has them, and using the network costs a small amount each time.{'\n\n'}
-                  <Text style={{ fontWeight: 'bold' }}>How can I get more?</Text>{'\n\n'}
-                  • <Text style={{ fontWeight: '600' }}>Power Up Hive:</Text> The more Hive Power you have, the more RC you get.{'\n\n'}
-                  • <Text style={{ fontWeight: '600' }}>Ask for a Delegation:</Text> A friend or community can temporarily boost your RC by delegating Hive Power.{'\n\n'}
-                  • <Text style={{ fontWeight: '600' }}>Use a Faucet or Service:</Text> Some apps or websites offer small amounts of RC for free.{'\n\n'}
-                  <Text style={{ fontWeight: 'bold' }}>Don't worry—RC recharges over time!</Text>{'\n\n'}
-                  Even if you're out of credits, just wait a bit. Your RC will slowly refill, and you'll be able to use Hive again without doing anything else.
+                  Resource Credits are like digital fuel. You need them to do
+                  things on Hive, like posting, voting, or making transactions.
+                  Every account has them, and using the network costs a small
+                  amount each time.{'\n\n'}
+                  <Text style={{ fontWeight: 'bold' }}>
+                    How can I get more?
+                  </Text>
+                  {'\n\n'}•{' '}
+                  <Text style={{ fontWeight: '600' }}>Power Up Hive:</Text> The
+                  more Hive Power you have, the more RC you get.{'\n\n'}•{' '}
+                  <Text style={{ fontWeight: '600' }}>
+                    Ask for a Delegation:
+                  </Text>{' '}
+                  A friend or community can temporarily boost your RC by
+                  delegating Hive Power.{'\n\n'}•{' '}
+                  <Text style={{ fontWeight: '600' }}>
+                    Use a Faucet or Service:
+                  </Text>{' '}
+                  Some apps or websites offer small amounts of RC for free.
+                  {'\n\n'}
+                  <Text style={{ fontWeight: 'bold' }}>
+                    Don't worry—RC recharges over time!
+                  </Text>
+                  {'\n\n'}
+                  Even if you're out of credits, just wait a bit. Your RC will
+                  slowly refill, and you'll be able to use Hive again without
+                  doing anything else.
                 </Text>
                 <Pressable
                   style={{

--- a/app/FeedScreen.tsx
+++ b/app/FeedScreen.tsx
@@ -41,10 +41,41 @@ import { useUserProfile } from '../hooks/useUserProfile';
 // Components
 import Snap from './components/Snap';
 import NotificationBadge from './components/NotificationBadge';
+import SmallButton from '../components/SmallButton';
+import StaticContentModal from '../components/StaticContentModal';
 import Slider from '@react-native-community/slider';
 import UpvoteModal from '../components/UpvoteModal';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+// Modal content constants
+const VP_MODAL_CONTENT = {
+  title: 'What is Voting Power (VP)?',
+  content: `Voting Power (VP) is a measure of your ability to upvote posts and comments on the Hive blockchain. The higher your VP, the more influence your votes have.
+
+- VP decreases each time you upvote.
+- VP regenerates automatically over time (about 20% per day).
+- Keeping your VP high means your votes have more impact.
+
+You can see your current VP in the top bar. After upvoting, your VP will drop slightly and recharge over time.`,
+};
+
+const RC_MODAL_CONTENT = {
+  title: 'What are Resource Credits (RC)?',
+  content: `Resource Credits are like digital fuel. You need them to do things on Hive, like posting, voting, or making transactions. Every account has them, and using the network costs a small amount each time.
+
+How can I get more?
+
+• Power Up Hive: The more Hive Power you have, the more RC you get.
+
+• Ask for a Delegation: A friend or community can temporarily boost your RC by delegating Hive Power.
+
+• Use a Faucet or Service: Some apps or websites offer small amounts of RC for free.
+
+Don't worry—RC recharges over time!
+
+Even if you're out of credits, just wait a bit. Your RC will slowly refill, and you'll be able to use Hive again without doing anything else.`,
+};
 
 const twitterColors = {
   light: {
@@ -370,303 +401,59 @@ const FeedScreenRefactored = () => {
               <ActivityIndicator
                 size='small'
                 color={colors.button}
-                style={{ marginLeft: 8 }}
+                style={styles.creditsIcon}
               />
             ) : username ? (
-              <View
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  marginLeft: 8,
-                }}
-              >
+              <View style={styles.creditsContainer}>
                 {/* Voting Power */}
-                <Pressable
+                <SmallButton
+                  label="VP:"
+                  value={votingPower !== null ? (votingPower / 100).toFixed(1) : '--'}
+                  unit="%"
+                  colors={colors}
                   onPress={() => setVpInfoModalVisible(true)}
-                  style={({ pressed }) => [
-                    {
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                      paddingHorizontal: 6,
-                      paddingVertical: 4,
-                      borderRadius: 6,
-                      backgroundColor: pressed
-                        ? colors.buttonInactive
-                        : 'transparent',
-                    },
-                  ]}
                   accessibilityLabel='Show Voting Power info'
                   accessibilityRole='button'
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                >
-                  <Text
-                    style={{
-                      color: colors.button,
-                      fontSize: 12,
-                      fontWeight: 'bold',
-                    }}
-                  >
-                    VP:{' '}
-                    {votingPower !== null
-                      ? (votingPower / 100).toFixed(1)
-                      : '--'}
-                    %
-                  </Text>
-                  <FontAwesome
-                    name='question-circle'
-                    size={14}
-                    color={colors.button}
-                    style={{ marginLeft: 4 }}
-                  />
-                </Pressable>
+                />
 
                 {/* Separator */}
-                <Text
-                  style={{
-                    color: colors.text,
-                    fontSize: 12,
-                    marginHorizontal: 4,
-                  }}
-                >
-                  |
-                </Text>
+                <Text style={styles.creditsSeparator}>|</Text>
 
                 {/* Resource Credits */}
-                <Pressable
+                <SmallButton
+                  label="RC:"
+                  value={resourceCredits !== null ? resourceCredits.toFixed(1) : '--'}
+                  unit="%"
+                  colors={colors}
                   onPress={() => setRcInfoModalVisible(true)}
-                  style={({ pressed }) => [
-                    {
-                      flexDirection: 'row',
-                      alignItems: 'center',
-                      paddingHorizontal: 6,
-                      paddingVertical: 4,
-                      borderRadius: 6,
-                      backgroundColor: pressed
-                        ? colors.buttonInactive
-                        : 'transparent',
-                    },
-                  ]}
                   accessibilityLabel='Show Resource Credits info'
                   accessibilityRole='button'
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                >
-                  <Text
-                    style={{
-                      color: colors.button,
-                      fontSize: 12,
-                      fontWeight: 'bold',
-                    }}
-                  >
-                    RC:{' '}
-                    {resourceCredits !== null
-                      ? resourceCredits.toFixed(1)
-                      : '--'}
-                    %
-                  </Text>
-                  <FontAwesome
-                    name='question-circle'
-                    size={14}
-                    color={colors.button}
-                    style={{ marginLeft: 4 }}
-                  />
-                </Pressable>
+                />
               </View>
             ) : null}
           </View>
         </View>
 
-        {/* Voting Power Info Modal */}
-        <Modal
+        {/* Info Modals */}
+        <StaticContentModal
           visible={vpInfoModalVisible}
-          transparent
-          animationType='fade'
-          onRequestClose={() => setVpInfoModalVisible(false)}
-        >
-          <View
-            style={{
-              flex: 1,
-              backgroundColor: 'rgba(0,0,0,0.4)',
-              justifyContent: 'center',
-              alignItems: 'center',
-              padding: 20,
-            }}
-          >
-            <View
-              style={{
-                backgroundColor: colors.background,
-                borderRadius: 16,
-                width: '100%',
-                maxWidth: 400,
-                maxHeight: '80%',
-                alignItems: 'center',
-              }}
-            >
-              <ScrollView
-                contentContainerStyle={{
-                  padding: 24,
-                  alignItems: 'center',
-                }}
-                showsVerticalScrollIndicator={false}
-              >
-                <Text
-                  style={{
-                    color: colors.text,
-                    fontSize: 18,
-                    fontWeight: 'bold',
-                    marginBottom: 12,
-                    textAlign: 'center',
-                  }}
-                >
-                  What is Voting Power (VP)?
-                </Text>
-                <Text
-                  style={{
-                    color: colors.text,
-                    fontSize: 15,
-                    marginBottom: 18,
-                    textAlign: 'left',
-                  }}
-                >
-                  Voting Power (VP) is a measure of your ability to upvote posts
-                  and comments on the Hive blockchain. The higher your VP, the
-                  more influence your votes have.{'\n\n'}- VP decreases each
-                  time you upvote.{'\n'}- VP regenerates automatically over time
-                  (about 20% per day).{'\n'}- Keeping your VP high means your
-                  votes have more impact.{'\n\n'}
-                  You can see your current VP in the top bar. After upvoting,
-                  your VP will drop slightly and recharge over time.
-                </Text>
-                <Pressable
-                  style={{
-                    backgroundColor: colors.button,
-                    borderRadius: 8,
-                    paddingVertical: 10,
-                    paddingHorizontal: 24,
-                    marginTop: 8,
-                  }}
-                  onPress={() => setVpInfoModalVisible(false)}
-                  accessibilityLabel='Close Voting Power info'
-                >
-                  <Text
-                    style={{
-                      color: colors.buttonText,
-                      fontWeight: '600',
-                      fontSize: 16,
-                    }}
-                  >
-                    Close
-                  </Text>
-                </Pressable>
-              </ScrollView>
-            </View>
-          </View>
-        </Modal>
+          onClose={() => setVpInfoModalVisible(false)}
+          title={VP_MODAL_CONTENT.title}
+          content={VP_MODAL_CONTENT.content}
+          colors={colors}
+          closeButtonAccessibilityLabel='Close Voting Power info'
+        />
 
-        {/* Resource Credits Info Modal */}
-        <Modal
+        <StaticContentModal
           visible={rcInfoModalVisible}
-          transparent
-          animationType='fade'
-          onRequestClose={() => setRcInfoModalVisible(false)}
-        >
-          <View
-            style={{
-              flex: 1,
-              backgroundColor: 'rgba(0,0,0,0.4)',
-              justifyContent: 'center',
-              alignItems: 'center',
-              padding: 20,
-            }}
-          >
-            <View
-              style={{
-                backgroundColor: colors.background,
-                borderRadius: 16,
-                width: '100%',
-                maxWidth: 400,
-                maxHeight: '80%',
-                alignItems: 'center',
-              }}
-            >
-              <ScrollView
-                contentContainerStyle={{
-                  padding: 24,
-                  alignItems: 'center',
-                }}
-                showsVerticalScrollIndicator={false}
-              >
-                <Text
-                  style={{
-                    color: colors.text,
-                    fontSize: 18,
-                    fontWeight: 'bold',
-                    marginBottom: 12,
-                    textAlign: 'center',
-                  }}
-                >
-                  What are Resource Credits (RC)?
-                </Text>
-                <Text
-                  style={{
-                    color: colors.text,
-                    fontSize: 15,
-                    marginBottom: 18,
-                    textAlign: 'left',
-                  }}
-                >
-                  Resource Credits are like digital fuel. You need them to do
-                  things on Hive, like posting, voting, or making transactions.
-                  Every account has them, and using the network costs a small
-                  amount each time.{'\n\n'}
-                  <Text style={{ fontWeight: 'bold' }}>
-                    How can I get more?
-                  </Text>
-                  {'\n\n'}•{' '}
-                  <Text style={{ fontWeight: '600' }}>Power Up Hive:</Text> The
-                  more Hive Power you have, the more RC you get.{'\n\n'}•{' '}
-                  <Text style={{ fontWeight: '600' }}>
-                    Ask for a Delegation:
-                  </Text>{' '}
-                  A friend or community can temporarily boost your RC by
-                  delegating Hive Power.{'\n\n'}•{' '}
-                  <Text style={{ fontWeight: '600' }}>
-                    Use a Faucet or Service:
-                  </Text>{' '}
-                  Some apps or websites offer small amounts of RC for free.
-                  {'\n\n'}
-                  <Text style={{ fontWeight: 'bold' }}>
-                    Don't worry—RC recharges over time!
-                  </Text>
-                  {'\n\n'}
-                  Even if you're out of credits, just wait a bit. Your RC will
-                  slowly refill, and you'll be able to use Hive again without
-                  doing anything else.
-                </Text>
-                <Pressable
-                  style={{
-                    backgroundColor: colors.button,
-                    borderRadius: 8,
-                    paddingVertical: 10,
-                    paddingHorizontal: 24,
-                    marginTop: 8,
-                  }}
-                  onPress={() => setRcInfoModalVisible(false)}
-                  accessibilityLabel='Close Resource Credits info'
-                >
-                  <Text
-                    style={{
-                      color: colors.buttonText,
-                      fontWeight: '600',
-                      fontSize: 16,
-                    }}
-                  >
-                    Close
-                  </Text>
-                </Pressable>
-              </ScrollView>
-            </View>
-          </View>
-        </Modal>
+          onClose={() => setRcInfoModalVisible(false)}
+          title={RC_MODAL_CONTENT.title}
+          content={RC_MODAL_CONTENT.content}
+          colors={colors}
+          closeButtonAccessibilityLabel='Close Resource Credits info'
+        />
 
         {/* Slogan row */}
         <View style={styles.sloganRow}>

--- a/components/SmallButton.tsx
+++ b/components/SmallButton.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Text, Pressable, PressableProps } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+
+interface SmallButtonProps extends Omit<PressableProps, 'style' | 'children'> {
+  /** The label text to display (e.g., "VP:", "RC:") */
+  label: string;
+  /** The value to display (e.g., "85.2", "92.1") */
+  value: string | number;
+  /** The unit to display after the value (e.g., "%") */
+  unit?: string;
+  /** Whether to show the question mark icon */
+  showIcon?: boolean;
+  /** Icon name from FontAwesome */
+  iconName?: string;
+  /** Icon size */
+  iconSize?: number;
+  /** Colors object for theming */
+  colors: {
+    button: string;
+    buttonInactive: string;
+  };
+  /** Custom style for the button container */
+  buttonStyle?: any;
+  /** Custom style for the text */
+  textStyle?: any;
+  /** Custom style for the icon */
+  iconStyle?: any;
+}
+
+const SmallButton: React.FC<SmallButtonProps> = ({
+  label,
+  value,
+  unit = '',
+  showIcon = true,
+  iconName = 'question-circle',
+  iconSize = 14,
+  colors,
+  buttonStyle,
+  textStyle,
+  iconStyle,
+  ...pressableProps
+}) => {
+  const baseButtonStyle = {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    borderRadius: 6,
+  };
+
+  const baseTextStyle = {
+    color: colors.button,
+    fontSize: 12,
+    fontWeight: 'bold' as const,
+  };
+
+  const baseIconStyle = {
+    marginLeft: 4,
+  };
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        baseButtonStyle,
+        {
+          backgroundColor: pressed ? colors.buttonInactive : 'transparent',
+        },
+        buttonStyle,
+      ]}
+      {...pressableProps}
+    >
+      <Text style={[baseTextStyle, textStyle]}>
+        {label} {value}{unit}
+      </Text>
+      {showIcon && (
+        <FontAwesome
+          name={iconName as any}
+          size={iconSize}
+          color={colors.button}
+          style={[baseIconStyle, iconStyle]}
+        />
+      )}
+    </Pressable>
+  );
+};
+
+export default SmallButton;

--- a/components/StaticContentModal.tsx
+++ b/components/StaticContentModal.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Modal, View, Text, ScrollView, Pressable } from 'react-native';
+
+interface StaticContentModalProps {
+  /** Whether the modal is visible */
+  visible: boolean;
+  /** Function to call when modal should be closed */
+  onClose: () => void;
+  /** The title text to display */
+  title: string;
+  /** The main content text to display */
+  content: string;
+  /** Colors object for theming */
+  colors: {
+    background: string;
+    text: string;
+    button: string;
+    buttonText: string;
+  };
+  /** Custom close button text (optional) */
+  closeButtonText?: string;
+  /** Custom modal animation type */
+  animationType?: 'none' | 'slide' | 'fade';
+  /** Custom accessibility label for close button */
+  closeButtonAccessibilityLabel?: string;
+}
+
+const StaticContentModal: React.FC<StaticContentModalProps> = ({
+  visible,
+  onClose,
+  title,
+  content,
+  colors,
+  closeButtonText = 'Close',
+  animationType = 'fade',
+  closeButtonAccessibilityLabel = 'Close modal',
+}) => {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType={animationType}
+      onRequestClose={onClose}
+    >
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(0,0,0,0.4)',
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: 20,
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: colors.background,
+            borderRadius: 16,
+            width: '100%',
+            maxWidth: 400,
+            maxHeight: '80%',
+            alignItems: 'center',
+          }}
+        >
+          <ScrollView
+            contentContainerStyle={{
+              padding: 24,
+              alignItems: 'center',
+            }}
+            showsVerticalScrollIndicator={false}
+          >
+            <Text
+              style={{
+                color: colors.text,
+                fontSize: 18,
+                fontWeight: 'bold',
+                marginBottom: 12,
+                textAlign: 'center',
+              }}
+            >
+              {title}
+            </Text>
+            <Text
+              style={{
+                color: colors.text,
+                fontSize: 15,
+                marginBottom: 18,
+                textAlign: 'left',
+              }}
+            >
+              {content}
+            </Text>
+            <Pressable
+              style={{
+                backgroundColor: colors.button,
+                borderRadius: 8,
+                paddingVertical: 10,
+                paddingHorizontal: 24,
+                marginTop: 8,
+              }}
+              onPress={onClose}
+              accessibilityLabel={closeButtonAccessibilityLabel}
+            >
+              <Text
+                style={{
+                  color: colors.buttonText,
+                  fontWeight: '600',
+                  fontSize: 16,
+                }}
+              >
+                {closeButtonText}
+              </Text>
+            </Pressable>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default StaticContentModal;

--- a/hooks/useResourceCredits.ts
+++ b/hooks/useResourceCredits.ts
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Client } from '@hiveio/dhive';
+
+interface ResourceCreditsData {
+  account: string;
+  rc_manabar: {
+    current_mana: string;
+    last_update_time: number;
+  };
+  max_rc_creation_adjustment: {
+    amount: string;
+    precision: number;
+    nai: string;
+  };
+  max_rc: string;
+}
+
+export const useResourceCredits = (username: string | null) => {
+  const [resourceCredits, setResourceCredits] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const calculateRCPercentage = useCallback((rcData: ResourceCreditsData) => {
+    try {
+      const currentMana = parseFloat(rcData.rc_manabar.current_mana);
+      const maxRc = parseFloat(rcData.max_rc);
+      
+      if (maxRc === 0) return 0;
+      
+      // Calculate percentage (0-100)
+      const percentage = (currentMana / maxRc) * 100;
+      return Math.max(0, Math.min(100, percentage));
+    } catch (err) {
+      console.error('Error calculating RC percentage:', err);
+      return 0;
+    }
+  }, []);
+
+  const fetchResourceCredits = useCallback(async () => {
+    if (!username) {
+      setResourceCredits(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const client = new Client([
+        'https://api.hive.blog',
+        'https://api.hivekings.com',
+        'https://anyx.io',
+        'https://api.openhive.network',
+      ]);
+
+      const response = await client.call('rc_api', 'find_rc_accounts', {
+        accounts: [username]
+      });
+
+      if (response?.rc_accounts && response.rc_accounts.length > 0) {
+        const rcData = response.rc_accounts[0];
+        const rcPercentage = calculateRCPercentage(rcData);
+        setResourceCredits(rcPercentage);
+      } else {
+        setResourceCredits(0);
+      }
+    } catch (err) {
+      console.error('Error fetching resource credits:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch resource credits');
+      setResourceCredits(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [username, calculateRCPercentage]);
+
+  const updateResourceCreditsOptimistically = useCallback((newRc: number) => {
+    setResourceCredits(prev => {
+      if (prev === null) return newRc;
+      return Math.max(0, Math.min(100, newRc));
+    });
+  }, []);
+
+  const refreshResourceCredits = useCallback(() => {
+    return fetchResourceCredits();
+  }, [fetchResourceCredits]);
+
+  useEffect(() => {
+    fetchResourceCredits();
+  }, [fetchResourceCredits]);
+
+  return {
+    resourceCredits,
+    loading,
+    error,
+    refreshResourceCredits,
+    updateResourceCreditsOptimistically,
+  };
+};

--- a/hooks/useResourceCredits.ts
+++ b/hooks/useResourceCredits.ts
@@ -24,9 +24,9 @@ export const useResourceCredits = (username: string | null) => {
     try {
       const currentMana = parseFloat(rcData.rc_manabar.current_mana);
       const maxRc = parseFloat(rcData.max_rc);
-      
+
       if (maxRc === 0) return 0;
-      
+
       // Calculate percentage (0-100)
       const percentage = (currentMana / maxRc) * 100;
       return Math.max(0, Math.min(100, percentage));
@@ -54,7 +54,7 @@ export const useResourceCredits = (username: string | null) => {
       ]);
 
       const response = await client.call('rc_api', 'find_rc_accounts', {
-        accounts: [username]
+        accounts: [username],
       });
 
       if (response?.rc_accounts && response.rc_accounts.length > 0) {
@@ -66,7 +66,9 @@ export const useResourceCredits = (username: string | null) => {
       }
     } catch (err) {
       console.error('Error fetching resource credits:', err);
-      setError(err instanceof Error ? err.message : 'Failed to fetch resource credits');
+      setError(
+        err instanceof Error ? err.message : 'Failed to fetch resource credits'
+      );
       setResourceCredits(null);
     } finally {
       setLoading(false);

--- a/styles/FeedScreenStyles.ts
+++ b/styles/FeedScreenStyles.ts
@@ -627,6 +627,21 @@ export const createFeedScreenStyles = (colors: any, isDark: boolean) => {
     visible: {
       opacity: 1,
     },
+
+    // Resource Credits and Voting Power styles
+    creditsContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginLeft: 8,
+    },
+    creditsIcon: {
+      marginLeft: 4,
+    },
+    creditsSeparator: {
+      color: colors.text,
+      fontSize: 12,
+      marginHorizontal: 4,
+    },
   });
 };
 


### PR DESCRIPTION
 NEW FEATURES:
- Added Resource Credits display next to Voting Power in top bar
- Side-by-side VP/RC layout with clean separator (VP: 85.2% | RC: 92.1%)
- Educational RC modal explaining 'digital fuel' concept
- Username truncation for better mobile layout (8 chars + '...')

 TECHNICAL IMPLEMENTATION:
- Created useResourceCredits hook following useVotingPower pattern
- Integrated official Hive rc_api.find_rc_accounts API
- Proper TypeScript interfaces matching Hive API spec
- String-to-number conversion for large RC values
- Error handling with graceful fallbacks

 UX/ACCESSIBILITY IMPROVEMENTS:
- Both VP and RC modals now fully scrollable (maxHeight: 80%)
- Touch-friendly buttons with proper hit slop areas
- Screen reader support with accessibility labels
- Responsive design for various screen sizes
- Loading states shared between VP and RC

 USER EDUCATION:
- Clear explanation of RC as 'digital fuel'
- Practical guidance: Power Up Hive, ask for delegations, use faucets
- Reassurance that RC recharges automatically over time
- Helps new users understand transaction limitations

 PROBLEM SOLVED:
New users no longer confused when they can't transact after 2-3 comments. Now they see their RC level and understand how to get more resources.