### PR TITLE
fix: Gate wallet on stored active key; fix storedKeyAvailable detection

### DIFF
--- a/app/components/profile/WalletSection.tsx
+++ b/app/components/profile/WalletSection.tsx
@@ -6,6 +6,7 @@ import type { Href } from 'expo-router';
 
 interface WalletSectionProps {
     isOwnProfile: boolean;
+    hasStoredKey: boolean;
     hive?: number;
     hbd?: number;
     hivePower?: number;
@@ -22,6 +23,7 @@ interface WalletSectionProps {
 
 export const WalletSection: React.FC<WalletSectionProps> = ({
     isOwnProfile,
+    hasStoredKey,
     hive,
     hbd,
     hivePower,
@@ -29,7 +31,7 @@ export const WalletSection: React.FC<WalletSectionProps> = ({
 }) => {
     const router = useRouter();
 
-    if (!isOwnProfile) return null;
+    if (!isOwnProfile || !hasStoredKey) return null;
 
     const rows: { label: string; value: string }[] = [
         { label: 'HIVE', value: hive !== undefined ? hive.toFixed(3) : '–' },

--- a/app/components/profile/WalletSection.tsx
+++ b/app/components/profile/WalletSection.tsx
@@ -6,7 +6,7 @@ import type { Href } from 'expo-router';
 
 interface WalletSectionProps {
     isOwnProfile: boolean;
-    hasStoredKey: boolean;
+    isWalletAccessible: boolean;
     hive?: number;
     hbd?: number;
     hivePower?: number;
@@ -23,7 +23,7 @@ interface WalletSectionProps {
 
 export const WalletSection: React.FC<WalletSectionProps> = ({
     isOwnProfile,
-    hasStoredKey,
+    isWalletAccessible,
     hive,
     hbd,
     hivePower,
@@ -31,7 +31,7 @@ export const WalletSection: React.FC<WalletSectionProps> = ({
 }) => {
     const router = useRouter();
 
-    if (!isOwnProfile || !hasStoredKey) return null;
+    if (!isOwnProfile || !isWalletAccessible) return null;
 
     const rows: { label: string; value: string }[] = [
         { label: 'HIVE', value: hive !== undefined ? hive.toFixed(3) : '–' },

--- a/app/components/wallet/PowerDownModal.tsx
+++ b/app/components/wallet/PowerDownModal.tsx
@@ -104,8 +104,7 @@ export const PowerDownModal: React.FC<PowerDownModalProps> = ({
         <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
             <KeyboardAvoidingView
                 style={styles.overlay}
-                behavior="padding"
-                enabled={Platform.OS === 'ios'}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             >
                     <View style={[styles.content, { backgroundColor: colors.background }]}>
                         <Text style={[styles.title, { color: colors.text }]}>Power Down</Text>

--- a/app/components/wallet/PowerUpModal.tsx
+++ b/app/components/wallet/PowerUpModal.tsx
@@ -84,8 +84,7 @@ export const PowerUpModal: React.FC<PowerUpModalProps> = ({
         <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
             <KeyboardAvoidingView
                 style={styles.overlay}
-                behavior="padding"
-                enabled={Platform.OS === 'ios'}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             >
                     <View style={[styles.content, { backgroundColor: colors.background }]}>
                         <Text style={[styles.title, { color: colors.text }]}>Power Up</Text>

--- a/app/components/wallet/TransferModal.tsx
+++ b/app/components/wallet/TransferModal.tsx
@@ -90,8 +90,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
         <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
             <KeyboardAvoidingView
                 style={styles.overlay}
-                behavior="padding"
-                enabled={Platform.OS === 'ios'}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
             >
                 <View style={[styles.content, { backgroundColor: colors.background }]}>
                         <Text style={[styles.title, { color: colors.text }]}>

--- a/app/screens/AccountSelectionScreen.tsx
+++ b/app/screens/AccountSelectionScreen.tsx
@@ -101,7 +101,7 @@ export default function AccountSelectionScreen(): React.JSX.Element {
                 if (remaining.length > 0) {
                   try {
                     await switchAccount(remaining[0].username);
-                    router.replace('/');
+                    router.back();
                   } catch {
                     // Switch failed after deletion — fall back to login
                     await logout();

--- a/app/screens/AccountSelectionScreen.tsx
+++ b/app/screens/AccountSelectionScreen.tsx
@@ -95,9 +95,16 @@ export default function AccountSelectionScreen(): React.JSX.Element {
             try {
               await accountStorageService.removeAccount(account.username);
               if (account.username === currentUsername) {
-                // Removed the active account — clear auth state then go to login
-                await logout();
-                router.replace('/');
+                // Removed the active account — switch to another if one exists,
+                // otherwise clear auth and go to login.
+                const remaining = await accountStorageService.getAccounts();
+                if (remaining.length > 0) {
+                  await switchAccount(remaining[0].username);
+                  router.replace('/');
+                } else {
+                  await logout();
+                  router.replace('/');
+                }
               } else {
                 await loadAccounts();
               }
@@ -109,7 +116,7 @@ export default function AccountSelectionScreen(): React.JSX.Element {
         },
       ]
     );
-  }, [currentUsername, loadAccounts, logout, router]);
+  }, [currentUsername, loadAccounts, logout, switchAccount, router]);
 
   const renderAccount = useCallback(({ item }: { item: StoredAccount }): React.JSX.Element => {
     const isActive = item.username === currentUsername;

--- a/app/screens/AccountSelectionScreen.tsx
+++ b/app/screens/AccountSelectionScreen.tsx
@@ -99,8 +99,14 @@ export default function AccountSelectionScreen(): React.JSX.Element {
                 // otherwise clear auth and go to login.
                 const remaining = await accountStorageService.getAccounts();
                 if (remaining.length > 0) {
-                  await switchAccount(remaining[0].username);
-                  router.replace('/');
+                  try {
+                    await switchAccount(remaining[0].username);
+                    router.replace('/');
+                  } catch {
+                    // Switch failed after deletion — fall back to login
+                    await logout();
+                    router.replace('/');
+                  }
                 } else {
                   await logout();
                   router.replace('/');

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { SafeAreaView as SafeAreaViewSA } from 'react-native-safe-area-context';
 import {
   View,
@@ -37,6 +37,7 @@ import { useRewardsManagement } from '../../hooks/useRewardsManagement';
 import { useAuth } from '../../store/context';
 import { useUpvote } from '../../hooks/useUpvote';
 import { useHiveData } from '../../hooks/useHiveData';
+import { localAuthService } from '../../services/LocalAuthService';
 // useEdit removed - now using ComposeScreen for edit
 
 const ProfileScreen = () => {
@@ -58,6 +59,18 @@ const ProfileScreen = () => {
 
   // Define isOwnProfile early to avoid undefined issues
   const isOwnProfile = currentUsername === username;
+
+  // Wallet is accessible only when an active key is stored AND device auth is available.
+  // hasActiveKey alone isn't enough — if biometrics aren't set up the key can't be used.
+  const [walletAccessible, setWalletAccessible] = useState(false);
+  useEffect(() => {
+    if (!isOwnProfile || !hasActiveKey) { setWalletAccessible(false); return; }
+    let cancelled = false;
+    localAuthService.isAvailable()
+      .then((available) => { if (!cancelled) setWalletAccessible(available); })
+      .catch(() => { if (!cancelled) setWalletAccessible(false); });
+    return () => { cancelled = true; };
+  }, [isOwnProfile, hasActiveKey]);
   const {
     profile,
     loading,
@@ -353,10 +366,10 @@ const ProfileScreen = () => {
               handleClaimRewards={handleClaimRewards}
             />
 
-            {/* Wallet Section — only shown when an active key is stored */}
+            {/* Wallet Section — only shown when active key stored AND device auth available */}
             <WalletSection
               isOwnProfile={isOwnProfile}
-              hasStoredKey={hasActiveKey}
+              hasStoredKey={walletAccessible}
               hive={profile?.hive}
               hbd={profile?.hbd}
               hivePower={profile?.hivePower}

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -353,9 +353,10 @@ const ProfileScreen = () => {
               handleClaimRewards={handleClaimRewards}
             />
 
-            {/* Wallet Section */}
+            {/* Wallet Section — only shown when an active key is stored */}
             <WalletSection
               isOwnProfile={isOwnProfile}
+              hasStoredKey={hasActiveKey}
               hive={profile?.hive}
               hbd={profile?.hbd}
               hivePower={profile?.hivePower}

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -369,7 +369,7 @@ const ProfileScreen = () => {
             {/* Wallet Section — only shown when active key stored AND device auth available */}
             <WalletSection
               isOwnProfile={isOwnProfile}
-              hasStoredKey={walletAccessible}
+              isWalletAccessible={walletAccessible}
               hive={profile?.hive}
               hbd={profile?.hbd}
               hivePower={profile?.hivePower}

--- a/hooks/useWalletOperations.ts
+++ b/hooks/useWalletOperations.ts
@@ -48,11 +48,13 @@ export const useWalletOperations = (
     /**
      * Check if a stored active key exists (no biometric prompt).
      * Use this on modal open to decide whether to show the key input.
+     * Biometric availability is checked at operation time (getStoredActiveKey),
+     * not here — so the key input is hidden whenever a key is stored, regardless
+     * of whether the device has biometrics configured.
      */
     const checkStoredKeyAvailable = useCallback(async (): Promise<boolean> => {
         if (!currentUsername) return false;
         try {
-            if (!(await localAuthService.isAvailable())) return false;
             const keys = await accountStorageService.getAccountKeys(currentUsername);
             return !!(keys?.activeKey?.trim());
         } catch {


### PR DESCRIPTION
## Summary

- **WalletSection now hidden unless active key is stored** — previously it showed for all own profiles, sending users without a key into the wallet where they'd immediately be asked to enter one. Added `hasStoredKey` prop driven by `hasActiveKey` from the auth context.

- **Fixed `checkStoredKeyAvailable` incorrectly returning `false`** — it was gating on `localAuthService.isAvailable()` before checking key storage. On any device where biometrics aren't configured (e.g. simulator, or device without enrollment), this short-circuited to `false` even when a key was stored, causing every modal to render the manual key input despite the user having "full access". The biometric gate belongs at operation time in `getStoredActiveKey()`, not at the UI-check stage.

## Root cause

`checkStoredKeyAvailable` is used to decide whether to show the "Secured by biometrics" label vs the inline key input in modals. Its only question is: *is a key in storage?* Whether biometrics can unlock it is an operation-time concern already handled by `getStoredActiveKey`.

## Test plan

- [ ] Log in with an account that has a stored active key ("full access") — wallet section visible on own profile
- [ ] Log in with an account without a stored active key — wallet section hidden
- [ ] Open Transfer/PowerUp/PowerDown modal with stored key — shows "Secured by biometrics", no key input field
- [ ] Confirm operation triggers biometric prompt and broadcasts correctly
- [ ] Open modals without stored key — shows inline key input field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Wallet section now shows only on your profile when a stored key exists and device authentication is available.
  * Key-availability reporting now reflects stored-key presence alone; biometric/device-auth is enforced when accessing the key.
  * Deleting the active account will try to switch to another stored account before falling back to logout.
* **UI Changes**
  * Wallet modals use height-based keyboard avoidance on non‑iOS platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->