### PR TITLE
fix: Update Hive link for App Store compliance

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -131,8 +131,8 @@ export default function LoginScreen() {
     }
   };
 
-  const handleSignUpPress = () => {
-    Linking.openURL('https://signup.hive.io/');
+  const handleLearnMorePress = () => {
+    Linking.openURL('https://hive.io/');
   };
 
   return (
@@ -249,15 +249,15 @@ export default function LoginScreen() {
                 {/* Add space and move the phrase up here */}
                 <View style={{ height: 32 }} />
 
-                {/* Signup link */}
+                {/* Learn more link */}
                 <TouchableOpacity
-                  onPress={handleSignUpPress}
+                  onPress={handleLearnMorePress}
                   style={{ marginBottom: 16 }}
                   accessibilityRole='button'
-                  accessibilityLabel='Sign up for a Hive account'
+                  accessibilityLabel='Learn more about Hive'
                 >
                   <Text style={[styles.signupLink, { color: colors.button }]}>
-                    Don't have a Hive account?
+                    Learn more at hive.io
                   </Text>
                 </TouchableOpacity>
 


### PR DESCRIPTION
- Changed URL from https://signup.hive.io/ to https://hive.io/
- Updated text from 'Don't have a Hive account?' to 'Learn more at hive.io'
- Updated accessibility label to 'Learn more about Hive'
- Renamed handleSignUpPress to handleLearnMorePress for clarity
- Updated comment from 'Signup link' to 'Learn more link'

This change addresses App Store compliance requirements by directing users to educational content about Hive rather than direct account creation, avoiding issues with account deletion policies while maintaining user value.