### PR TITLE
feat: add compose preview functionality

### DIFF
--- a/app/components/Preview.tsx
+++ b/app/components/Preview.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Snap from './Snap';
+import { SnapData } from '../../hooks/useConversationData';
+
+interface PreviewProps {
+  visible: boolean;
+  onClose: () => void;
+  snapData: SnapData;
+  currentUsername?: string | null;
+  colors: {
+    background: string;
+    text: string;
+    inputBorder: string;
+  };
+}
+
+const Preview: React.FC<PreviewProps> = ({
+  visible,
+  onClose,
+  snapData,
+  currentUsername,
+  colors,
+}) => {
+  return (
+    <Modal
+      visible={visible}
+      animationType='slide'
+      presentationStyle='pageSheet'
+      onRequestClose={onClose}
+    >
+      <SafeAreaView
+        style={[
+          styles.container,
+          { backgroundColor: colors.background }
+        ]}
+      >
+        {/* Preview Header */}
+        <View
+          style={[
+            styles.header,
+            { borderBottomColor: colors.inputBorder }
+          ]}
+        >
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.headerButton}
+          >
+            <Text style={[styles.headerButtonText, { color: colors.text }]}>
+              Close
+            </Text>
+          </TouchableOpacity>
+
+          <Text style={[styles.headerTitle, { color: colors.text }]}>
+            Preview
+          </Text>
+
+          <View style={styles.headerButton} />
+        </View>
+
+        {/* Preview Content */}
+        <ScrollView
+          style={styles.content}
+          showsVerticalScrollIndicator={false}
+        >
+          <Snap
+            snap={snapData}
+            showAuthor={true}
+            onUserPress={() => {}}
+            onContentPress={() => {}}
+            onImagePress={() => {}}
+            onHashtagPress={() => {}}
+            currentUsername={currentUsername}
+          />
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  headerButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    minWidth: 80,
+    alignItems: 'center',
+  },
+  headerButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  content: {
+    flex: 1,
+    padding: 16,
+  },
+});
+
+export default Preview;

--- a/app/screens/ComposeScreen.tsx
+++ b/app/screens/ComposeScreen.tsx
@@ -31,7 +31,7 @@ import { useShare } from '../../context/ShareContext';
 import { useGifPicker } from '../../hooks/useGifPickerV2';
 import { GifPickerModal } from '../../components/GifPickerModalV2';
 import { SnapData } from '../../hooks/useConversationData';
-import Snap from '../components/Snap';
+import Preview from '../components/Preview';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
@@ -1162,58 +1162,17 @@ export default function ComposeScreen() {
       </Modal>
 
       {/* Preview Modal */}
-      <Modal
+      <Preview
         visible={previewVisible}
-        animationType='slide'
-        presentationStyle='pageSheet'
-        onRequestClose={() => setPreviewVisible(false)}
-      >
-        <SafeAreaView
-          style={[
-            { flex: 1 },
-            { backgroundColor: colors.background }
-          ]}
-        >
-          {/* Preview Header */}
-          <View
-            style={[
-              styles.header,
-              { borderBottomColor: colors.inputBorder }
-            ]}
-          >
-            <TouchableOpacity
-              onPress={() => setPreviewVisible(false)}
-              style={styles.headerButton}
-            >
-              <Text style={[styles.headerButtonText, { color: colors.text }]}>
-                Close
-              </Text>
-            </TouchableOpacity>
-
-            <Text style={[styles.headerTitle, { color: colors.text }]}>
-              Preview
-            </Text>
-
-            <View style={styles.headerButton} />
-          </View>
-
-          {/* Preview Content */}
-          <ScrollView
-            style={{ flex: 1, padding: 16 }}
-            showsVerticalScrollIndicator={false}
-          >
-            <Snap
-              snap={createPreviewSnapData()}
-              showAuthor={true}
-              onUserPress={() => {}}
-              onContentPress={() => {}}
-              onImagePress={() => {}}
-              onHashtagPress={() => {}}
-              currentUsername={currentUsername}
-            />
-          </ScrollView>
-        </SafeAreaView>
-      </Modal>
+        onClose={() => setPreviewVisible(false)}
+        snapData={createPreviewSnapData()}
+        currentUsername={currentUsername}
+        colors={{
+          background: colors.background,
+          text: colors.text,
+          inputBorder: colors.inputBorder,
+        }}
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
- Add preview button to markdown toolbar with eye icon
- Create preview modal that reuses Snap component
- Implement createPreviewSnapData() to generate mock SnapData
- Preview disabled when no content (text, images, or GIFs)
- Modal shows exactly how the snap will look when posted