### PR TITLE
Add 'Go to Profile' option to Snap three-dots menu

### DIFF
--- a/app/ConversationScreen.tsx
+++ b/app/ConversationScreen.tsx
@@ -1393,6 +1393,9 @@ const ConversationScreenRefactored = () => {
                     onEditPress={(snapData: { author: string; permlink: string; body: string }) =>
                       handleOpenEditModal(snapData, 'reply')
                     }
+                    onUserPress={username => {
+                      router.push(`/ProfileScreen?username=${username}` as any);
+                    }}
                     onImagePress={handleImagePress}
                     currentUsername={currentUsername}
                     posting={posting}

--- a/app/HivePostScreen.tsx
+++ b/app/HivePostScreen.tsx
@@ -533,6 +533,9 @@ const HivePostScreen = () => {
                     // TODO: Implement edit functionality
                   }}
                   onImagePress={handleImagePress}
+                  onUserPress={username => {
+                    router.push(`/ProfileScreen?username=${username}` as any);
+                  }}
                   currentUsername={currentUsername}
                   // Reply-specific props
                   visualLevel={comment.visualLevel}

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -1098,6 +1098,16 @@ const Snap: React.FC<SnapProps> = ({
         onClose={() => setMoreMenuVisible(false)}
         items={[
           {
+            label: 'Go to Profile',
+            accessibilityLabel: 'Go to Profile',
+            onPress: () => {
+              setMoreMenuVisible(false);
+              if (onUserPress) {
+                onUserPress(snap.author);
+              }
+            },
+          },
+          {
             label: 'Report Content',
             tone: 'danger',
             accessibilityLabel: 'Report Content',


### PR DESCRIPTION
- Add 'Go to Profile' as first option in ActionSheet menu in Snap component
- Enable navigation to user profiles from any Snap context
- Added onUserPress handlers to ConversationScreen (both main post and replies)
- Added onUserPress handler to HivePostScreen for comment navigation
- Excluded ProfileScreen since all snaps belong to profile owner (redundant)

Features:
 ConversationScreen: Navigate to commenter profiles from replies
 HivePostScreen: Navigate to commenter profiles from comments
 DiscoveryScreen: Navigate to author profiles (already had onUserPress)
 FeedScreen: Navigate to author profiles (already had onUserPress)

This provides consistent access to user profiles across all contexts where users interact with content from multiple authors.