### PR TITLE
Increase conversation reply depth limit

### DIFF
--- a/hooks/useConversationData.ts
+++ b/hooks/useConversationData.ts
@@ -12,7 +12,7 @@ const HIVE_NODES = [
 const client = new Client(HIVE_NODES);
 
 // Default maximum depth for fetching nested replies
-const DEFAULT_MAX_REPLY_DEPTH = 3;
+const DEFAULT_MAX_REPLY_DEPTH = 10;
 
 // Types for conversation data
 export interface SnapData {

--- a/hooks/useHivePostData.ts
+++ b/hooks/useHivePostData.ts
@@ -117,7 +117,7 @@ export const useHivePostData = (
       postAuthor: string,
       postPermlink: string,
       depth = 0,
-      maxDepth = 3
+      maxDepth = 10
     ): Promise<HiveCommentData[]> => {
       if (depth > maxDepth) return [];
 


### PR DESCRIPTION
- Change DEFAULT_MAX_REPLY_DEPTH from 3 to 10 levels
- Update useHivePostData maxDepth from 3 to 10
- Enables full conversation context without cutting off deep replies
- Visual display remains clean with maxVisualLevel = 2 indentation limit
- Improves UX for understanding complex conversation threads