### PR TITLE
feat: implement resnap functionality with auto-focus UX

### DIFF
--- a/app/ComposeScreen.tsx
+++ b/app/ComposeScreen.tsx
@@ -178,7 +178,15 @@ export default function ComposeScreen() {
         : params.resnapUrl;
 
       if (typeof resnapUrl === 'string') {
-        setText(prev => (prev ? `${prev}\n\n${resnapUrl}` : resnapUrl));
+        const newText = resnapUrl + '\n\n';
+        setText(newText);
+
+        // Focus the input and position cursor after URL and line breaks
+        setTimeout(() => {
+          textInputRef.current?.focus();
+          const cursorPosition = newText.length;
+          textInputRef.current?.setSelection(cursorPosition, cursorPosition);
+        }, 100);
       }
     }
   }, [params.resnapUrl]);

--- a/app/ComposeScreen.tsx
+++ b/app/ComposeScreen.tsx
@@ -170,6 +170,19 @@ export default function ComposeScreen() {
     }
   }, [sharedContent, hasSharedContent, clearSharedContent]);
 
+  // Handle resnap URL parameter
+  useEffect(() => {
+    if (params.resnapUrl) {
+      const resnapUrl = Array.isArray(params.resnapUrl)
+        ? params.resnapUrl[0]
+        : params.resnapUrl;
+
+      if (typeof resnapUrl === 'string') {
+        setText(prev => (prev ? `${prev}\n\n${resnapUrl}` : resnapUrl));
+      }
+    }
+  }, [params.resnapUrl]);
+
   const handleAddImage = async () => {
     try {
       let pickType: 'camera' | 'gallery' | 'cancel';

--- a/app/ConversationScreen.tsx
+++ b/app/ConversationScreen.tsx
@@ -1369,6 +1369,13 @@ const ConversationScreenRefactored = () => {
                     'snap'
                   )
                 }
+                onResnapPress={(author, permlink) => {
+                  const snapUrl = `https://hive.blog/@${author}/${permlink}`;
+                  router.push({
+                    pathname: '/ComposeScreen',
+                    params: { resnapUrl: snapUrl },
+                  });
+                }}
                 currentUsername={currentUsername}
               />
             )}

--- a/app/DiscoveryScreen.tsx
+++ b/app/DiscoveryScreen.tsx
@@ -536,6 +536,13 @@ const DiscoveryScreen = () => {
                 });
               }}
               onEditPress={handleEditPress}
+              onResnapPress={(author, permlink) => {
+                const snapUrl = `https://hive.blog/@${author}/${permlink}`;
+                router.push({
+                  pathname: '/ComposeScreen',
+                  params: { resnapUrl: snapUrl },
+                });
+              }}
               currentUsername={currentUsername}
             />
           )}

--- a/app/FeedScreen.tsx
+++ b/app/FeedScreen.tsx
@@ -407,9 +407,11 @@ const FeedScreenRefactored = () => {
               <View style={styles.creditsContainer}>
                 {/* Voting Power */}
                 <SmallButton
-                  label="VP:"
-                  value={votingPower !== null ? (votingPower / 100).toFixed(1) : '--'}
-                  unit="%"
+                  label='VP:'
+                  value={
+                    votingPower !== null ? (votingPower / 100).toFixed(1) : '--'
+                  }
+                  unit='%'
                   colors={colors}
                   onPress={() => setVpInfoModalVisible(true)}
                   accessibilityLabel='Show Voting Power info'
@@ -422,9 +424,11 @@ const FeedScreenRefactored = () => {
 
                 {/* Resource Credits */}
                 <SmallButton
-                  label="RC:"
-                  value={resourceCredits !== null ? resourceCredits.toFixed(1) : '--'}
-                  unit="%"
+                  label='RC:'
+                  value={
+                    resourceCredits !== null ? resourceCredits.toFixed(1) : '--'
+                  }
+                  unit='%'
                   colors={colors}
                   onPress={() => setRcInfoModalVisible(true)}
                   accessibilityLabel='Show Resource Credits info'
@@ -618,6 +622,13 @@ const FeedScreenRefactored = () => {
                   router.push({
                     pathname: '/DiscoveryScreen',
                     params: { hashtag: tag },
+                  });
+                }}
+                onResnapPress={(author, permlink) => {
+                  const snapUrl = `https://hive.blog/@${author}/${permlink}`;
+                  router.push({
+                    pathname: '/ComposeScreen',
+                    params: { resnapUrl: snapUrl },
                   });
                 }}
               />

--- a/app/ProfileScreen.tsx
+++ b/app/ProfileScreen.tsx
@@ -739,6 +739,13 @@ const ProfileScreen = () => {
                               onContentPress={() => handleSnapPress(userSnap)}
                               showAuthor={true} // Show author for consistency with other feeds
                               onEditPress={handleEditPress}
+                              onResnapPress={(author, permlink) => {
+                                const snapUrl = `https://hive.blog/@${author}/${permlink}`;
+                                router.push({
+                                  pathname: '/ComposeScreen',
+                                  params: { resnapUrl: snapUrl },
+                                });
+                              }}
                               currentUsername={currentUsername}
                             />
                           );

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -81,6 +81,7 @@ interface SnapProps {
     permlink: string;
     body: string;
   }) => void; // NEW: handler for edit button
+  onResnapPress?: (author: string, permlink: string) => void; // NEW: handler for resnap button
   currentUsername?: string | null; // NEW: current user to check if they can edit
 }
 
@@ -465,6 +466,7 @@ const Snap: React.FC<SnapProps> = ({
   onHashtagPress,
   onReplyPress,
   onEditPress,
+  onResnapPress,
   currentUsername,
 }) => {
   // Process hashtags in text, converting them to clickable markdown links
@@ -828,6 +830,23 @@ const Snap: React.FC<SnapProps> = ({
         <Text style={[styles.replyCount, { color: colors.text }]}>
           {replyCount}
         </Text>
+        {/* Resnap button */}
+        {onResnapPress && permlink && (
+          <Pressable
+            onPress={() => onResnapPress(author, permlink)}
+            style={({ pressed }) => [
+              {
+                opacity: pressed ? 0.6 : 1,
+                marginLeft: 12,
+                padding: 4,
+              },
+            ]}
+            accessibilityRole='button'
+            accessibilityLabel='Resnap this post'
+          >
+            <FontAwesome name='retweet' size={18} color={colors.icon} />
+          </Pressable>
+        )}
         <View style={{ flex: 1 }} />
         <Text style={[styles.payout, { color: colors.payout }]}>
           ${payout.toFixed(2)}


### PR DESCRIPTION
- Add resnap icon (retweet) to Snap component action bar
- Implement onResnapPress handler across all screens (Feed, Conversation, Discovery, Profile)
- Navigate to ComposeScreen with pre-filled Hive post URL
- Auto-focus text input and position cursor below URL for immediate commenting
- Generate hive.blog URLs in format: https://hive.blog/@author/permlink
- Handle URL parameters safely with proper TypeScript types
- Maintain consistent styling and accessibility labels

Allows users to easily share and comment on existing snaps by clicking the resnap icon, providing a seamless Twitter-like resharing experience.