### PR TITLE
fix: prevent URL fragments from being treated as hashtags

### DIFF
--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -223,9 +223,10 @@ const Snap: React.FC<SnapProps> = ({
   }, [author, avatarUrl]);
   // Process hashtags in text, converting them to clickable markdown links
   function processHashtags(text: string): string {
-    return text.replace(/(#\w+)/g, (match, hashtag) => {
-      const tag = hashtag.replace('#', '');
-      return `[${hashtag}](hashtag://${tag})`;
+    // Only match hashtags that are NOT part of URLs (not preceded by /)
+    return text.replace(/(^|[^\/\w])#(\w+)/g, (match, prefix, hashtag) => {
+      const tag = hashtag;
+      return `${prefix}[#${hashtag}](hashtag://${tag})`;
     });
   }
   const colorScheme = useColorScheme() || 'light';

--- a/utils/contentProcessing.ts
+++ b/utils/contentProcessing.ts
@@ -42,8 +42,9 @@ export const linkifyMentions = (text: string): string => {
  * Linkifies hashtags (#tag) in text content
  */
 export const linkifyHashtags = (text: string): string => {
-  const hashtagRegex = /#([a-zA-Z0-9]+)/g;
-  return text.replace(hashtagRegex, '[$&](https://peakd.com/trending/$1)');
+  // Only match hashtags that are NOT part of URLs (not preceded by /)
+  const hashtagRegex = /(^|[^\/\w])#([a-zA-Z0-9]+)/g;
+  return text.replace(hashtagRegex, '$1[#$2](https://peakd.com/trending/$2)');
 };
 
 /**


### PR DESCRIPTION
- Updated hashtag regex in Snap.tsx to avoid matching # preceded by /
- Updated hashtag regex in contentProcessing.ts to avoid matching # preceded by /
- Fixes issue where URLs like example.com/page#fn:4 had #fn:4 treated as hashtag
- Ensures hashtags only match at word boundaries, not within URLs