### PR TITLE
fix: temporarily disable gif replies in iOS

### DIFF
--- a/app/components/ContentModal.tsx
+++ b/app/components/ContentModal.tsx
@@ -334,7 +334,7 @@ const ContentModal: React.FC<ContentModalProps> = ({
               <FontAwesome name='image' size={22} color={colors.icon} />
             </TouchableOpacity>
             {/* Hide GIF button for iOS in reply mode */}
-            {/* {!(Platform.OS === 'ios' && mode === 'reply') && (
+            {!(Platform.OS === 'ios' && mode === 'reply') && (
               <TouchableOpacity
                 onPress={onAddGif}
                 disabled={uploading || posting || processing}
@@ -345,7 +345,7 @@ const ContentModal: React.FC<ContentModalProps> = ({
               >
                 <Text style={{ fontSize: 18, color: colors.icon }}>GIF</Text>
               </TouchableOpacity>
-            )} */}
+            )}
             {uploading && (
               <FontAwesome name='spinner' size={16} color={colors.icon} />
             )}


### PR DESCRIPTION
Trying to post a gif will render the app unresponsive in iOS, the problem is iOS cannot handle mutlple modals present at the same time, a new UI should be thought, then refactor.