### PR TITLE
 Reapply: robust raw image URL handling and text cleanup (Snap + Conversation)

### DIFF
--- a/app/ConversationScreen.tsx
+++ b/app/ConversationScreen.tsx
@@ -40,6 +40,10 @@ import RenderHtml, {
 import { Dimensions } from 'react-native';
 
 import { extractImageUrls } from '../utils/extractImageUrls';
+import {
+  extractRawImageUrls as extractRawImageUrlsUtil,
+  removeRawImageUrls as removeRawImageUrlsUtil,
+} from '../utils/rawImageUrls';
 import ImageView from 'react-native-image-viewing';
 import genericAvatar from '../assets/images/generic-avatar.png';
 import { extractHivePostUrls } from '../utils/extractHivePostInfo';
@@ -657,7 +661,8 @@ const ConversationScreenRefactored = () => {
   // DEPRECATED: renderReplyTree function - Now using flattened approach instead
   const renderReplyTree = (reply: ReplyData, level = 0) => {
     const videoInfo = extractVideoInfo(reply.body);
-    const imageUrls = extractImageUrls(reply.body);
+  const imageUrls = extractImageUrls(reply.body);
+  const rawImageUrls = extractRawImageUrlsUtil(reply.body);
     const hivePostUrls = extractHivePostUrls(reply.body);
 
     let textBody = reply.body;
@@ -670,6 +675,9 @@ const ConversationScreenRefactored = () => {
       textBody = removeTwitterUrls(textBody);
     }
     textBody = stripImageTags(textBody);
+    if (rawImageUrls.length > 0) {
+      textBody = removeRawImageUrlsUtil(textBody);
+    }
 
     // Process spoiler syntax
     const spoilerData = convertSpoilerSyntax(textBody);
@@ -755,6 +763,21 @@ const ConversationScreenRefactored = () => {
                   key={url + idx}
                   onPress={() => handleImagePress(url)}
                 >
+                  <ExpoImage
+                    source={{ uri: url }}
+                    style={ConversationScreenStyles.imageStyle}
+                    contentFit='cover'
+                  />
+                </Pressable>
+              ))}
+            </View>
+          )}
+
+          {/* Images from raw URLs */}
+          {rawImageUrls.length > 0 && (
+            <View style={ConversationScreenStyles.imageContainer}>
+              {rawImageUrls.map((url, idx) => (
+                <Pressable key={url + idx} onPress={() => handleImagePress(url)}>
                   <ExpoImage
                     source={{ uri: url }}
                     style={ConversationScreenStyles.imageStyle}
@@ -931,7 +954,8 @@ const ConversationScreenRefactored = () => {
     if (!snap) return null;
 
     const videoInfo = extractVideoInfo(snap.body);
-    const imageUrls = extractImageUrls(snap.body);
+  const imageUrls = extractImageUrls(snap.body);
+  const rawImageUrls = extractRawImageUrlsUtil(snap.body);
     const hivePostUrls = extractHivePostUrls(snap.body);
 
     let textBody = snap.body;
@@ -944,6 +968,9 @@ const ConversationScreenRefactored = () => {
       textBody = removeTwitterUrls(textBody);
     }
     textBody = stripImageTags(textBody);
+    if (rawImageUrls.length > 0) {
+      textBody = removeRawImageUrlsUtil(textBody);
+    }
 
     // Process spoiler syntax
     const spoilerData = convertSpoilerSyntax(textBody);
@@ -1020,6 +1047,21 @@ const ConversationScreenRefactored = () => {
         {imageUrls.length > 0 && (
           <View style={ConversationScreenStyles.imageContainer}>
             {imageUrls.map((url, idx) => (
+              <Pressable key={url + idx} onPress={() => handleImagePress(url)}>
+                <ExpoImage
+                  source={{ uri: url }}
+                  style={ConversationScreenStyles.imageStyle}
+                  contentFit='cover'
+                />
+              </Pressable>
+            ))}
+          </View>
+        )}
+
+        {/* Images from raw URLs */}
+        {rawImageUrls.length > 0 && (
+          <View style={ConversationScreenStyles.imageContainer}>
+            {rawImageUrls.map((url, idx) => (
               <Pressable key={url + idx} onPress={() => handleImagePress(url)}>
                 <ExpoImage
                   source={{ uri: url }}

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@types/jest": "^30.0.0",
         "@types/react": "~19.0.10",
         "@types/react-native": "^0.73.0",
         "jest": "^29.2.1",
@@ -2371,6 +2372,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2430,6 +2440,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2444,6 +2463,28 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -3341,6 +3382,221 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.5.tgz",
+      "integrity": "sha512-F3lmTT7CXWYywoVUGTCmom0vXq3HTTkaZyTAzIy+bXSBizB7o5qzlC9VCtq0arOa8GqmNsbg/cE9C6HLn7Szew==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.39",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.39.tgz",
+      "integrity": "sha512-keEoFsevmLwAedzacnTVmra66GViRH3fhWO1M+nZ8rUgpPJyN4mcvqlGr3QMrQXx4L8KNwW0q9/BeHSEoO4teg==",
+      "dev": true
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
+      "integrity": "sha512-P0te2pt+hHI5qLJkIR+iMvS+lYUZml8rKKsohVHAGY+uClp9XVbdyYNJOIjSRpHVp8s8YqxJCiHUkSYZGr8rtQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "30.0.5",
+        "@jest/get-type": "30.0.1",
+        "jest-matcher-utils": "30.0.5",
+        "jest-message-util": "30.0.5",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
+      "integrity": "sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
+      "integrity": "sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.0.5",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.5.tgz",
+      "integrity": "sha512-NAiDOhsK3V7RU0Aa/HnrQo+E4JlbarbmI3q6Pi4KcxicdtjV82gcIUrejOtczChtVQR4kddu1E1EJlW6EN9IyA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.5",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.5",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@types/jest": "^30.0.0",
     "@types/react": "~19.0.10",
     "@types/react-native": "^0.73.0",
     "jest": "^29.2.1",

--- a/utils/rawImageUrls.ts
+++ b/utils/rawImageUrls.ts
@@ -1,0 +1,78 @@
+// Utilities for robust raw image URL extraction and removal
+// Handles direct and Hive proxy-chained image URLs with optional query strings.
+// Preserves newlines and paragraph spacing when removing URLs.
+
+// Build a fresh regex each call to avoid lastIndex state issues with /g
+export function getRawImageUrlRegex(): RegExp {
+  // Pattern breakdown:
+  // (^) or ([\s(]) - Capture start of string OR the leading whitespace/paren
+  // (              - Capture the URL itself:
+  //   https?:\/\/ - Protocol
+  //   \S+?        - Non-whitespace chars (non-greedy), covers domains/paths including proxy chains
+  //   \.          - Literal dot before extension
+  //   (?:jpe?g|png|gif|webp|bmp|svg) - Common image extensions
+  //   (?:\?[^\s)]*)? - Optional query string, stopping before whitespace or ')'
+  // )
+  // Trailing handling:
+  //  - Capture a trailing newline (\r?\n) as group 3 OR a single space/tab as group 4 so we can re-insert it
+  //  - Or match a closing punctuation or end of string without capturing
+  // This avoids swallowing a newline and collapsing blank lines
+  // Note: We split the leading boundary into two alternatives so we can preserve it in replacements
+  const source = String.raw`(?:^|([\s(]))((https?:\/\/\S+?\.(?:jpe?g|png|gif|webp|bmp|svg)(?:\?[^\s)]*)?))(?:(\r?\n)|([ \t])|[)\],.!?]|$)`;
+  return new RegExp(source, 'gi');
+}
+
+// Extract raw image URLs not already inside markdown image syntax
+export function extractRawImageUrls(text: string): string[] {
+  if (!text) return [];
+  const found = new Set<string>();
+  text.replace(
+    getRawImageUrlRegex(),
+    (
+      _full: string,
+      leading: string | undefined,
+      url: string,
+      _trailNewline?: string,
+      _trailSpace?: string
+    ) => {
+    // Some punctuation can still slip through in edge cases; strip common trailing chars except ')'
+    const cleaned = url.replace(/[,.!]+$/g, '');
+    found.add(cleaned);
+    return _full;
+    }
+  );
+
+  return Array.from(found).filter(u => {
+    // Escape the URL safely for use inside a regex
+    const escaped = u.replace(/[][*+?^${}()|[\]\\]/g, m => `\\${m}`);
+    const markdownImagePattern = new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)`);
+    return !markdownImagePattern.test(text);
+  });
+}
+
+// Remove discovered raw image URLs while preserving newlines/paragraphs
+export function removeRawImageUrls(text: string): string {
+  if (!text) return text;
+  let result = text;
+
+  // 1) URLs inside parentheses: transform `(URL)` -> `(`
+  const urlCore = String.raw`https?:\/\/\S+?\.(?:jpe?g|png|gif|webp|bmp|svg)(?:\?[^)\s]*)?`;
+  const parenthesized = new RegExp(String.raw`\((${urlCore})\)`, 'gi');
+  result = result.replace(parenthesized, '(');
+
+  // 2) Raw URLs preceded by whitespace; keep the whitespace, drop the URL.
+  // Use lookahead so a trailing space/newline remains untouched and is handled by line-trim below
+  const rawWithWs = new RegExp(String.raw`(\s)(${urlCore})(?=\s|$)`, 'gi');
+  result = result.replace(rawWithWs, '$1');
+
+  // Normalize horizontal whitespace per line without collapsing blank lines
+  result = result
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(line => line.replace(/[ \t]{2,}/g, ' ').replace(/ +$/, ''))
+  .join('\n')
+  // Collapse 3+ blank lines to at most 2 (keep double newlines intact)
+  .replace(/\n{3,}/g, '\n\n');
+
+  return result;
+}


### PR DESCRIPTION
Summary Re-implements and expands PR #57 on latest main. Centralizes raw image URL detection/removal in utils and wires it into Snap and Conversation to avoid URL blobs while still rendering images cleanly.

Changes

[rawImageUrls.ts]
extractRawImageUrls: detects direct and Hive proxy “double” image URLs (with queries), ignores markdown images, strips trailing punctuation, fresh regex per call, documented.
removeRawImageUrls: removes raw image URLs from text while preserving newlines/paragraph spacing; handles “(URL)” → “(” case.

[Snap.tsx]
Renders images from raw URLs and removes them from text before Markdown/HTML to prevent duplicates.

[ConversationScreen.tsx]
Mirrors the same behavior for snap header and replies.

Tests
[rawImageUrls.test.ts] ensures extraction and whitespace/newline preservation.

Dev tooling
Added @types/jest for TS test typings.
Why Raw pasted image URLs (including Hive proxy-chained) made text unreadable and duplicated content. This renders those images once and keeps the text clean and readable.

Review notes from PR #57 addressed

- Regex readability: added inline comments and helper; clearer intent.
- Global RegExp state: avoided by building fresh regex per call.
- Trailing punctuation/parenthesis: preserved context; no double-stripping.
“Move to utils” (joseamena): done; reused in both screens.


Edge cases

- Direct and Hive proxy-chained URLs with queries.
- URLs next to punctuation or wrapped in parentheses.
- Markdown image syntax ignored to prevent duplicates.
- Preserves blank lines; trims stray trailing spaces per line.
