### PR TITLE
Fix/hashtag hyphen support

### DIFF
--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -227,8 +227,7 @@ const Snap: React.FC<SnapProps> = ({
     // Support hyphens within hashtags: #react-native, #covid-19, etc.
     // Pattern: #word(s) optionally followed by -word(s) (prevents starting/ending with -)
     return text.replace(/(^|[^\/\w])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/g, (match, prefix, hashtag) => {
-      const tag = hashtag;
-      return `${prefix}[#${hashtag}](hashtag://${tag})`;
+      return `${prefix}[#${hashtag}](hashtag://${hashtag})`;
     });
   }
   const colorScheme = useColorScheme() || 'light';

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -223,9 +223,10 @@ const Snap: React.FC<SnapProps> = ({
   }, [author, avatarUrl]);
   // Process hashtags in text, converting them to clickable markdown links
   function processHashtags(text: string): string {
-    return text.replace(/(#\w+)/g, (match, hashtag) => {
-      const tag = hashtag.replace('#', '');
-      return `[${hashtag}](hashtag://${tag})`;
+    // Only match hashtags that are NOT part of URLs (not preceded by /)
+    return text.replace(/(^|[^\/\w])#(\w+)/g, (match, prefix, hashtag) => {
+      const tag = hashtag;
+      return `${prefix}[#${hashtag}](hashtag://${tag})`;
     });
   }
   const colorScheme = useColorScheme() || 'light';

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -224,7 +224,9 @@ const Snap: React.FC<SnapProps> = ({
   // Process hashtags in text, converting them to clickable markdown links
   function processHashtags(text: string): string {
     // Only match hashtags that are NOT part of URLs (not preceded by /)
-    return text.replace(/(^|[^\/\w])#(\w+)/g, (match, prefix, hashtag) => {
+    // Support hyphens within hashtags: #react-native, #covid-19, etc.
+    // Pattern: #word(s) optionally followed by -word(s) (prevents starting/ending with -)
+    return text.replace(/(^|[^\/\w])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/g, (match, prefix, hashtag) => {
       const tag = hashtag;
       return `${prefix}[#${hashtag}](hashtag://${tag})`;
     });

--- a/app/screens/ConversationScreen.tsx
+++ b/app/screens/ConversationScreen.tsx
@@ -480,7 +480,9 @@ const ConversationScreenRefactored = () => {
 
   const linkifyHashtags = (text: string): string => {
     return text.replace(
-      /(^|[^\w/#])#(\w+)(?![a-z0-9\-\.])/gi,
+      // Support hyphens within hashtags: #react-native, #covid-19, etc.
+      // Pattern: #word(s) optionally followed by -word(s) (prevents starting/ending with -)
+      /(^|[^\w/#])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/gi,
       (match, pre, hashtag, offset, string) => {
         const beforeMatch = string.substring(0, offset);
         const afterMatch = string.substring(offset + match.length);

--- a/utils/contentProcessing.ts
+++ b/utils/contentProcessing.ts
@@ -40,10 +40,12 @@ export const linkifyMentions = (text: string): string => {
 
 /**
  * Linkifies hashtags (#tag) in text content
+ * Supports hyphens within hashtags: #react-native, #covid-19, etc.
  */
 export const linkifyHashtags = (text: string): string => {
   // Only match hashtags that are NOT part of URLs (not preceded by /)
-  const hashtagRegex = /(^|[^\/\w])#([a-zA-Z0-9]+)/g;
+  // Pattern: #word(s) optionally followed by -word(s) (prevents starting/ending with -)
+  const hashtagRegex = /(^|[^\/\w])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/g;
   return text.replace(hashtagRegex, '$1[#$2](https://peakd.com/trending/$2)');
 };
 

--- a/utils/contentProcessing.ts
+++ b/utils/contentProcessing.ts
@@ -42,8 +42,9 @@ export const linkifyMentions = (text: string): string => {
  * Linkifies hashtags (#tag) in text content
  */
 export const linkifyHashtags = (text: string): string => {
-  const hashtagRegex = /#([a-zA-Z0-9]+)/g;
-  return text.replace(hashtagRegex, '[$&](https://peakd.com/trending/$1)');
+  // Only match hashtags that are NOT part of URLs (not preceded by /)
+  const hashtagRegex = /(^|[^\/\w])#([a-zA-Z0-9]+)/g;
+  return text.replace(hashtagRegex, '$1[#$2](https://peakd.com/trending/$2)');
 };
 
 /**


### PR DESCRIPTION
- Updated hashtag regex patterns to support hyphens: #react-native, #covid-19
- Pattern: [a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)* prevents starting/ending with hyphens  
- Prevents double hyphens: #valid--invalid only captures 'valid'
- Maintains URL fragment protection from previous fix
- Fixes issue where #i-like-puppies only captured '#i' leaving '-like-puppies' as text

Updated files:
- app/components/Snap.tsx: processHashtags() function
- utils/contentProcessing.ts: linkifyHashtags() function  
- app/screens/ConversationScreen.tsx: linkifyHashtags() function"