### PR TITLE
Fix: Improve Terms of Service modal UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ HiveSnaps is a cutting-edge React Native mobile app built with Expo and TypeScri
 - **Image Uploads** - Camera capture or gallery selection with Cloudinary hosting
 - **GIF Integration** - Powered by Tenor API with search functionality
 - **Video Embedding** - YouTube, 3Speak, and IPFS video support
+- **Instagram Embeds** - Native Instagram post rendering in feed
 - **Twitter/X Embeds** - Native tweet rendering in posts
 - **Image Galleries** - Full-screen image viewing with zoom
 
@@ -39,12 +40,15 @@ HiveSnaps is a cutting-edge React Native mobile app built with Expo and TypeScri
 - **Smart Composer** - Rich text editor with live previews
 - **Media Attachments** - Images, GIFs, and video embeds
 - **Edit Functionality** - Edit your posts and replies after publishing
+- **Three-Dots Menu** - Quick actions including "Go to Profile" and content reporting
 - **Optimistic Updates** - Instant UI updates for better UX
 - **Draft Support** - Auto-save functionality (coming soon)
 
 ### 🔔 User Experience
 
 - **Notifications System** - Track mentions, votes, and replies
+- **Content Moderation** - Community-driven reporting and moderation system
+- **Terms of Service** - Required acceptance for App Store compliance
 - **Dark/Light Theme** - Automatic theme switching
 - **Pull-to-Refresh** - Intuitive feed updates
 - **Infinite Scroll** - Smooth content loading
@@ -135,9 +139,17 @@ HiveSnaps is a cutting-edge React Native mobile app built with Expo and TypeScri
 
 We standardized avatars to images.hive.blog across the app. See `docs/avatar-unification.md` for details on behavior, affected files, and testing.
 
-### Moderation (Downvote Hiding)
+### Moderation & Community Guidelines
 
-Client-side moderation hides posts/replies downvoted by an allowlisted moderator (default: `@snapie`). Minimal, on-chain, no backend. See `docs/moderation.md` for policy, config, and integration points.
+HiveSnaps implements a comprehensive content moderation system:
+
+- **Community Reporting** - Users can report inappropriate content through three-dots menu
+- **Blockchain-native Moderation** - Content moderation via @snapie account voting system  
+- **Automatic Content Filtering** - Posts with moderation downvotes are hidden from interface
+- **Zero-tolerance Policy** - Strict enforcement against harassment, abuse, and harmful content
+- **Terms of Service** - Required acceptance with App Store compliance for community standards
+
+See `docs/moderation.md` for detailed policy, configuration, and technical implementation.
 
 ### Testing
 

--- a/components/TermsOfServiceModal.tsx
+++ b/components/TermsOfServiceModal.tsx
@@ -61,21 +61,7 @@ const TermsOfServiceModal: React.FC<TermsOfServiceModalProps> = ({
   };
 
   const handleDecline = () => {
-    Alert.alert(
-      'Terms Required',
-      'You must accept the Terms of Service to use HiveSnaps. The app will close if you decline.',
-      [
-        {
-          text: 'Review Terms',
-          style: 'cancel',
-        },
-        {
-          text: 'Close App',
-          style: 'destructive',
-          onPress: onDecline,
-        },
-      ]
-    );
+    onDecline?.();
   };
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -108,19 +94,6 @@ const TermsOfServiceModal: React.FC<TermsOfServiceModalProps> = ({
           />
           <Text style={styles.headerTitle}>
             Terms of Service
-          </Text>
-        </View>
-
-        {/* Important Notice */}
-        <View style={styles.noticeContainer}>
-          <View style={styles.noticeHeader}>
-            <FontAwesome name="info-circle" size={18} color={colors.primaryButton} />
-            <Text style={styles.noticeTitle}>
-              Required for App Store Compliance
-            </Text>
-          </View>
-          <Text style={styles.noticeText}>
-            You must read and accept these terms before using HiveSnaps. These terms include our zero-tolerance policy for abusive content and community guidelines.
           </Text>
         </View>
 

--- a/constants/TermsOfService.ts
+++ b/constants/TermsOfService.ts
@@ -28,7 +28,6 @@ HiveSnaps maintains a zero-tolerance policy for abusive, harmful, or objectionab
   - Content that violates our guidelines may receive moderation downvotes via @snapie
   - Posts with moderation downvotes are automatically hidden from the HiveSnaps interface
   - Repeat violations may result in automatic moderation of future posts
-  - Severe violations may result in restricted access to the HiveSnaps app
   - Our moderation system operates within Hive blockchain's voting mechanisms
 
 3. USER RESPONSIBILITIES
@@ -55,7 +54,7 @@ Our moderation approach uses blockchain-native mechanisms:
 • Content with moderation downvotes is automatically filtered from HiveSnaps
 • This system respects blockchain principles while maintaining community standards
 • Persistent violations may result in automatic moderation of future content
-• App access may also be restricted for severe or repeated violations
+
 
 Important: Moderation actions use Hive's voting system and do not delete blockchain content.
 
@@ -85,7 +84,7 @@ We may update these Terms periodically. Continued use after changes constitutes 
 
 11. CONTACT INFORMATION
 For questions about these Terms or to report violations:
-• Email: support@hivesnaps.com
+• Email: snapieapp@proton.me
 • Report content through in-app reporting features
 
 12. GOVERNING LAW

--- a/constants/TermsOfService.ts
+++ b/constants/TermsOfService.ts
@@ -84,7 +84,7 @@ We may update these Terms periodically. Continued use after changes constitutes 
 
 11. CONTACT INFORMATION
 For questions about these Terms or to report violations:
-• Email: snapieapp@proton.me
+• Email: snapieapp@protonmail.me
 • Report content through in-app reporting features
 
 12. GOVERNING LAW


### PR DESCRIPTION
- Remove 'App Store Compliance' banner for cleaner UI
- Fix iOS double-alert issue when declining terms
- Simplify decline flow to single alert on iOS
- Remove temporary debug button

Changes:
- TermsOfServiceModal.tsx: Remove compliance banner, simplify decline handler
- Clean up debug code from FeedScreen.tsx