### PR TITLE
feat: unified payout-based sorting for replies/comments (descending p…

### DIFF
--- a/hooks/useConversationData.ts
+++ b/hooks/useConversationData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { sortByPayoutRecursive } from '../utils/sortRepliesByPayout';
 import { Client } from '@hiveio/dhive';
 import { useOptimisticUpdates } from './useOptimisticUpdates';
 
@@ -257,9 +258,10 @@ export const useConversationData = (
       // Fetch replies tree with full content
       const tree = await fetchRepliesTreeWithContent(author, permlink);
 
+      const sortedTree = sortByPayoutRecursive(tree);
       setState({
         snap: snapData,
-        replies: tree,
+        replies: sortedTree,
         loading: false,
         error: null,
       });
@@ -324,7 +326,8 @@ export const useConversationData = (
       ]);
 
       // Fetch replies tree without setting loading state
-      const tree = await fetchRepliesTreeWithContent(author, permlink);
+  const tree = await fetchRepliesTreeWithContent(author, permlink);
+  const sortedTree = sortByPayoutRecursive(tree);
 
       // Check if we have new content
       const hasNewReplies = tree.length > state.replies.length;
@@ -359,7 +362,7 @@ export const useConversationData = (
             parent_author: post.parent_author,
             parent_permlink: post.parent_permlink,
           },
-          replies: tree,
+          replies: sortedTree,
         }));
       }
 

--- a/hooks/useHivePostData.ts
+++ b/hooks/useHivePostData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { sortByPayoutRecursive } from '../utils/sortRepliesByPayout';
 import { Client } from '@hiveio/dhive';
 
 const HIVE_NODES = [
@@ -360,12 +361,12 @@ export const useHivePostData = (
 
       const updatedCommentsTree = updateCommentsHasUpvoted(commentsTree);
 
-      // Sort comments by creation date (newest first)
-      updatedCommentsTree.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
+  // Sort comments by payout (desc) then created (asc) recursively
+  const sortedTree = sortByPayoutRecursive(updatedCommentsTree);
 
       setState(prev => ({
         ...prev,
-        comments: updatedCommentsTree,
+  comments: sortedTree,
         commentsLoading: false,
         commentsError: null,
       }));

--- a/utils/sortRepliesByPayout.ts
+++ b/utils/sortRepliesByPayout.ts
@@ -1,0 +1,28 @@
+// Utility to recursively sort replies/comments by payout (desc) then created (asc)
+// Keeps data shape intact; returns a new array (shallow clones) to avoid mutating original state.
+
+export interface HasPayoutAndReplies<T> {
+  payout?: number;
+  created?: string;
+  replies?: T[];
+}
+
+export function sortByPayoutRecursive<T extends HasPayoutAndReplies<T>>(items: T[]): T[] {
+  if (!Array.isArray(items) || items.length === 0) return items;
+  // Copy first to avoid mutating caller's array
+  const cloned = items.map(item => ({ ...item }));
+  for (const item of cloned) {
+    if (item.replies && item.replies.length > 0) {
+      item.replies = sortByPayoutRecursive(item.replies as T[]);
+    }
+  }
+  cloned.sort((a, b) => {
+    const payoutA = typeof a.payout === 'number' ? a.payout! : 0;
+    const payoutB = typeof b.payout === 'number' ? b.payout! : 0;
+    if (payoutB !== payoutA) return payoutB - payoutA; // higher first
+    const timeA = a.created ? new Date(a.created).getTime() : 0;
+    const timeB = b.created ? new Date(b.created).getTime() : 0;
+    return timeA - timeB; // earlier first within same payout
+  });
+  return cloned;
+}


### PR DESCRIPTION
Unifies reply/comment ordering across Conversation and Hive Post views: now sorted by payout descending, then creation time ascending within ties.

Changes

Added sortRepliesByPayout.ts recursive utility.
Applied payout-based sorting in [useConversationData]

Replaced newest-first sort in [useHivePostData]

Rationale
Consistent ordering emphasizes highest-value contributions first and removes cross-screen inconsistency.

Testing

- Verified trees render with highest payout at top (sample data).
- Nested replies maintain payout ordering at each depth.
- Tie cases fall back to earlier timestamp first.
- No TypeScript errors introduced.
- No API or dependency changes. Merge after quick visual sanity check.