### PR TITLE
feat: Remove negative symbol from vote count display

### DIFF
--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -906,7 +906,7 @@ const Snap: React.FC<SnapProps> = ({
             />
           )}
           <Text style={[styles.voteCount, { color: colors.text, fontSize: 14 }]}>
-            {Math.abs(voteCount)}
+            {typeof voteCount === 'number' ? Math.abs(voteCount) : '0'}
           </Text>
           
           <FontAwesome
@@ -1000,7 +1000,7 @@ const Snap: React.FC<SnapProps> = ({
             />
           )}
           <Text style={[styles.voteCount, { color: colors.text }]}>
-            {Math.abs(voteCount)}
+            {typeof voteCount === 'number' ? Math.abs(voteCount) : '0'}
           </Text>
           {onSpeechBubblePress ? (
             <Pressable


### PR DESCRIPTION
UX improvement to create a more positive user experience for new users.

Changes:
- Vote count now displays absolute value (Math.abs(voteCount))
- Negative votes like -5 now show as 5
- Positive votes remain unchanged (10 shows as 10)
- Reduces visual negativity from spam downvotes

Impact:
- New users see less intimidating vote counts
- Spam downvotes don't create scary minus symbols
- Still shows engagement level without negativity
- Payout calculations remain accurate (unchanged)

Example:
Before: -3 votes, /usr/bin/bash.02
After:   3 votes, /usr/bin/bash.02

Simple 2-line change with significant UX benefit.