### PR TITLE
fix: Prevent double-linkification of mentions and markdown links

### DIFF
--- a/app/components/PostBody.tsx
+++ b/app/components/PostBody.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'expo-router';
 import { Image as ExpoImage } from 'expo-image';
 import { renderHiveToHtml } from '../../utils/renderHive';
 import { proxyImageUrl } from '../../utils/proxyImageUrl';
+import { linkifyMentions } from '../../utils/linkifyMentions';
 import {
   extractVideoInfo,
   removeVideoUrls,
@@ -203,7 +204,7 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
             },
           }}
         >
-          {preprocessForMarkdown(body)}
+          {preprocessForMarkdown(linkifyMentions(body))}
         </Markdown>
       </View>
     );
@@ -466,7 +467,7 @@ const PostBody: React.FC<PostBodyProps> = ({ body, colors, isDark }) => {
             },
           }}
         >
-          {preprocessForMarkdown(contentToRender)}
+          {preprocessForMarkdown(linkifyMentions(contentToRender))}
         </Markdown>
       )}
     </View>

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -38,7 +38,6 @@ import AudioEmbed from './AudioEmbed';
 import InstagramEmbed from './InstagramEmbed';
 import { extractBlogPostUrls } from '../../utils/extractHivePostInfo';
 import { OptimizedHivePostPreviewRenderer } from '../../components/OptimizedHivePostPreviewRenderer';
-import { classifyUrl } from '../../utils/urlClassifier';
 import { canBeResnapped } from '../../utils/postTypeDetector';
 import { getMarkdownStyles } from '../../styles/markdownStyles';
 import { linkStyles, useLinkTextStyle } from '../../styles/linkStyles';
@@ -54,6 +53,8 @@ import { SnapData } from '../../hooks/useConversationData';
 import { wasPostedViaHiveSnaps } from '../../utils/appDetection';
 import { preprocessForMarkdown } from '../../utils/htmlPreprocessing';
 import { renderHiveToHtml } from '../../utils/renderHive';
+import { linkifyMentions } from '../../utils/linkifyMentions';
+import { linkifyUrls } from '../../utils/linkifyUrls';
 
 interface SnapProps {
   snap: SnapData;
@@ -99,55 +100,7 @@ function containsHtml(str: string): boolean {
   return /<([a-z][\s\S]*?)>/i.test(str);
 }
 
-// Utility: Preprocess @username mentions to clickable profile links
-function linkifyMentions(text: string): string {
-  // Only match @username if not preceded by a '/' or inside a markdown link
-  // Negative lookbehind for '/': (?<!/)
-  // Hive usernames: 3-16 chars, a-z, 0-9, dash, dot (no @ in username)
-  // Avoid emails and already-linked mentions
-  return text.replace(
-    /(^|[^\w/@])@([a-z0-9\-\.]{3,16})(?![a-z0-9\-\.])/gi,
-    (match, pre, username, offset, string) => {
-      // Don't process if we're inside a markdown link [text](url)
-      const beforeMatch = string.substring(0, offset);
-      const afterMatch = string.substring(offset + match.length);
 
-      const openBrackets = (beforeMatch.match(/\[/g) || []).length;
-      const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
-      const isInsideMarkdownLink =
-        openBrackets > closeBrackets && afterMatch.includes('](');
-
-      if (isInsideMarkdownLink) {
-        return match; // Don't modify if inside a markdown link
-      }
-
-      // Return non-bold markdown link; bold is applied via linkStyles.mention
-      return `${pre}[@${username}](profile://${username})`;
-    }
-  );
-}
-
-// Utility: Preprocess raw URLs to clickable markdown links (if not already linked)
-function linkifyUrls(text: string): string {
-  // Use our URL classifier to determine how to handle each URL
-  return text.replace(/(https?:\/\/[\w.-]+(?:\/[\w\-./?%&=+#@]*)?)/gi, url => {
-    // If already inside a markdown or html link, skip
-    if (/\]\([^)]+\)$/.test(url) || /href=/.test(url)) return url;
-
-    // Classify the URL using our utility
-    const urlInfo = classifyUrl(url);
-
-    // For now, only create markdown links for normal URLs
-    // Hive posts and embedded media will be handled by their respective renderers
-    if (urlInfo.type === 'normal') {
-      return `[${urlInfo.displayText || url}](${url})`;
-    }
-
-    // For all other types (hive_post, embedded_media, invalid), return as-is
-    // This allows the existing renderers to handle them properly
-    return url;
-  });
-}
 
 // Helper: Render mp4 video using expo-av Video
 const renderMp4Video = (uri: string, key?: string | number) => (

--- a/tests/linkification.test.ts
+++ b/tests/linkification.test.ts
@@ -165,6 +165,24 @@ describe('linkifyUrls', () => {
     // Should be wrapped and display text should be truncated with ellipsis
     expect(result).toMatch(/\[.*\.\.\.\]\(https:\/\/example\.com/);
   });
+
+  it('linkifies URLs with a port number', () => {
+    const url = 'https://example.com:8080/path';
+    const result = linkifyUrls(url);
+    expect(result).toContain(`[${url}](${url})`);
+  });
+
+  it('linkifies URLs with a query string and no path', () => {
+    const url = 'https://example.com?foo=bar';
+    const result = linkifyUrls(url);
+    expect(result).toContain(`[${url}](${url})`);
+  });
+
+  it('linkifies URLs with a fragment and no path', () => {
+    const url = 'https://example.com#section';
+    const result = linkifyUrls(url);
+    expect(result).toContain(`[${url}](${url})`);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/linkification.test.ts
+++ b/tests/linkification.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the markdown linkification pipeline.
+ *
+ * Root cause of bugs fixed by this suite:
+ *   1. linkifyMentions lived only in Snap.tsx; preprocessForMarkdown had its
+ *      own @username regex that ran AFTER linkifyMentions and corrupted the
+ *      already-formed links into invalid nested syntax, causing raw markdown
+ *      text to appear in the UI.
+ *   2. linkifyUrls had a broken context guard that tested the URL string
+ *      itself rather than the surrounding text, so [text](url) links written
+ *      by users were double-wrapped into [text]([url](url)).
+ */
+
+import { linkifyMentions } from '../utils/linkifyMentions';
+import { linkifyUrls } from '../utils/linkifyUrls';
+import { preprocessForMarkdown } from '../utils/htmlPreprocessing';
+
+// ---------------------------------------------------------------------------
+// linkifyMentions
+// ---------------------------------------------------------------------------
+describe('linkifyMentions', () => {
+  it('wraps a bare @mention into a profile:// markdown link', () => {
+    expect(linkifyMentions('Hello @alice!')).toBe(
+      'Hello [@alice](profile://alice)!'
+    );
+  });
+
+  it('handles a mention at the very start of the string', () => {
+    expect(linkifyMentions('@bob said hi')).toBe(
+      '[@bob](profile://bob) said hi'
+    );
+  });
+
+  it('handles multiple mentions in one string', () => {
+    const result = linkifyMentions('Thanks @alice and @bob!');
+    expect(result).toContain('[@alice](profile://alice)');
+    expect(result).toContain('[@bob](profile://bob)');
+  });
+
+  it('does NOT re-wrap a mention already inside a markdown link', () => {
+    // This is the core regression: content stored on-chain by other Hive
+    // clients (e.g. Ecency) already contains [@user](profile://user) syntax.
+    const already = '[@bitterirony](profile://bitterirony) said something';
+    expect(linkifyMentions(already)).toBe(already);
+  });
+
+  it('does NOT re-wrap when the full markdown link is in a sentence', () => {
+    const input =
+      'I thought [@steevc](profile://steevc) had a point about this.';
+    expect(linkifyMentions(input)).toBe(input);
+  });
+
+  it('does NOT match email addresses (@ preceded by word character)', () => {
+    expect(linkifyMentions('contact user@example.com please')).toBe(
+      'contact user@example.com please'
+    );
+  });
+
+  it('does NOT match @username preceded by a slash (e.g. inside a URL path)', () => {
+    expect(linkifyMentions('https://hive.blog/@alice/my-post')).toBe(
+      'https://hive.blog/@alice/my-post'
+    );
+  });
+
+  it('ignores usernames shorter than 3 characters', () => {
+    expect(linkifyMentions('hey @ab there')).toBe('hey @ab there');
+  });
+
+  it('ignores usernames longer than 16 characters', () => {
+    expect(linkifyMentions('@averylongusernamethatexceeds')).toBe(
+      '@averylongusernamethatexceeds'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// linkifyUrls
+// ---------------------------------------------------------------------------
+describe('linkifyUrls', () => {
+  it('wraps a bare URL in a markdown link', () => {
+    const result = linkifyUrls('Visit https://puppy.com for more');
+    expect(result).toContain('[https://puppy.com](https://puppy.com)');
+  });
+
+  it('does NOT double-wrap a URL already inside a markdown link', () => {
+    // This was the bug: [My blog](https://puppy.com) was being mangled into
+    // [My blog]([https://puppy.com](https://puppy.com))
+    const input = '[My favorite puppy blog](https://puppy.com)';
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('does NOT double-wrap a URL already inside a markdown link mid-sentence', () => {
+    const input = 'Check out [this site](https://example.com) for details.';
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('does NOT wrap a URL inside an HTML href attribute', () => {
+    const input = '<a href="https://example.com">click</a>';
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('does NOT wrap a URL inside an HTML href attribute without quotes', () => {
+    const input = "<a href='https://example.com'>click</a>";
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('leaves YouTube URLs unwrapped (handled by the video renderer)', () => {
+    const yt = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    expect(linkifyUrls(yt)).toBe(yt);
+  });
+
+  it('leaves Hive post URLs unwrapped (handled by the post-preview renderer)', () => {
+    const hive = 'https://peakd.com/@alice/my-great-post';
+    expect(linkifyUrls(hive)).toBe(hive);
+  });
+
+  it('truncates display text for long URLs', () => {
+    const long =
+      'https://example.com/this/is/a/very/long/path/that/exceeds/fifty/characters/total';
+    const result = linkifyUrls(long);
+    // Should be wrapped and display text should be truncated with ellipsis
+    expect(result).toMatch(/\[.*\.\.\.\]\(https:\/\/example\.com/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preprocessForMarkdown — regression: must NOT re-linkify @mentions
+// ---------------------------------------------------------------------------
+describe('preprocessForMarkdown — mention regression', () => {
+  it('does NOT convert bare @username (linkifyMentions is responsible for that)', () => {
+    // preprocessForMarkdown should only convert HTML tags; mention linkification
+    // was removed from it to prevent double-processing when used after linkifyMentions.
+    const result = preprocessForMarkdown('Hello @alice today');
+    expect(result).toBe('Hello @alice today');
+  });
+
+  it('does NOT corrupt an already-linked mention produced by linkifyMentions', () => {
+    // Simulate the pipeline: linkifyMentions runs first, then preprocessForMarkdown.
+    // The combined output must still be valid markdown.
+    const afterMentions = linkifyMentions(
+      '[@bitterirony](profile://bitterirony) said it'
+    );
+    const final = preprocessForMarkdown(afterMentions);
+    // Must remain a single, well-formed markdown link — no double brackets
+    expect(final).toBe(
+      '[@bitterirony](profile://bitterirony) said it'
+    );
+    expect(final).not.toContain('[[');
+  });
+
+  it('does NOT corrupt a mention that was bare before linkifyMentions ran', () => {
+    const afterMentions = linkifyMentions('@steevc mentioned something');
+    const final = preprocessForMarkdown(afterMentions);
+    expect(final).toBe('[@steevc](profile://steevc) mentioned something');
+    expect(final).not.toContain('[[');
+  });
+
+  it('still converts HTML bold tags to markdown', () => {
+    expect(preprocessForMarkdown('<b>bold</b>')).toBe('**bold**');
+  });
+
+  it('still converts HTML line breaks to newlines', () => {
+    expect(preprocessForMarkdown('line one<br>line two')).toBe(
+      'line one\n\nline two'
+    );
+  });
+
+  it('still converts HTML anchor tags to markdown links', () => {
+    expect(
+      preprocessForMarkdown('<a href="https://example.com">click here</a>')
+    ).toBe('[click here](https://example.com)');
+  });
+});

--- a/tests/linkification.test.ts
+++ b/tests/linkification.test.ts
@@ -144,6 +144,13 @@ describe('linkifyUrls', () => {
     expect(linkifyUrls(hive)).toBe(hive);
   });
 
+  it('DOES linkify a URL that appears inside plain parentheses in text', () => {
+    // (https://example.com) is just prose punctuation, not a markdown link dest
+    const input = 'See the docs (https://example.com) for details.';
+    const result = linkifyUrls(input);
+    expect(result).toContain('[https://example.com](https://example.com)');
+  });
+
   it('truncates display text for long URLs', () => {
     const long =
       'https://example.com/this/is/a/very/long/path/that/exceeds/fifty/characters/total';

--- a/tests/linkification.test.ts
+++ b/tests/linkification.test.ts
@@ -71,6 +71,25 @@ describe('linkifyMentions', () => {
       '@averylongusernamethatexceeds'
     );
   });
+
+  it('does NOT match handles with a leading hyphen (@-alice)', () => {
+    expect(linkifyMentions('hey @-alice there')).toBe('hey @-alice there');
+  });
+
+  it('does NOT match handles with a trailing hyphen (@alice-)', () => {
+    expect(linkifyMentions('hey @alice- there')).toBe('hey @alice- there');
+  });
+
+  it('normalises uppercase mentions to lowercase', () => {
+    expect(linkifyMentions('Hello @Alice!')).toBe(
+      'Hello [@alice](profile://alice)!'
+    );
+  });
+
+  it('does NOT wrap a URL inside an HTML href with uppercase HREF', () => {
+    const input = '<a HREF="https://example.com">click</a>';
+    expect(linkifyUrls(input)).toBe(input);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -91,6 +110,17 @@ describe('linkifyUrls', () => {
 
   it('does NOT double-wrap a URL already inside a markdown link mid-sentence', () => {
     const input = 'Check out [this site](https://example.com) for details.';
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('does NOT double-wrap a markdown link that includes a title attribute', () => {
+    const input = '[Example](https://example.com "site title")';
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('does NOT wrap a URL that is itself the link text of a markdown link', () => {
+    // e.g. auto-linked URL displayed as itself: [https://example.com](https://example.com)
+    const input = '[https://example.com](https://example.com)';
     expect(linkifyUrls(input)).toBe(input);
   });
 

--- a/tests/linkification.test.ts
+++ b/tests/linkification.test.ts
@@ -86,10 +86,6 @@ describe('linkifyMentions', () => {
     );
   });
 
-  it('does NOT wrap a URL inside an HTML href with uppercase HREF', () => {
-    const input = '<a HREF="https://example.com">click</a>';
-    expect(linkifyUrls(input)).toBe(input);
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -129,8 +125,13 @@ describe('linkifyUrls', () => {
     expect(linkifyUrls(input)).toBe(input);
   });
 
-  it('does NOT wrap a URL inside an HTML href attribute without quotes', () => {
+  it('does NOT wrap a URL inside an HTML href attribute with single quotes', () => {
     const input = "<a href='https://example.com'>click</a>";
+    expect(linkifyUrls(input)).toBe(input);
+  });
+
+  it('does NOT wrap a URL inside an HTML href with uppercase HREF', () => {
+    const input = '<a HREF="https://example.com">click</a>';
     expect(linkifyUrls(input)).toBe(input);
   });
 
@@ -142,6 +143,12 @@ describe('linkifyUrls', () => {
   it('leaves Hive post URLs unwrapped (handled by the post-preview renderer)', () => {
     const hive = 'https://peakd.com/@alice/my-great-post';
     expect(linkifyUrls(hive)).toBe(hive);
+  });
+
+  it('does NOT wrap a URL inside an angle-bracket markdown destination', () => {
+    // [label](<https://example.com>) is valid CommonMark
+    const input = '[label](<https://example.com>)';
+    expect(linkifyUrls(input)).toBe(input);
   });
 
   it('DOES linkify a URL that appears inside plain parentheses in text', () => {

--- a/utils/htmlPreprocessing.ts
+++ b/utils/htmlPreprocessing.ts
@@ -61,11 +61,6 @@ export const preprocessForMarkdown = (content: string): string => {
         '![$1]($2)'
       )
       .replace(/<img[^>]*src=["']([^"']*)["'][^>]*\/?>/g, '![]($1)')
-      // Convert @usernames to clickable links
-      .replace(
-        /(^|[^\w/@])@([a-z0-9\-\.]{3,16})(?![a-z0-9\-\.])/gi,
-        '$1[**@$2**](profile://$2)'
-      )
       // Clean up excessive whitespace
       .replace(/\n{3,}/g, '\n\n') // Replace 3+ newlines with just 2
       .trim()

--- a/utils/linkifyMentions.ts
+++ b/utils/linkifyMentions.ts
@@ -12,9 +12,9 @@ export function linkifyMentions(text: string): string {
     // Hive usernames: start with a letter, end with alphanumeric, 3–16 chars total.
     // Middle chars may include letters, digits, hyphens, and dots.
     /(^|[^\w/@])@([a-z][a-z0-9\-.]{1,14}[a-z0-9])(?![a-z0-9\-.])/gi,
-    (match, pre, username, offset, string) => {
-      const beforeMatch = string.substring(0, offset);
-      const afterMatch = string.substring(offset + match.length);
+    (match: string, pre: string, username: string, offset: number, source: string): string => {
+      const beforeMatch = source.substring(0, offset);
+      const afterMatch = source.substring(offset + match.length);
 
       // Case 1: the match IS the link text — e.g. "[@username" where pre='['
       // and the rest of the string begins with "](url)".  The '[' was captured

--- a/utils/linkifyMentions.ts
+++ b/utils/linkifyMentions.ts
@@ -9,7 +9,9 @@
  */
 export function linkifyMentions(text: string): string {
   return text.replace(
-    /(^|[^\w/@])@([a-z0-9\-\.]{3,16})(?![a-z0-9\-\.])/gi,
+    // Hive usernames: start with a letter, end with alphanumeric, 3–16 chars total.
+    // Middle chars may include letters, digits, hyphens, and dots.
+    /(^|[^\w/@])@([a-z][a-z0-9\-.]{1,14}[a-z0-9])(?![a-z0-9\-.])/gi,
     (match, pre, username, offset, string) => {
       const beforeMatch = string.substring(0, offset);
       const afterMatch = string.substring(offset + match.length);
@@ -29,7 +31,9 @@ export function linkifyMentions(text: string): string {
         return match;
       }
 
-      return `${pre}[@${username}](profile://${username})`;
+      // Hive usernames are always lowercase on-chain
+      const normalized = username.toLowerCase();
+      return `${pre}[@${normalized}](profile://${normalized})`;
     }
   );
 }

--- a/utils/linkifyMentions.ts
+++ b/utils/linkifyMentions.ts
@@ -1,0 +1,35 @@
+/**
+ * Convert bare @username mentions to clickable markdown profile links.
+ *
+ * Skips mentions that are already inside a markdown link [text](url) to
+ * prevent double-linkification from corrupting the syntax.
+ *
+ * Produces:  [@username](profile://username)
+ * The visual bold/colour treatment is handled downstream via linkStyles.mention.
+ */
+export function linkifyMentions(text: string): string {
+  return text.replace(
+    /(^|[^\w/@])@([a-z0-9\-\.]{3,16})(?![a-z0-9\-\.])/gi,
+    (match, pre, username, offset, string) => {
+      const beforeMatch = string.substring(0, offset);
+      const afterMatch = string.substring(offset + match.length);
+
+      // Case 1: the match IS the link text — e.g. "[@username" where pre='['
+      // and the rest of the string begins with "](url)".  The '[' was captured
+      // as `pre` so it doesn't appear in beforeMatch — check pre directly.
+      if (pre === '[' && afterMatch.startsWith('](')) {
+        return match;
+      }
+
+      // Case 2: @username appears somewhere inside a link text that opened
+      // earlier — e.g. "[ foo @username](url)".
+      const openBrackets = (beforeMatch.match(/\[/g) || []).length;
+      const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
+      if (openBrackets > closeBrackets && afterMatch.includes('](')) {
+        return match;
+      }
+
+      return `${pre}[@${username}](profile://${username})`;
+    }
+  );
+}

--- a/utils/linkifyUrls.ts
+++ b/utils/linkifyUrls.ts
@@ -24,12 +24,13 @@ export function linkifyUrls(text: string): string {
       const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
       if (openBrackets > closeBrackets && afterMatch.includes('](')) return url;
 
-      // Skip if the URL is the href of a markdown link [text](url "title").
-      // Require beforeMatch to end with "](" so plain parenthesised URLs like
-      // (https://example.com) are still linkified.
+      // Skip if the URL is the href of a markdown link, including optional
+      // title and angle-bracket destinations: [text](url), [text](url "title"),
+      // [text](<url>).  Require beforeMatch to end with "](" (optionally followed
+      // by "<") so plain parenthesised prose URLs are still linkified.
       if (
-        /\]\(\s*$/.test(beforeMatch) &&
-        /^\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\)/.test(afterMatch)
+        /\]\(\s*<?\s*$/.test(beforeMatch) &&
+        /^\s*>?\s*(?:(?:"[^"]*"|'[^']*'|\([^)]*\))\s*)?\)/.test(afterMatch)
       ) {
         return url;
       }

--- a/utils/linkifyUrls.ts
+++ b/utils/linkifyUrls.ts
@@ -15,15 +15,28 @@ export function linkifyUrls(text: string): string {
   return text.replace(
     /(https?:\/\/[\w.-]+(?:\/[\w\-./?%&=+#@]*)?)/gi,
     (url, _p1, offset: number, string: string) => {
-      // A URL is already inside a markdown link [text](url) when the character
-      // immediately before it is '(' and immediately after it is ')'.
       const charBefore = string[offset - 1];
-      const charAfter = string[offset + url.length];
-      if (charBefore === '(' && charAfter === ')') return url;
+      const beforeMatch = string.slice(0, offset);
+      const afterMatch = string.slice(offset + url.length);
 
-      // Also skip HTML href attributes
-      const nearby = string.substring(Math.max(0, offset - 8), offset);
-      if (/href=["']?$/.test(nearby)) return url;
+      // Skip if the URL appears as the text part of a markdown link:
+      // [ https://... ](...) — more open brackets than close before this point.
+      const openBrackets = (beforeMatch.match(/\[/g) || []).length;
+      const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
+      if (openBrackets > closeBrackets && afterMatch.includes('](')) return url;
+
+      // Skip if the URL is the href of a markdown link, including optional
+      // title: [text](https://... "optional title") or [text](https://...)
+      if (
+        charBefore === '(' &&
+        /^\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\)/.test(afterMatch)
+      ) {
+        return url;
+      }
+
+      // Skip HTML href attributes — case-insensitive, allows whitespace around =
+      const nearby = string.substring(Math.max(0, offset - 24), offset);
+      if (/\bhref\s*=\s*["']?$/i.test(nearby)) return url;
 
       const urlInfo = classifyUrl(url);
 

--- a/utils/linkifyUrls.ts
+++ b/utils/linkifyUrls.ts
@@ -13,11 +13,10 @@ import { classifyUrl } from './urlClassifier';
  */
 export function linkifyUrls(text: string): string {
   return text.replace(
-    /(https?:\/\/[\w.-]+(?:\/[\w\-./?%&=+#@]*)?)/gi,
-    (url, _p1, offset: number, string: string) => {
-      const charBefore = string[offset - 1];
-      const beforeMatch = string.slice(0, offset);
-      const afterMatch = string.slice(offset + url.length);
+    /https?:\/\/[\w.-]+(?:\/[\w\-./?%&=+#@]*)?/gi,
+    (url: string, offset: number, source: string): string => {
+      const beforeMatch = source.slice(0, offset);
+      const afterMatch = source.slice(offset + url.length);
 
       // Skip if the URL appears as the text part of a markdown link:
       // [ https://... ](...) — more open brackets than close before this point.
@@ -25,17 +24,18 @@ export function linkifyUrls(text: string): string {
       const closeBrackets = (beforeMatch.match(/\]/g) || []).length;
       if (openBrackets > closeBrackets && afterMatch.includes('](')) return url;
 
-      // Skip if the URL is the href of a markdown link, including optional
-      // title: [text](https://... "optional title") or [text](https://...)
+      // Skip if the URL is the href of a markdown link [text](url "title").
+      // Require beforeMatch to end with "](" so plain parenthesised URLs like
+      // (https://example.com) are still linkified.
       if (
-        charBefore === '(' &&
+        /\]\(\s*$/.test(beforeMatch) &&
         /^\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\)/.test(afterMatch)
       ) {
         return url;
       }
 
       // Skip HTML href attributes — case-insensitive, allows whitespace around =
-      const nearby = string.substring(Math.max(0, offset - 24), offset);
+      const nearby = source.substring(Math.max(0, offset - 24), offset);
       if (/\bhref\s*=\s*["']?$/i.test(nearby)) return url;
 
       const urlInfo = classifyUrl(url);

--- a/utils/linkifyUrls.ts
+++ b/utils/linkifyUrls.ts
@@ -1,0 +1,38 @@
+import { classifyUrl } from './urlClassifier';
+
+/**
+ * Wrap bare HTTP(S) URLs in markdown link syntax so they render as clickable
+ * links through react-native-markdown-display.
+ *
+ * Skips URLs that are already the href of a markdown link [text](url) or an
+ * HTML href attribute, to prevent double-wrapping which produces invalid nested
+ * link syntax and causes the renderer to show raw text.
+ *
+ * Non-normal URLs (Hive posts, embedded media, YouTube, etc.) are returned
+ * unchanged so their dedicated renderers can handle them.
+ */
+export function linkifyUrls(text: string): string {
+  return text.replace(
+    /(https?:\/\/[\w.-]+(?:\/[\w\-./?%&=+#@]*)?)/gi,
+    (url, _p1, offset: number, string: string) => {
+      // A URL is already inside a markdown link [text](url) when the character
+      // immediately before it is '(' and immediately after it is ')'.
+      const charBefore = string[offset - 1];
+      const charAfter = string[offset + url.length];
+      if (charBefore === '(' && charAfter === ')') return url;
+
+      // Also skip HTML href attributes
+      const nearby = string.substring(Math.max(0, offset - 8), offset);
+      if (/href=["']?$/.test(nearby)) return url;
+
+      const urlInfo = classifyUrl(url);
+
+      if (urlInfo.type === 'normal') {
+        return `[${urlInfo.displayText || url}](${url})`;
+      }
+
+      // hive_post, embedded_media, invalid — leave for their own renderers
+      return url;
+    }
+  );
+}

--- a/utils/linkifyUrls.ts
+++ b/utils/linkifyUrls.ts
@@ -13,7 +13,7 @@ import { classifyUrl } from './urlClassifier';
  */
 export function linkifyUrls(text: string): string {
   return text.replace(
-    /https?:\/\/[\w.-]+(?:\/[\w\-./?%&=+#@]*)?/gi,
+    /https?:\/\/[\w.-]+(?::\d+)?(?:[/?#][\w\-./?%&=+#@:;]*)?/gi,
     (url: string, offset: number, source: string): string => {
       const beforeMatch = source.slice(0, offset);
       const afterMatch = source.slice(offset + url.length);


### PR DESCRIPTION
## Summary

- **Mentions showing as raw markdown** (`[@bitterirony](profile://bitterirony)` visible as literal text): `preprocessForMarkdown` had its own `@username` regex that ran *after* `linkifyMentions` had already formed the link, corrupting it into `[[**@user**](profile://user)](profile://user)` — invalid nested syntax the renderer couldn't parse.
- **User-written `[text](url)` links being mangled**: `linkifyUrls` had a broken guard that tested the URL string itself rather than the surrounding context, so `[My blog](https://url.com)` was double-wrapped into `[My blog]([https://url.com](https://url.com))`.
- **Third bug found by tests**: The `isInsideMarkdownLink` guard in `linkifyMentions` failed when `[@user]` appeared at the start of a string — the `[` was captured as `pre`, absent from `beforeMatch`, so the bracket-count check returned false.

## Changes

- `utils/htmlPreprocessing.ts` — removed the `@username` replacement (mention linkification belongs to `linkifyMentions`, not here)
- `utils/linkifyMentions.ts` — extracted from `Snap.tsx` into a shared util; fixed the start-of-string guard
- `utils/linkifyUrls.ts` — extracted from `Snap.tsx` into a shared util; fixed the context guard to check `charBefore`/`charAfter` in the original string
- `app/components/Snap.tsx` — imports from the new util files
- `app/components/PostBody.tsx` — now calls `linkifyMentions` on its markdown fallback path
- `tests/linkification.test.ts` — 23 tests covering the full pipeline

## Test plan

- [ ] All 23 unit tests pass (`npx jest tests/linkification.test.ts`)
- [ ] Snap with `@mention` renders as a clickable blue link, not raw text
- [ ] Snap with `[@user](profile://user)` stored on-chain renders correctly (not double-wrapped)
- [ ] `[My blog](https://url.com)` written by a user renders as a clickable link
- [ ] Bare `https://url.com` in a snap still gets auto-linked
- [ ] YouTube/Hive post URLs are still left unwrapped for their dedicated renderers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linkification: bare @mentions and plain URLs are consistently turned into clickable links before Markdown rendering; avoids double-linking, false matches (emails, excluded URL types), and linkification inside HTML attributes. Mentions normalize case and length rules apply; long URLs show truncated display text.

* **New Features**
  * Centralized/shared linkification utilities to standardize behavior across the app.

* **Tests**
  * Added comprehensive tests covering mention/URL linkification and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->