### PR TITLE
feat: Use stored active key for avatar updates

### DIFF
--- a/app/components/profile/ActiveKeyModal.tsx
+++ b/app/components/profile/ActiveKeyModal.tsx
@@ -67,8 +67,9 @@ export const ActiveKeyModal: React.FC<ActiveKeyModalProps> = ({
                                 </Text>
                             </View>
                             <Text style={[styles.securityText, { color: colors.text }]}>
-                                To change your avatar, your active key is needed. This will be used to sign the
-                                transaction only. It will not be stored on this phone for security reasons.
+                                Your active key is needed to sign this transaction. It will not be saved from
+                                this screen. To avoid re-entering it, you can store it securely via
+                                Profile → Add Active Key.
                             </Text>
                         </View>
 

--- a/hooks/useAvatarManagement.ts
+++ b/hooks/useAvatarManagement.ts
@@ -216,10 +216,15 @@ export const useAvatarManagement = (currentUsername: string | null) => {
     }
   };
 
+  const openManualKeyEntry = (): void => {
+    setEditAvatarModalVisible(false);
+    setActiveKeyModalVisible(true);
+  };
+
   const handleNextStep = async (): Promise<void> => {
     if (!currentUsername) {
       setEditAvatarModalVisible(false);
-      setActiveKeyModalVisible(true);
+      Alert.alert('Session Required', 'Please sign in again to update your avatar.');
       return;
     }
     try {
@@ -237,14 +242,12 @@ export const useAvatarManagement = (currentUsername: string | null) => {
         }
       } else {
         // No stored key — fall through to manual entry
-        setEditAvatarModalVisible(false);
-        setActiveKeyModalVisible(true);
+        openManualKeyEntry();
       }
     } catch (err) {
       if (err instanceof AuthCancelledError) return;
       // On any other error (e.g. storage read failure), fall through to manual entry
-      setEditAvatarModalVisible(false);
-      setActiveKeyModalVisible(true);
+      openManualKeyEntry();
     }
   };
 

--- a/hooks/useAvatarManagement.ts
+++ b/hooks/useAvatarManagement.ts
@@ -229,13 +229,14 @@ export const useAvatarManagement = (currentUsername: string | null) => {
     }
     try {
       const keys = await accountStorageService.getAccountKeys(currentUsername);
-      if (keys?.activeKey) {
+      const storedActiveKey = keys?.activeKey?.trim();
+      if (storedActiveKey) {
         // Stored key available — gate behind biometrics then update directly
         if (await localAuthService.isAvailable()) {
           await localAuthService.authenticate('Confirm avatar update');
         }
         try {
-          await handleUpdateAvatar(keys.activeKey);
+          await handleUpdateAvatar(storedActiveKey);
         } catch (err) {
           const msg = err instanceof Error ? err.message : 'Failed to update avatar';
           Alert.alert('Update Failed', msg);

--- a/hooks/useAvatarManagement.ts
+++ b/hooks/useAvatarManagement.ts
@@ -10,6 +10,8 @@ import { avatarService } from '../services/AvatarService';
 import { saveAvatarImage } from '../utils/avatarUtils';
 import { useAppStore } from '../store/context';
 import { convertImageSmart } from '../utils/imageConverter';
+import { accountStorageService } from '../services/AccountStorageService';
+import { localAuthService, AuthCancelledError } from '../services/LocalAuthService';
 
 const client = getClient();
 
@@ -214,14 +216,41 @@ export const useAvatarManagement = (currentUsername: string | null) => {
     }
   };
 
-  const handleNextStep = () => {
-    // Move to active key input modal
-    setEditAvatarModalVisible(false);
-    setActiveKeyModalVisible(true);
+  const handleNextStep = async (): Promise<void> => {
+    if (!currentUsername) {
+      setEditAvatarModalVisible(false);
+      setActiveKeyModalVisible(true);
+      return;
+    }
+    try {
+      const keys = await accountStorageService.getAccountKeys(currentUsername);
+      if (keys?.activeKey) {
+        // Stored key available — gate behind biometrics then update directly
+        if (await localAuthService.isAvailable()) {
+          await localAuthService.authenticate('Confirm avatar update');
+        }
+        try {
+          await handleUpdateAvatar(keys.activeKey);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : 'Failed to update avatar';
+          Alert.alert('Update Failed', msg);
+        }
+      } else {
+        // No stored key — fall through to manual entry
+        setEditAvatarModalVisible(false);
+        setActiveKeyModalVisible(true);
+      }
+    } catch (err) {
+      if (err instanceof AuthCancelledError) return;
+      // On any other error (e.g. storage read failure), fall through to manual entry
+      setEditAvatarModalVisible(false);
+      setActiveKeyModalVisible(true);
+    }
   };
 
-  const handleUpdateAvatar = async () => {
-    if (!newAvatarImage || !currentUsername || !activeKeyInput.trim()) return;
+  const handleUpdateAvatar = async (activeKeyOverride?: string): Promise<void> => {
+    const keyStr = (activeKeyOverride ?? activeKeyInput).trim();
+    if (!newAvatarImage || !currentUsername || !keyStr) return;
 
     setAvatarUpdateLoading(true);
     setAvatarUpdateSuccess(false);
@@ -230,7 +259,6 @@ export const useAvatarManagement = (currentUsername: string | null) => {
       // Validate and create active key
       let activeKey;
       try {
-        const keyStr = activeKeyInput.trim();
         // Basic validation: should start with 5 and be roughly the right length
         if (!keyStr.startsWith('5') || keyStr.length < 50) {
           throw new Error('Invalid key format');


### PR DESCRIPTION
## Summary

- When a user has stored their active key via `AddActiveKeyScreen`, avatar updates now skip the manual key entry modal — a biometric/PIN prompt is shown instead and the update proceeds directly
- Falls back to the existing `ActiveKeyModal` (manual entry) only when no key is stored in `AccountStorageService`
- Updates the `ActiveKeyModal` security notice to reflect that keys can be stored securely via Profile settings

## Changes

- `hooks/useAvatarManagement.ts` — `handleNextStep` is now async; checks `AccountStorageService` for a stored active key before deciding which path to take
- `app/components/profile/ActiveKeyModal.tsx` — security notice updated (old text claimed the key is never stored anywhere, which is no longer accurate)

## Test plan

- [ ] User with stored active key: tap "Next" in edit avatar modal → biometric prompt → update proceeds in edit modal (no manual key modal shown)
- [ ] User without stored active key: existing manual entry flow unchanged
- [ ] User cancels biometric prompt: update aborts silently, modals stay in current state
- [ ] Biometric unavailable (emulator): stored key used directly, no biometric prompt
- [ ] Error during `handleUpdateAvatar` in stored key path: `Alert` shown with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Biometric authentication can now retrieve and use stored keys to update avatars automatically.
  * Security notice updated with clearer guidance on storing an active key securely.

* **Improvements**
  * Better error handling during avatar updates with user alerts on failures.
  * Streamlined flow: falls back to manual key entry when automatic retrieval or biometric confirmation isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->