### PR TITLE
Fix: Remove duplicate onUserPress attribute in HivePostScreen

### DIFF
--- a/app/HivePostScreen.tsx
+++ b/app/HivePostScreen.tsx
@@ -536,9 +536,6 @@ const HivePostScreen = () => {
                     router.push(`/ProfileScreen?username=${username}` as any);
                   }}
                   onImagePress={handleImagePress}
-                  onUserPress={username => {
-                    router.push(`/ProfileScreen?username=${username}` as any);
-                  }}
                   currentUsername={currentUsername}
                   // Reply-specific props
                   visualLevel={comment.visualLevel}


### PR DESCRIPTION
- Fixed JSX compilation error caused by duplicate onUserPress props
- Snap component now has single onUserPress handler for profile navigation
- Critical hotfix needed for app compilation

This error was likely introduced during recent PR merges and breaks JSX compilation.