### PR TITLE
fix: Make profile website link tappable (closes #204)

### DIFF
--- a/app/components/profile/InfoRow.tsx
+++ b/app/components/profile/InfoRow.tsx
@@ -28,7 +28,13 @@ export const InfoRow: React.FC<InfoRowProps> = ({
         <View style={styles.infoRow}>
             <FontAwesome name={icon} size={16} color={iconColor} />
             {onPress ? (
-                <TouchableOpacity onPress={onPress} accessibilityRole="link" accessibilityLabel={text}>
+                <TouchableOpacity
+                    onPress={onPress}
+                    accessibilityRole="link"
+                    accessibilityLabel={text}
+                    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    style={styles.linkTouchable}
+                >
                     <Text style={[styles.infoText, styles.linkText, { color: textColor }]}>{text}</Text>
                 </TouchableOpacity>
             ) : (
@@ -50,5 +56,9 @@ const styles = StyleSheet.create({
     },
     linkText: {
         textDecorationLine: 'underline',
+    },
+    linkTouchable: {
+        minHeight: 44,
+        justifyContent: 'center',
     },
 });

--- a/app/components/profile/InfoRow.tsx
+++ b/app/components/profile/InfoRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
 import { ComponentProps } from 'react';
 
@@ -10,6 +10,7 @@ interface InfoRowProps {
     text: string;
     iconColor: string;
     textColor: string;
+    onPress?: () => void;
 }
 
 /**
@@ -21,11 +22,18 @@ export const InfoRow: React.FC<InfoRowProps> = ({
     text,
     iconColor,
     textColor,
+    onPress,
 }) => {
     return (
         <View style={styles.infoRow}>
             <FontAwesome name={icon} size={16} color={iconColor} />
-            <Text style={[styles.infoText, { color: textColor }]}>{text}</Text>
+            {onPress ? (
+                <TouchableOpacity onPress={onPress} accessibilityRole="link" accessibilityLabel={text}>
+                    <Text style={[styles.infoText, styles.linkText, { color: textColor }]}>{text}</Text>
+                </TouchableOpacity>
+            ) : (
+                <Text style={[styles.infoText, { color: textColor }]}>{text}</Text>
+            )}
         </View>
     );
 };
@@ -39,5 +47,8 @@ const styles = StyleSheet.create({
     infoText: {
         marginLeft: 8,
         fontSize: 14,
+    },
+    linkText: {
+        textDecorationLine: 'underline',
     },
 });

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   useColorScheme,
   ScrollView,
+  Linking,
 } from 'react-native';
 import { FontAwesome, Ionicons } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
@@ -366,6 +367,12 @@ const ProfileScreen = () => {
                     text={profile.website}
                     iconColor={colors.icon}
                     textColor={colors.icon}
+                    onPress={() => {
+                      const url = profile.website!.startsWith('http')
+                        ? profile.website!
+                        : `https://${profile.website}`;
+                      Linking.openURL(url);
+                    }}
                   />
                 )}
               </View>

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -7,6 +7,7 @@ import {
   useColorScheme,
   ScrollView,
   Linking,
+  Alert,
 } from 'react-native';
 import { FontAwesome, Ionicons } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
@@ -367,11 +368,22 @@ const ProfileScreen = () => {
                     text={profile.website}
                     iconColor={colors.icon}
                     textColor={colors.icon}
-                    onPress={() => {
-                      const url = profile.website!.startsWith('http')
-                        ? profile.website!
-                        : `https://${profile.website}`;
-                      Linking.openURL(url);
+                    onPress={async (): Promise<void> => {
+                      const website = profile.website?.trim();
+                      if (!website) return;
+                      const url = /^https?:\/\//i.test(website)
+                        ? website
+                        : `https://${website}`;
+                      try {
+                        const supported = await Linking.canOpenURL(url);
+                        if (!supported) {
+                          Alert.alert('Invalid link', 'This website cannot be opened.');
+                          return;
+                        }
+                        await Linking.openURL(url);
+                      } catch (err: unknown) {
+                        Alert.alert('Link error', err instanceof Error ? err.message : 'Unable to open website');
+                      }
                     }}
                   />
                 )}


### PR DESCRIPTION
## Summary

- `InfoRow` gains an optional `onPress` prop — when provided, the text renders underlined inside a `TouchableOpacity` with `accessibilityRole="link"`; plain text when omitted (location row unchanged)
- `ProfileScreen` passes an `onPress` to the website `InfoRow` that calls `Linking.openURL()`, prepending `https://` when the stored value has no scheme

## Test plan

- [ ] Profile with a website set — link is underlined and tappable, opens in the browser
- [ ] Profile with `example.com` (no scheme) — app prepends `https://` before opening
- [ ] Location row is unchanged (not tappable)
- [ ] All 104 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Website URLs in user profiles are now tappable and open in the device browser.
  * Profile fields can be made interactive with improved touch targets and visible link styling (underline).
  * Improved accessibility for tappable profile items (link role and labels).
  * Graceful error handling with user-friendly alerts when a URL cannot be opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->