### PR TITLE
feat: improved title fallback - 'Reply to Post' for untitled replies,…

### DIFF
--- a/hooks/useHivePostData.ts
+++ b/hooks/useHivePostData.ts
@@ -288,10 +288,43 @@ export const useHivePostData = (
         return hasUpvoted;
       };
 
+      // Improved fallback title logic
+      let computedTitle = postData.title;
+      if (!computedTitle || !computedTitle.trim()) {
+        // Determine if this is likely a snap
+        let isSnap = false;
+        try {
+          if (
+            postData.permlink?.startsWith('snap-') ||
+            postData.parent_author === 'peak.snaps'
+          ) {
+            isSnap = true;
+          } else if (postData.json_metadata) {
+            try {
+              const md = JSON.parse(postData.json_metadata);
+              if (
+                (md.app && String(md.app).includes('hivesnaps')) ||
+                (Array.isArray(md.tags) && md.tags.includes('hivesnaps'))
+              ) {
+                isSnap = true;
+              }
+            } catch (e) {}
+          }
+        } catch (e) {}
+
+        if (isSnap) {
+          computedTitle = 'Resnap';
+        } else if (postData.parent_author) {
+          computedTitle = 'Reply to Post';
+        } else {
+          computedTitle = 'Untitled Post';
+        }
+      }
+
       const hivePostData: HivePostData = {
         author: postData.author,
         permlink: postData.permlink,
-        title: postData.title || 'Untitled Post',
+        title: computedTitle,
         body: postData.body,
         created: postData.created,
         voteCount: postData.net_votes || 0,

--- a/utils/extractHivePostInfo.ts
+++ b/utils/extractHivePostInfo.ts
@@ -342,7 +342,12 @@ export async function fetchHivePostInfo(
       const postType = await detectPostType(postInfo);
 
       // Return appropriate label based on type
-      return postType === 'snap' ? 'Resnap' : 'Untitled Post';
+      if (postType === 'snap') return 'Resnap';
+      // If it's a reply (has parent_author) but no title, label clearly
+      if (postData.parent_author && postData.parent_author.length > 0) {
+        return 'Reply to Post';
+      }
+      return 'Untitled Post';
     };
 
     return {


### PR DESCRIPTION
Improve fallback title logic: untitled replies now show “Reply to Post”; untitled snaps still show “Resnap”; only true final fallback uses “Untitled Post”.

Changes

Updated smart title in [extractHivePostInfo.ts]
Updated fallback in [useHivePostData.ts] with lightweight snap/reply detection.

Rationale
“Untitled Post” looked broken for normal replies without titles. Clearer labels improve trust and UX.