### PR TITLE
security: Proxy user-content images to prevent tracking pixel attacks

### DIFF
--- a/app/components/PostBody.tsx
+++ b/app/components/PostBody.tsx
@@ -5,6 +5,7 @@ import SafeRenderHtml from '../../components/SafeRenderHtml';
 import { useRouter } from 'expo-router';
 import { Image as ExpoImage } from 'expo-image';
 import { renderHiveToHtml } from '../../utils/renderHive';
+import { proxyImageUrl } from '../../utils/proxyImageUrl';
 import {
   extractVideoInfo,
   removeVideoUrls,
@@ -40,7 +41,7 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
   // Use Ecency's renderHiveToHtml to process the content
   const processedHtml = useMemo(() => {
     try {
-      return renderHiveToHtml(body, { breaks: true, proxifyImages: false });
+      return renderHiveToHtml(body, { breaks: true, proxifyImages: true });
     } catch (error) {
       console.warn('[PostBody] Error processing HTML:', error);
       return body; // Fallback to original body
@@ -185,7 +186,7 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
               return (
                 <ExpoImage
                   key={src}
-                  source={{ uri: src }}
+                  source={{ uri: proxyImageUrl(src) }}
                   style={{
                     width: '100%',
                     height: 220,
@@ -381,7 +382,7 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
               return (
                 <ExpoImage
                   key={src}
-                  source={{ uri: src }}
+                  source={{ uri: proxyImageUrl(src) }}
                   style={{
                     width: '100%',
                     height: 220,

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -43,6 +43,7 @@ import { canBeResnapped } from '../../utils/postTypeDetector';
 import { getMarkdownStyles } from '../../styles/markdownStyles';
 import { linkStyles, useLinkTextStyle } from '../../styles/linkStyles';
 import { extractRawImageUrls as extractRawImageUrlsUtil, removeRawImageUrls as removeRawImageUrlsUtil } from '../../utils/rawImageUrls';
+import { proxyImageUrl } from '../../utils/proxyImageUrl';
 import ModerationRequestModal, { ModerationReason, ModerationRequestPayload } from './moderation/ModerationRequestModal';
 import { formatRelativeShort } from '../../utils/time';
 import ActionSheet from './common/ActionSheet';
@@ -298,7 +299,7 @@ const Snap: React.FC<SnapProps> = ({
           }}
         >
           <ExpoImage
-            source={{ uri: src }}
+            source={{ uri: proxyImageUrl(src) }}
             style={styles.markdownImage}
             contentFit='cover'
             accessibilityLabel={alt || 'image'}
@@ -608,7 +609,7 @@ const Snap: React.FC<SnapProps> = ({
   const processedHtmlBody = useMemo(() => {
     if (!bodyIsHtml) return htmlBody;
     try {
-      const result = renderHiveToHtml(htmlBody, { breaks: true, proxifyImages: false });
+      const result = renderHiveToHtml(htmlBody, { breaks: true, proxifyImages: true });
       return result && result.trim().length > 0 ? result : htmlBody;
     } catch {
       return htmlBody;
@@ -761,15 +762,15 @@ const Snap: React.FC<SnapProps> = ({
                 key={url + idx}
                 onPress={() => {
                   if (onImagePress) {
-                    onImagePress(url);
+                    onImagePress(proxyImageUrl(url));
                   } else {
-                    setModalImageUrl(url);
+                    setModalImageUrl(proxyImageUrl(url));
                     setModalVisible(true);
                   }
                 }}
               >
                 <ExpoImage
-                  source={{ uri: url }}
+                  source={{ uri: proxyImageUrl(url) }}
                   style={styles.feedImage}
                   contentFit='cover'
                 />
@@ -785,15 +786,15 @@ const Snap: React.FC<SnapProps> = ({
                 key={url + idx}
                 onPress={() => {
                   if (onImagePress) {
-                    onImagePress(url);
+                    onImagePress(proxyImageUrl(url));
                   } else {
-                    setModalImageUrl(url);
+                    setModalImageUrl(proxyImageUrl(url));
                     setModalVisible(true);
                   }
                 }}
               >
                 <ExpoImage
-                  source={{ uri: url }}
+                  source={{ uri: proxyImageUrl(url) }}
                   style={styles.feedImage}
                   contentFit='cover'
                 />

--- a/utils/proxyImageUrl.ts
+++ b/utils/proxyImageUrl.ts
@@ -18,6 +18,8 @@ export function proxyImageUrl(url: string): string {
     if (!url) return url;
     // Don't proxy data URIs (inline images)
     if (url.startsWith('data:')) return url;
+    // Only proxy HTTP(S) URLs — pass through file://, protocol-relative, etc. unchanged
+    if (!url.startsWith('http://') && !url.startsWith('https://')) return url;
     // Already proxied — don't double-wrap
     if (PROXY_PREFIXES.some((p) => url.startsWith(p))) return url;
     return `${HIVE_IMAGE_PROXY}${url}`;

--- a/utils/proxyImageUrl.ts
+++ b/utils/proxyImageUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * Route external image URLs through the Hive image proxy.
+ *
+ * This prevents the device from making direct HTTP requests to arbitrary
+ * third-party servers embedded in snap content, which would expose the user's
+ * IP address and device info (tracking pixel attack).
+ *
+ * Format: https://images.hive.blog/0x0/{originalUrl}
+ * "0x0" means return the image at its original dimensions.
+ */
+const HIVE_IMAGE_PROXY = 'https://images.hive.blog/0x0/';
+const PROXY_PREFIXES = [
+    'https://images.hive.blog/',
+    'https://images.ecency.com/',
+];
+
+export function proxyImageUrl(url: string): string {
+    if (!url) return url;
+    // Don't proxy data URIs (inline images)
+    if (url.startsWith('data:')) return url;
+    // Already proxied — don't double-wrap
+    if (PROXY_PREFIXES.some((p) => url.startsWith(p))) return url;
+    return `${HIVE_IMAGE_PROXY}${url}`;
+}

--- a/utils/proxyImageUrl.ts
+++ b/utils/proxyImageUrl.ts
@@ -18,9 +18,17 @@ export function proxyImageUrl(url: string): string {
     if (!url) return url;
     // Don't proxy data URIs (inline images)
     if (url.startsWith('data:')) return url;
-    // Only proxy HTTP(S) URLs — pass through file://, protocol-relative, etc. unchanged
-    if (!url.startsWith('http://') && !url.startsWith('https://')) return url;
-    // Already proxied — don't double-wrap
-    if (PROXY_PREFIXES.some((p) => url.startsWith(p))) return url;
-    return `${HIVE_IMAGE_PROXY}${url}`;
+    // Parse the URL so scheme normalization is handled by the runtime (case-insensitive).
+    // Malformed URLs (relative paths, protocol-relative, etc.) throw and are returned as-is.
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return url;
+    }
+    // Only proxy HTTP(S) — file://, javascript:, blob:, etc. pass through unchanged
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return url;
+    // Already proxied — don't double-wrap (compare against normalised href)
+    if (PROXY_PREFIXES.some((p) => parsed.href.startsWith(p))) return parsed.href;
+    return `${HIVE_IMAGE_PROXY}${parsed.href}`;
 }


### PR DESCRIPTION
## Summary

- Introduces `utils/proxyImageUrl.ts` — routes all external image URLs from snap content through `https://images.hive.blog/0x0/{url}` so the user's device never makes direct requests to arbitrary third-party servers
- Applied to every `ExpoImage` source that originates from user content in `Snap.tsx` and `PostBody.tsx`
- Enabled `proxifyImages: true` on all `renderHiveToHtml` calls (was `false`) so the HTML rendering path also proxies via Ecency CDN

## Attack vector

An attacker posts a snap with a markdown image tag pointing to a tracking server:
```
![alt](https://tracker.attacker.com/pixel)
```
When the app renders the snap, `ExpoImage` makes a direct HTTP request to that URL. The attacker's server logs the viewer's **IP address**, **user-agent**, and device info — no interaction required beyond simply scrolling past the snap.

This is a known tracking pixel attack used in the wild on Hive (confirmed via a real incident on `peak.snaps`).

## Fix

All image URLs from user content are now routed through the Hive image proxy before being passed to `ExpoImage`:
```ts
// utils/proxyImageUrl.ts
https://images.hive.blog/0x0/{originalUrl}
```
The proxy fetches the image server-side. The user's device only ever connects to `images.hive.blog` — the tracker never sees the viewer's IP.

`data:` URIs and already-proxied URLs are passed through unchanged to avoid double-wrapping.

## Test plan

- [ ] Images in snaps still render correctly (GIFs, JPEGs, PNGs)
- [ ] Tapping an image opens the full-screen modal with the proxied URL
- [ ] A snap containing a non-image tracking URL (no image extension, no `image` in path) does not make a direct outbound request to that URL
- [ ] `proxyImageUrl('data:image/png;base64,...')` returns the data URI unchanged
- [ ] `proxyImageUrl('https://images.hive.blog/0x0/...')` is not double-wrapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * All images displayed in posts and snap content are now served via the Hive image proxy for consistent delivery.
  * Rendered HTML/Markdown images are proxied to ensure uniform URL handling.
  * Image interactions (tap/open modals) consistently use proxied URLs to avoid mixing raw and proxied sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->