### PR TITLE
feat: Add community tags to HiveSnaps posts

### DIFF
--- a/app/ComposeScreen.tsx
+++ b/app/ComposeScreen.tsx
@@ -432,6 +432,7 @@ export default function ComposeScreen() {
       const allMedia = [...images, ...gifs];
       const json_metadata = JSON.stringify({
         app: 'hivesnaps/1.0',
+        tags: ['hive-178315', 'snaps'],
         image: allMedia, // Include all images and GIFs in metadata
         shared: hasSharedContent, // Additional flag for shared content
       });


### PR DESCRIPTION
- Add 'hive-178315' community tag for HiveSnaps community visibility
- Add 'snaps' tag to maintain Snaps ecosystem integration
- Keep existing app attribution and image metadata unchanged

This enables dual visibility: posts appear in both the HiveSnaps community feed and the broader Snaps ecosystem, building brand recognition across all Hive frontends.