### PR TITLE
Fix Android back button behavior on FeedScreen

### DIFF
--- a/app/FeedScreen.tsx
+++ b/app/FeedScreen.tsx
@@ -14,7 +14,6 @@ import {
   TextInput,
   ScrollView,
   BackHandler,
-  ToastAndroid,
   KeyboardAvoidingView,
 } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
@@ -189,7 +188,6 @@ const FeedScreenRefactored = () => {
   const [imageModalVisible, setImageModalVisible] = useState(false);
   const [modalImages, setModalImages] = useState<Array<{ uri: string }>>([]);
   const [modalImageIndex, setModalImageIndex] = useState(0);
-  const [exitTimestamp, setExitTimestamp] = useState<number | null>(null);
 
   // Refs
   const flatListRef = useRef<FlatList<any>>(null);
@@ -262,31 +260,16 @@ const FeedScreenRefactored = () => {
     await handleSearch(searchTerm);
   };
 
-  // Handle back button for exit confirmation
+  // Handle back button - minimize app instead of logout
   useFocusEffect(
     React.useCallback(() => {
       const backAction = () => {
-        const now = Date.now();
-
-        if (exitTimestamp && now - exitTimestamp < 2000) {
-          logout();
-          return true;
-        } else {
-          setExitTimestamp(now);
-
-          if (Platform.OS === 'android') {
-            ToastAndroid.show(
-              'Press back again to log out',
-              ToastAndroid.SHORT
-            );
-          }
-
-          setTimeout(() => {
-            setExitTimestamp(null);
-          }, 2000);
-
+        // On Android, minimize the app when back is pressed on main feed
+        if (Platform.OS === 'android') {
+          BackHandler.exitApp();
           return true;
         }
+        return false;
       };
 
       const backHandler = BackHandler.addEventListener(
@@ -294,7 +277,7 @@ const FeedScreenRefactored = () => {
         backAction
       );
       return () => backHandler.remove();
-    }, [exitTimestamp, logout])
+    }, [])
   );
 
   // Viewability config for FlatList


### PR DESCRIPTION
- Replace complex double-tap-to-logout with standard app minimize behavior
- Back button on FeedScreen now minimizes app instead of requiring double-tap
- Matches user expectations and standard Android app patterns
- Removes unnecessary exitTimestamp state and toast messages
- Simplifies code from complex workaround to one-line standard solution

Fixes accidental logout issue by following platform conventions