### PR TITLE
Feature/android fullscreen fix

### DIFF
--- a/app/components/ThreeSpeakEmbed.android.tsx
+++ b/app/components/ThreeSpeakEmbed.android.tsx
@@ -273,9 +273,10 @@ const ThreeSpeakEmbed: React.FC<ThreeSpeakEmbedProps> = ({
                 ref={webViewRef}
                 source={{ uri: embedUrl }}
                 style={{ flex: 1, backgroundColor: themeIsDark ? '#000' : '#fff' }}
-                allowsFullscreenVideo
-                javaScriptEnabled
-                domStorageEnabled
+                allowsFullscreenVideo={true}
+                allowsInlineMediaPlayback={false}
+                javaScriptEnabled={true}
+                domStorageEnabled={true}
                 mixedContentMode="compatibility"
                 injectedJavaScript={injectedJavaScript}
                 mediaPlaybackRequiresUserAction={false}


### PR DESCRIPTION
Android 3Speak Video Fullscreen Support
Adds auto-fullscreen functionality for 3Speak videos on Android to match iOS behavior.

Changes:

Videos automatically enter fullscreen when played
Always show overlay after exiting fullscreen to allow re-entering
Fixes issue where video controls became inaccessible after exiting fullscreen early
Supports both play.3speak.tv/watch and embed URLs
Technical Details:

Added injected JavaScript to trigger fullscreen API on video play
Implemented fullscreen exit detection with overlay
Video dimension checks before requesting fullscreen to prevent sizing issues
Resolves user-reported issue where tapping videos on Android didn't go fullscreen and controls were lost after exiting fullscreen.