### PR TITLE
fix: Add support for reply_comment notification type in filtering

### DIFF
--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -256,25 +256,36 @@ export function filterNotificationsBySettings(
   settings: ReturnType<typeof getDefaultNotificationSettings>
 ): ParsedNotification[] {
   return notifications.filter(notification => {
+    let shouldInclude: boolean;
     switch (notification.type) {
       case 'vote':
-        return settings.votes;
+        shouldInclude = settings.votes;
+        break;
       case 'reply':
-        return settings.replies;
+      case 'reply_comment':
+        shouldInclude = settings.replies;
+        break;
       case 'reblog':
-        return settings.reblogs;
+        shouldInclude = settings.reblogs;
+        break;
       case 'follow':
-        return settings.follows;
+        shouldInclude = settings.follows;
+        break;
       case 'mention':
-        return settings.mentions;
+        shouldInclude = settings.mentions;
+        break;
       case 'subscribe':
       case 'set_role':
       case 'set_label':
       case 'new_community':
-        return settings.communityUpdates;
+        shouldInclude = settings.communityUpdates;
+        break;
       default:
-        return true;
+        shouldInclude = true;
+        break;
     }
+    
+    return shouldInclude;
   });
 }
 


### PR DESCRIPTION
- Reply notifications from Hive blockchain use type 'reply_comment'
- Previous filtering only handled 'reply' type
- Now both 'reply' and 'reply_comment' are filtered by replies setting
- Fixes issue where reply notifications ignored disabled setting

Resolves notification filtering inconsistency