### PR TITLE
fix: Add safe area inset to ActionSheet cancel button

### DIFF
--- a/app/components/common/ActionSheet.tsx
+++ b/app/components/common/ActionSheet.tsx
@@ -64,7 +64,6 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 14,
     borderTopRightRadius: 14,
     borderWidth: 1,
-    paddingBottom: 10,
   },
   item: {
     paddingHorizontal: 16,


### PR DESCRIPTION
The Cancel button was hidden behind the device home indicator because the sheet lacked safe area bottom padding.

