### PR TITLE
fix: Render hashtag:// links and sub/sup tags in post bodies

### DIFF
--- a/app/components/PostBody.tsx
+++ b/app/components/PostBody.tsx
@@ -445,6 +445,9 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
               }
 
               // Handle regular links
+              if (!href) {
+                return <Text key={node.key} style={{ color: colors.text }}>{children}</Text>;
+              }
               return (
                 <Text
                   key={node.key}

--- a/app/components/PostBody.tsx
+++ b/app/components/PostBody.tsx
@@ -281,14 +281,21 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
           }}
           renderersProps={{
             a: {
-              onPress: (_event: any, href: string) => {
-                if (href?.startsWith('hashtag://')) {
+              onPress: (_event: unknown, href?: string): void => {
+                if (!href) return;
+                if (href.startsWith('hashtag://')) {
                   const tag = href.replace('hashtag://', '');
-                  router.push(`/screens/DiscoveryScreen?hashtag=${tag}` as any);
-                } else if (href?.startsWith('profile://')) {
+                  router.push({
+                    pathname: '/screens/DiscoveryScreen',
+                    params: { hashtag: tag },
+                  });
+                } else if (href.startsWith('profile://')) {
                   const username = href.replace('profile://', '');
-                  router.push(`/screens/ProfileScreen?username=${username}` as any);
-                } else if (href) {
+                  router.push({
+                    pathname: '/screens/ProfileScreen',
+                    params: { username },
+                  });
+                } else {
                   Linking.openURL(href).catch(() => {});
                 }
               },
@@ -399,7 +406,10 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
                   <Text
                     key={node.key}
                     onPress={() =>
-                      router.push(`/screens/ProfileScreen?username=${username}` as any)
+                      router.push({
+                        pathname: '/screens/ProfileScreen',
+                        params: { username },
+                      })
                     }
                     style={{
                       color: colors.button,
@@ -420,7 +430,10 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
                   <Text
                     key={node.key}
                     onPress={() =>
-                      router.push(`/screens/DiscoveryScreen?hashtag=${tag}` as any)
+                      router.push({
+                        pathname: '/screens/DiscoveryScreen',
+                        params: { hashtag: tag },
+                      })
                     }
                     style={{ color: colors.button, fontWeight: 'bold' }}
                     accessibilityRole='link'

--- a/app/components/PostBody.tsx
+++ b/app/components/PostBody.tsx
@@ -241,6 +241,8 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
             br: { height: 16, marginBottom: 8 },
             div: { marginBottom: 8 },
             center: { textAlign: 'center', marginBottom: 16 },
+            sub: { fontSize: 12 },
+            sup: { fontSize: 12 },
             h1: {
               color: colors.text,
               fontSize: 24,
@@ -276,6 +278,21 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
             b: { fontWeight: 'bold' },
             em: { fontStyle: 'italic' },
             i: { fontStyle: 'italic' },
+          }}
+          renderersProps={{
+            a: {
+              onPress: (_event: any, href: string) => {
+                if (href?.startsWith('hashtag://')) {
+                  const tag = href.replace('hashtag://', '');
+                  router.push(`/screens/DiscoveryScreen?hashtag=${tag}` as any);
+                } else if (href?.startsWith('profile://')) {
+                  const username = href.replace('profile://', '');
+                  router.push(`/screens/ProfileScreen?username=${username}` as any);
+                } else if (href) {
+                  Linking.openURL(href).catch(() => {});
+                }
+              },
+            },
           }}
         />
       ) : (
@@ -396,11 +413,29 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
                 );
               }
 
+              // Handle hashtag:// deep links from Ecency and similar apps
+              if (href && href.startsWith('hashtag://')) {
+                const tag = href.replace('hashtag://', '');
+                return (
+                  <Text
+                    key={node.key}
+                    onPress={() =>
+                      router.push(`/screens/DiscoveryScreen?hashtag=${tag}` as any)
+                    }
+                    style={{ color: colors.button, fontWeight: 'bold' }}
+                    accessibilityRole='link'
+                    accessibilityLabel={`Browse #${tag}`}
+                  >
+                    {children}
+                  </Text>
+                );
+              }
+
               // Handle regular links
               return (
                 <Text
                   key={node.key}
-                  onPress={() => Linking.openURL(href)}
+                  onPress={() => Linking.openURL(href).catch(() => {})}
                   style={{
                     color: colors.button,
                     textDecorationLine: 'underline',

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -235,13 +235,17 @@ const Snap: React.FC<SnapProps> = ({
     // Support hyphens within hashtags: #react-native, #covid-19, etc.
     // Pattern: #word(s) optionally followed by -word(s) (prevents starting/ending with -)
     return text.replace(/(^|[^\/\w])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/g, (match, prefix, hashtag, offset, string) => {
-      // Skip if already inside a markdown link [#tag](...) — same guard as linkifyMentions
       const beforeMatch = string.substring(0, offset + prefix.length);
+      const afterMatch = string.substring(offset + match.length);
+      // Skip if already inside a markdown link [#tag](...)
       const openBrackets = (beforeMatch.match(/\[/g) || []).length;
       const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
-      if (openBrackets > closeBrackets) {
-        return match;
-      }
+      if (openBrackets > closeBrackets) return match;
+      // Skip if inside a raw HTML anchor <a ...>#tag</a>
+      const insideHtmlAnchor =
+        beforeMatch.lastIndexOf('<a') > beforeMatch.lastIndexOf('</a>') &&
+        afterMatch.includes('</a>');
+      if (insideHtmlAnchor) return match;
       return `${prefix}[#${hashtag}](hashtag://${hashtag})`;
     });
   }
@@ -589,8 +593,12 @@ const Snap: React.FC<SnapProps> = ({
 
   const markdownDisplayStyles = getMarkdownStyles(colors, isDark);
 
-  // Preprocess HTML tags out of the body so simple HTML (<br/>, <sub>, etc.)
-  // doesn't force the RenderHtml path with raw markdown text inside it.
+  // Determine HTML vs Markdown BEFORE preprocessing so sub/sup (e.g. CO<sub>2</sub>)
+  // still routes to RenderHtml. preprocessForMarkdown strips those tags, so checking
+  // containsHtml after preprocessing would miss them.
+  const bodyIsHtml = containsHtml(cleanTextBody);
+  // Preprocess simple HTML (<br/>, <sub>, <sup>, etc.) to markdown for the Markdown path.
+  // RenderHtml path still receives the original cleanTextBody via source={{ html: cleanTextBody }}.
   const finalRenderedBody = preprocessForMarkdown(cleanTextBody);
 
   return (
@@ -788,7 +796,6 @@ const Snap: React.FC<SnapProps> = ({
         {/* Body */}
         {cleanTextBody.length > 0 &&
           (() => {
-            const isHtml = containsHtml(finalRenderedBody);
             if (onContentPress) {
               return (
                 <Pressable
@@ -797,7 +804,7 @@ const Snap: React.FC<SnapProps> = ({
                   accessibilityRole='button'
                   accessibilityLabel='View conversation'
                 >
-                  {isHtml ? (
+                  {bodyIsHtml ? (
                     <RenderHtml
                       contentWidth={contentWidth}
                       source={{ html: cleanTextBody }}
@@ -811,6 +818,8 @@ const Snap: React.FC<SnapProps> = ({
                       tagsStyles={{
                         a: { color: colors.icon },
                         u: { textDecorationLine: 'underline' },
+                        sub: { fontSize: 12 },
+                        sup: { fontSize: 12 },
                         ...(isReply && { p: { marginBottom: 12, lineHeight: 20 } }),
                       }}
                       renderers={{
@@ -837,7 +846,7 @@ const Snap: React.FC<SnapProps> = ({
                 </Pressable>
               );
             } else {
-              return isHtml ? (
+              return bodyIsHtml ? (
                 <RenderHtml
                   contentWidth={contentWidth}
                   source={{ html: cleanTextBody }}
@@ -851,6 +860,8 @@ const Snap: React.FC<SnapProps> = ({
                   tagsStyles={{
                     a: { color: colors.icon },
                     u: { textDecorationLine: 'underline' },
+                    sub: { fontSize: 12 },
+                    sup: { fontSize: 12 },
                     ...(isReply && { p: { marginBottom: 12, lineHeight: 20 } }),
                   }}
                   renderers={{

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -474,12 +474,17 @@ const Snap: React.FC<SnapProps> = ({
   const spoilerData = convertSpoilerSyntax(textBody);
   textBody = spoilerData.processedText;
 
+  // Preserve the pre-linkified body for the HTML renderer path.
+  // RenderHtml only understands HTML — passing markdown syntax (profile://, hashtag://)
+  // would show as raw text. The linkified version is only for the Markdown path.
+  const htmlBody = textBody;
+
   // Add: linkify URLs first, then mentions, then hashtags (order matters!)
-  textBody = linkifyUrls(textBody);
-  textBody = linkifyMentions(textBody);
-  textBody = processHashtags(textBody);
-  // Remove extraction of external links
-  const cleanTextBody = textBody; // Just use the processed textBody
+  let markdownBody = textBody;
+  markdownBody = linkifyUrls(markdownBody);
+  markdownBody = linkifyMentions(markdownBody);
+  markdownBody = processHashtags(markdownBody);
+  const cleanTextBody = markdownBody;
   const [modalVisible, setModalVisible] = useState(false);
   const [modalImageUrl, setModalImageUrl] = useState<string | null>(null);
 
@@ -593,13 +598,11 @@ const Snap: React.FC<SnapProps> = ({
 
   const markdownDisplayStyles = getMarkdownStyles(colors, isDark);
 
-  // Determine HTML vs Markdown BEFORE preprocessing so sub/sup (e.g. CO<sub>2</sub>)
-  // still routes to RenderHtml. preprocessForMarkdown strips those tags, so checking
-  // containsHtml after preprocessing would miss them.
-  const bodyIsHtml = containsHtml(cleanTextBody);
-  // Preprocess simple HTML (<br/>, <sub>, <sup>, etc.) to markdown for the Markdown path.
-  // RenderHtml path still receives the original cleanTextBody via source={{ html: cleanTextBody }}.
-  const finalRenderedBody = preprocessForMarkdown(cleanTextBody);
+  // Route based on the original body (before linkification) so HTML tags like
+  // <sub>/<sup> are still detectable, and the HTML renderer gets clean HTML (not markdown).
+  const bodyIsHtml = containsHtml(htmlBody);
+  // Markdown path: preprocess simple HTML tags out of the linkified body.
+  const finalRenderedBody = preprocessForMarkdown(markdownBody);
 
   return (
     <View
@@ -807,7 +810,7 @@ const Snap: React.FC<SnapProps> = ({
                   {bodyIsHtml ? (
                     <RenderHtml
                       contentWidth={contentWidth}
-                      source={{ html: cleanTextBody }}
+                      source={{ html: htmlBody }}
                       baseStyle={{
                         color: colors.text,
                         fontSize: isReply ? 14 : 15,
@@ -849,7 +852,7 @@ const Snap: React.FC<SnapProps> = ({
               return bodyIsHtml ? (
                 <RenderHtml
                   contentWidth={contentWidth}
-                  source={{ html: cleanTextBody }}
+                  source={{ html: htmlBody }}
                   baseStyle={{
                     color: colors.text,
                     fontSize: isReply ? 14 : 15,

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -51,6 +51,7 @@ import { useAppColors } from '../styles/colors';
 import { submitReport, mapUiReasonToApi } from '../../services/reportService';
 import { SnapData } from '../../hooks/useConversationData';
 import { wasPostedViaHiveSnaps } from '../../utils/appDetection';
+import { preprocessForMarkdown } from '../../utils/htmlPreprocessing';
 
 interface SnapProps {
   snap: SnapData;
@@ -233,7 +234,14 @@ const Snap: React.FC<SnapProps> = ({
     // Only match hashtags that are NOT part of URLs (not preceded by /)
     // Support hyphens within hashtags: #react-native, #covid-19, etc.
     // Pattern: #word(s) optionally followed by -word(s) (prevents starting/ending with -)
-    return text.replace(/(^|[^\/\w])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/g, (match, prefix, hashtag) => {
+    return text.replace(/(^|[^\/\w])#([a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/g, (match, prefix, hashtag, offset, string) => {
+      // Skip if already inside a markdown link [#tag](...) — same guard as linkifyMentions
+      const beforeMatch = string.substring(0, offset + prefix.length);
+      const openBrackets = (beforeMatch.match(/\[/g) || []).length;
+      const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
+      if (openBrackets > closeBrackets) {
+        return match;
+      }
       return `${prefix}[#${hashtag}](hashtag://${hashtag})`;
     });
   }
@@ -581,8 +589,9 @@ const Snap: React.FC<SnapProps> = ({
 
   const markdownDisplayStyles = getMarkdownStyles(colors, isDark);
 
-  // Where cleanTextBody is derived before rendering Markdown/HTML
-  const finalRenderedBody = cleanTextBody;
+  // Preprocess HTML tags out of the body so simple HTML (<br/>, <sub>, etc.)
+  // doesn't force the RenderHtml path with raw markdown text inside it.
+  const finalRenderedBody = preprocessForMarkdown(cleanTextBody);
 
   return (
     <View
@@ -779,7 +788,7 @@ const Snap: React.FC<SnapProps> = ({
         {/* Body */}
         {cleanTextBody.length > 0 &&
           (() => {
-            const isHtml = containsHtml(cleanTextBody);
+            const isHtml = containsHtml(finalRenderedBody);
             if (onContentPress) {
               return (
                 <Pressable

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -52,6 +52,7 @@ import { submitReport, mapUiReasonToApi } from '../../services/reportService';
 import { SnapData } from '../../hooks/useConversationData';
 import { wasPostedViaHiveSnaps } from '../../utils/appDetection';
 import { preprocessForMarkdown } from '../../utils/htmlPreprocessing';
+import { renderHiveToHtml } from '../../utils/renderHive';
 
 interface SnapProps {
   snap: SnapData;
@@ -601,6 +602,18 @@ const Snap: React.FC<SnapProps> = ({
   // Route based on the original body (before linkification) so HTML tags like
   // <sub>/<sup> are still detectable, and the HTML renderer gets clean HTML (not markdown).
   const bodyIsHtml = containsHtml(htmlBody);
+  // When body has HTML, run it through Ecency's renderPostBody so that mixed
+  // HTML+Markdown (e.g. <sub>[link text](url)</sub>) gets converted to proper HTML
+  // before passing to RenderHtml. Falls back to raw htmlBody if processing fails.
+  const processedHtmlBody = useMemo(() => {
+    if (!bodyIsHtml) return htmlBody;
+    try {
+      const result = renderHiveToHtml(htmlBody, { breaks: true, proxifyImages: false });
+      return result && result.trim().length > 0 ? result : htmlBody;
+    } catch {
+      return htmlBody;
+    }
+  }, [bodyIsHtml, htmlBody]);
   // Markdown path: preprocess simple HTML tags out of the linkified body.
   const finalRenderedBody = preprocessForMarkdown(markdownBody);
 
@@ -810,7 +823,7 @@ const Snap: React.FC<SnapProps> = ({
                   {bodyIsHtml ? (
                     <RenderHtml
                       contentWidth={contentWidth}
-                      source={{ html: htmlBody }}
+                      source={{ html: processedHtmlBody }}
                       baseStyle={{
                         color: colors.text,
                         fontSize: isReply ? 14 : 15,
@@ -824,6 +837,30 @@ const Snap: React.FC<SnapProps> = ({
                         sub: { fontSize: 12 },
                         sup: { fontSize: 12 },
                         ...(isReply && { p: { marginBottom: 12, lineHeight: 20 } }),
+                      }}
+                      renderersProps={{
+                        a: {
+                          onPress: (_event: unknown, href?: string): void => {
+                            if (!href) return;
+                            if (href.startsWith('hashtag://')) {
+                              const tag = href.replace('hashtag://', '');
+                              if (isReply) {
+                                router.push({ pathname: '/screens/DiscoveryScreen', params: { hashtag: tag } } as any);
+                              } else {
+                                onHashtagPress && onHashtagPress(tag);
+                              }
+                            } else if (href.startsWith('profile://')) {
+                              const username = href.replace('profile://', '');
+                              if (isReply) {
+                                router.push(`/screens/ProfileScreen?username=${username}` as any);
+                              } else {
+                                onUserPress && onUserPress(username);
+                              }
+                            } else {
+                              Linking.openURL(href).catch(() => {});
+                            }
+                          },
+                        },
                       }}
                       renderers={{
                         video: (props: any) => {

--- a/utils/htmlPreprocessing.ts
+++ b/utils/htmlPreprocessing.ts
@@ -26,6 +26,9 @@ export const preprocessForMarkdown = (content: string): string => {
       .replace(/<center[^>]*>(.*?)<\/center>/gs, '$1\n\n')
       .replace(/<center[^>]*>/g, '') // Remove opening center tags without closing
       .replace(/<\/center>/g, '\n\n') // Replace closing center tags with newlines
+      // Handle sub/sup tags - remove wrapper, keep content
+      .replace(/<sub[^>]*>(.*?)<\/sub>/gs, '$1')
+      .replace(/<sup[^>]*>(.*?)<\/sup>/gs, '$1')
       // Convert HTML tags to markdown equivalents
       .replace(/<u[^>]*>(.*?)<\/u>/gs, '___$1___') // Convert <u> tags to markdown underlines
       .replace(/<strong[^>]*>(.*?)<\/strong>/gs, '**$1**') // Convert <strong> tags to markdown bold
@@ -84,6 +87,8 @@ export const HTML_TAGS_TO_CHECK = [
   '<p',
   '<span',
   '<br',
+  '<sub',
+  '<sup',
   '<h1',
   '<h2',
   '<h3',

--- a/utils/htmlPreprocessing.ts
+++ b/utils/htmlPreprocessing.ts
@@ -27,8 +27,8 @@ export const preprocessForMarkdown = (content: string): string => {
       .replace(/<center[^>]*>/g, '') // Remove opening center tags without closing
       .replace(/<\/center>/g, '\n\n') // Replace closing center tags with newlines
       // Handle sub/sup tags - remove wrapper, keep content
-      .replace(/<sub[^>]*>(.*?)<\/sub>/gs, '$1')
-      .replace(/<sup[^>]*>(.*?)<\/sup>/gs, '$1')
+      .replace(/<sub[^>]*>(.*?)<\/sub>/gis, '$1')
+      .replace(/<sup[^>]*>(.*?)<\/sup>/gis, '$1')
       // Convert HTML tags to markdown equivalents
       .replace(/<u[^>]*>(.*?)<\/u>/gs, '___$1___') // Convert <u> tags to markdown underlines
       .replace(/<strong[^>]*>(.*?)<\/strong>/gs, '**$1**') // Convert <strong> tags to markdown bold

--- a/utils/renderHive.ts
+++ b/utils/renderHive.ts
@@ -30,5 +30,25 @@ export function renderHiveToHtml(
     html = renderPostBody(raw || '', false, false);
   }
 
-  return typeof html === 'string' ? html : String(html ?? '');
+  const result = typeof html === 'string' ? html : String(html ?? '');
+  return sanitizeEcencyHtml(result);
+}
+
+/**
+ * Ecency's renderPostBody (forApp=true) stores URLs in data-href instead of href,
+ * and mangles non-http schemes by prepending "https://" (e.g. hashtag://hive →
+ * https://hashtag://hive). Fix both so react-native-render-html can handle links.
+ */
+function sanitizeEcencyHtml(html: string): string {
+  return (
+    html
+      // data-href="https://hashtag://tag" → href="hashtag://tag"
+      .replace(/data-href="https?:\/\/(hashtag:\/\/[^"]+)"/gi, 'href="$1"')
+      // data-href="https://profile://user" → href="profile://user"
+      .replace(/data-href="https?:\/\/(profile:\/\/[^"]+)"/gi, 'href="$1"')
+      // data-href="https://..." → href="https://..."
+      .replace(/data-href="(https?:\/\/[^"]+)"/gi, 'href="$1"')
+      // Any remaining data-href → href (catch-all)
+      .replace(/data-href="([^"]*)"/gi, 'href="$1"')
+  );
 }


### PR DESCRIPTION
## Summary

Fixes the rendering issues documented in `internal-docs/POST_BODY_HASHTAG_AND_MARKDOWN_RENDERING.md`.

**`hashtag://` deep links** (Phase 2 of the doc)
- **Markdown path** — new `hashtag://` case in the `link` rule; tapping navigates to `DiscoveryScreen?hashtag=<tag>` instead of passing the unroutable scheme to `Linking`
- **HTML path** — `renderersProps.a.onPress` added to `SafeRenderHtml` to intercept `hashtag://` (and `profile://`) before they reach `Linking`. Regular `https://` links fall through to `Linking.openURL` as before

**`<sub>` / `<sup>` tags** (Phase 1)
- `preprocessForMarkdown` now strips `<sub>`/`<sup>` wrapper tags while keeping inner content, so the Markdown renderer sees clean text/links rather than raw HTML
- `SafeRenderHtml` gets `sub`/`sup` entries in `tagsStyles` (font-size: 12) for the HTML path

**Unhandled rejection hardening**
- `Linking.openURL` calls now have `.catch(() => {})` — consistent with the rest of the codebase

## Test plan

- [ ] Post with `[#hive](hashtag://hive)` — tapping `#hive` navigates to the Hive tag feed
- [ ] Post with `<sub>[via Apps from](https://linktr.ee/...)</sub>` — link renders and taps open browser; no raw `<sub>` visible
- [ ] Regular `[text](https://...)` links still open in browser
- [ ] `@mention` links still navigate to ProfileScreen
- [ ] All 104 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hashtag links now open the hashtag discovery screen; profile links open the corresponding profile.
  * Subscript and superscript content render with improved sizing and consistent display.

* **Bug Fixes**
  * Custom-scheme and external links open reliably; link-opening errors are suppressed to avoid user-facing failures.
  * Markdown & HTML link handling improved to avoid duplicate navigation and to render links missing href as plain text.
  * Imported/converted link attributes are better sanitized for correct navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->