### PR TITLE
feat: Blog feed tab for Snapie community (hive-178315)

### DIFF
--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -113,8 +113,12 @@ export const BlogCard: React.FC<BlogCardProps> = ({ post, onPress, onAuthorPress
             </Text>
           </TouchableOpacity>
 
-          <Text style={[styles.dot, { color: theme.textSecondary }]}>·</Text>
-          <Text style={[styles.meta, { color: theme.textSecondary }]}>{timeAgo}</Text>
+          {timeAgo ? (
+            <>
+              <Text style={[styles.dot, { color: theme.textSecondary }]}>·</Text>
+              <Text style={[styles.meta, { color: theme.textSecondary }]}>{timeAgo}</Text>
+            </>
+          ) : null}
 
           {/* Stats */}
           <View style={styles.stats}>

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -1,0 +1,209 @@
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  useColorScheme,
+} from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { getTheme } from '../../constants/Colors';
+import type { BlogPost } from '../../hooks/useBlogFeed';
+
+interface BlogCardProps {
+  post: BlogPost;
+  onPress: () => void;
+  onAuthorPress: (username: string) => void;
+}
+
+/** Strip markdown and return a plain-text excerpt */
+function buildExcerpt(body: string, maxLen = 140): string {
+  const stripped = body
+    .replace(/!\[.*?\]\(.*?\)/g, '')   // images
+    .replace(/\[([^\]]+)\]\(.*?\)/g, '$1') // links → text
+    .replace(/#{1,6}\s*/g, '')          // headings
+    .replace(/[*_~`>]/g, '')            // emphasis/code/quote
+    .replace(/\n+/g, ' ')
+    .trim();
+  return stripped.length > maxLen ? stripped.slice(0, maxLen).trimEnd() + '…' : stripped;
+}
+
+function formatPayout(pendingPayout: string, totalPayout: string): string {
+  const pending = parseFloat(pendingPayout);
+  const total = parseFloat(totalPayout);
+  const value = pending > 0 ? pending : total;
+  return isNaN(value) ? '$0.00' : `$${value.toFixed(2)}`;
+}
+
+function formatTimeAgo(created: string): string {
+  const diff = Date.now() - new Date(created + 'Z').getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+  if (minutes < 2) return 'Just now';
+  if (minutes < 60) return `${minutes}m`;
+  if (hours < 24) return `${hours}h`;
+  return `${days}d`;
+}
+
+export const BlogCard: React.FC<BlogCardProps> = ({ post, onPress, onAuthorPress }) => {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+  const theme = useMemo(() => getTheme(isDark ? 'dark' : 'light'), [isDark]);
+
+  const excerpt = useMemo(() => buildExcerpt(post.body), [post.body]);
+  const payout = useMemo(
+    () => formatPayout(post.pending_payout_value, post.total_payout_value),
+    [post.pending_payout_value, post.total_payout_value]
+  );
+  const timeAgo = useMemo(() => formatTimeAgo(post.created), [post.created]);
+
+  return (
+    <TouchableOpacity
+      style={[styles.card, { backgroundColor: theme.bubble, borderColor: theme.border }]}
+      onPress={onPress}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+      accessibilityLabel={`Blog post: ${post.title} by ${post.author}`}
+    >
+      {/* Thumbnail */}
+      {post.thumbnailUrl ? (
+        <Image
+          source={{ uri: post.thumbnailUrl }}
+          style={styles.thumbnail}
+          resizeMode="cover"
+        />
+      ) : (
+        <View style={[styles.thumbnailPlaceholder, { backgroundColor: theme.border }]}>
+          <FontAwesome name="file-text-o" size={28} color={theme.textSecondary} />
+        </View>
+      )}
+
+      <View style={styles.body}>
+        {/* Title */}
+        <Text style={[styles.title, { color: theme.text }]} numberOfLines={2}>
+          {post.title || '(Untitled)'}
+        </Text>
+
+        {/* Excerpt */}
+        {excerpt.length > 0 && (
+          <Text style={[styles.excerpt, { color: theme.textSecondary }]} numberOfLines={2}>
+            {excerpt}
+          </Text>
+        )}
+
+        {/* Footer row */}
+        <View style={styles.footer}>
+          {/* Author */}
+          <TouchableOpacity
+            style={styles.authorRow}
+            onPress={() => onAuthorPress(post.author)}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            {post.avatarUrl ? (
+              <Image source={{ uri: post.avatarUrl }} style={styles.avatar} />
+            ) : (
+              <View style={[styles.avatar, styles.avatarFallback, { backgroundColor: theme.border }]} />
+            )}
+            <Text style={[styles.authorName, { color: theme.textSecondary }]}>
+              @{post.author}
+            </Text>
+          </TouchableOpacity>
+
+          <Text style={[styles.dot, { color: theme.textSecondary }]}>·</Text>
+          <Text style={[styles.meta, { color: theme.textSecondary }]}>{timeAgo}</Text>
+
+          {/* Stats */}
+          <View style={styles.stats}>
+            <Text style={[styles.stat, { color: theme.payout }]}>{payout}</Text>
+            <View style={styles.statItem}>
+              <FontAwesome name="heart-o" size={11} color={theme.textSecondary} />
+              <Text style={[styles.stat, { color: theme.textSecondary }]}>{post.net_votes}</Text>
+            </View>
+            <View style={styles.statItem}>
+              <FontAwesome name="comment-o" size={11} color={theme.textSecondary} />
+              <Text style={[styles.stat, { color: theme.textSecondary }]}>{post.children}</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    marginHorizontal: 12,
+    marginBottom: 12,
+    overflow: 'hidden',
+  },
+  thumbnail: {
+    width: '100%',
+    height: 180,
+  },
+  thumbnailPlaceholder: {
+    width: '100%',
+    height: 120,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: {
+    padding: 12,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    lineHeight: 22,
+    marginBottom: 6,
+  },
+  excerpt: {
+    fontSize: 13,
+    lineHeight: 19,
+    marginBottom: 10,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  authorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+  },
+  avatar: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+  },
+  avatarFallback: {},
+  authorName: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  dot: {
+    fontSize: 12,
+  },
+  meta: {
+    fontSize: 12,
+  },
+  stats: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginLeft: 'auto',
+  },
+  statItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+  },
+  stat: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+});

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -37,7 +37,9 @@ function formatPayout(pendingPayout: string, totalPayout: string): string {
 }
 
 function formatTimeAgo(created: string): string {
+  if (!created) return '';
   const diff = Date.now() - new Date(created + 'Z').getTime();
+  if (isNaN(diff) || diff < 0) return '';
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(diff / 3600000);
   const days = Math.floor(diff / 86400000);

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -971,6 +971,7 @@ const FeedScreenRefactored = () => {
             </View>
           ) : (
             <FlatList
+              key="blogs-feed"
               data={filteredBlogPosts}
               keyExtractor={(item) => `${item.author}-${item.permlink}`}
               renderItem={({ item }) => (
@@ -1036,6 +1037,7 @@ const FeedScreenRefactored = () => {
           </View>
         ) : (
           <FlatList
+            key="snaps-feed"
             ref={flatListRef}
             data={filteredSnaps}
             keyExtractor={(item, index) =>

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import {
   View,
   Text,
@@ -180,6 +180,12 @@ const FeedScreenRefactored = () => {
     refresh: refreshBlogPosts,
     loadMore: loadMoreBlogPosts,
   } = useBlogFeed();
+
+  const handleBlogEndReached = useCallback(() => {
+    if (!blogLoadingMore) {
+      loadMoreBlogPosts();
+    }
+  }, [blogLoadingMore, loadMoreBlogPosts]);
 
   // Cache management for follow/mute lists
   const { invalidateFollowingCache, invalidateMutedCache } = useFollowCacheManagement();
@@ -985,7 +991,7 @@ const FeedScreenRefactored = () => {
                 />
               )}
               contentContainerStyle={{ paddingTop: 12, paddingBottom: 40 }}
-              onEndReached={loadMoreBlogPosts}
+              onEndReached={handleBlogEndReached}
               onEndReachedThreshold={0.3}
               refreshing={globalRefreshing}
               onRefresh={handleGlobalRefresh}

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -1002,7 +1002,7 @@ const FeedScreenRefactored = () => {
                 <BlogCard
                   post={item}
                   onPress={() => router.push({
-                    pathname: '/screens/ConversationScreen',
+                    pathname: '/screens/HivePostScreen',
                     params: { author: item.author, permlink: item.permlink },
                   })}
                   onAuthorPress={(u) => router.push(`/screens/ProfileScreen?username=${u}` as any)}

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -184,6 +184,7 @@ const FeedScreenRefactored = () => {
     loading: blogLoading,
     loadingMore: blogLoadingMore,
     error: blogError,
+    loadMoreError: blogLoadMoreError,
     fetchPosts: fetchBlogPosts,
     refresh: refreshBlogPosts,
     loadMore: loadMoreBlogPosts,
@@ -955,6 +956,8 @@ const FeedScreenRefactored = () => {
                     }
                   }}
                   activeOpacity={0.7}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: isActive }}
                 >
                   <FontAwesome
                     name={filter.icon}
@@ -987,7 +990,7 @@ const FeedScreenRefactored = () => {
                 Loading blogs...
               </Text>
             </View>
-          ) : blogError ? (
+          ) : blogError && filteredBlogPosts.length === 0 ? (
             <View style={{ alignItems: 'center', marginTop: 40, paddingHorizontal: 24 }}>
               <Text style={{ color: colors.text, fontSize: 16, textAlign: 'center' }}>
                 {blogError}
@@ -1005,9 +1008,21 @@ const FeedScreenRefactored = () => {
                     pathname: '/screens/HivePostScreen',
                     params: { author: item.author, permlink: item.permlink },
                   })}
-                  onAuthorPress={(u) => router.push(`/screens/ProfileScreen?username=${u}` as any)}
+                  onAuthorPress={(u) => router.push({
+                    pathname: '/screens/ProfileScreen',
+                    params: { username: u },
+                  })}
                 />
               )}
+              ListHeaderComponent={
+                blogError && filteredBlogPosts.length > 0 ? (
+                  <View style={{ paddingHorizontal: 16, paddingTop: 12, paddingBottom: 4 }}>
+                    <Text style={{ color: colors.text, fontSize: 13, textAlign: 'center', opacity: 0.7 }}>
+                      Refresh failed — showing cached posts
+                    </Text>
+                  </View>
+                ) : null
+              }
               contentContainerStyle={{ paddingTop: 12, paddingBottom: 40 }}
               onEndReached={handleBlogEndReached}
               onEndReachedThreshold={0.3}
@@ -1017,6 +1032,12 @@ const FeedScreenRefactored = () => {
                 blogLoadingMore ? (
                   <View style={{ paddingVertical: 20, alignItems: 'center' }}>
                     <ActivityIndicator size="small" color={colors.button} />
+                  </View>
+                ) : blogLoadMoreError ? (
+                  <View style={{ paddingVertical: 16, alignItems: 'center', paddingHorizontal: 24 }}>
+                    <Text style={{ color: colors.text, fontSize: 13, textAlign: 'center' }}>
+                      {blogLoadMoreError}
+                    </Text>
                   </View>
                 ) : null
               }

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -170,7 +170,7 @@ const FeedScreenRefactored = () => {
   } = useFeedData();
 
   // Blog feed
-  const [activeFeed, setActiveFeed] = useState<'blogs' | 'snaps'>('blogs');
+  const [activeFeed, setActiveFeed] = useState<'blogs' | 'snaps'>('snaps');
   const {
     posts: blogPosts,
     loading: blogLoading,

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -207,6 +207,13 @@ const FeedScreenRefactored = () => {
     return filtered;
   }, [snaps, mutedList]);
 
+  // Apply the same muted-list filter to blog posts
+  const filteredBlogPosts = useMemo(() => {
+    if (!mutedList || mutedList.length === 0) return blogPosts;
+    const mutedSet = new Set(mutedList);
+    return blogPosts.filter((post) => !mutedSet.has(post.author));
+  }, [blogPosts, mutedList]);
+
   const { medianPrice, rewardFund } = useHiveData();
 
   const {
@@ -964,7 +971,7 @@ const FeedScreenRefactored = () => {
             </View>
           ) : (
             <FlatList
-              data={blogPosts}
+              data={filteredBlogPosts}
               keyExtractor={(item) => `${item.author}-${item.permlink}`}
               renderItem={({ item }) => (
                 <BlogCard

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -29,6 +29,7 @@ import { createFeedScreenStyles } from '../../styles/FeedScreenStyles';
 // Custom hooks for business logic
 import { useAuth } from '../../store/context';
 import { useFeedData, FeedFilter } from '../../hooks/useFeedData';
+import { useBlogFeed } from '../../hooks/useBlogFeed';
 import { useUpvote } from '../../hooks/useUpvote';
 import { useSearch } from '../../hooks/useSearch';
 import { useHiveData } from '../../hooks/useHiveData';
@@ -43,6 +44,7 @@ import { useAppStore, useCurrentUser, useAppDebug, useFollowCacheManagement } fr
 
 // Components
 import Snap from '../components/Snap';
+import { BlogCard } from '../components/BlogCard';
 import NotificationBadge from '../components/NotificationBadge';
 import SmallButton from '../../components/SmallButton';
 import StaticContentModal from '../../components/StaticContentModal';
@@ -167,6 +169,18 @@ const FeedScreenRefactored = () => {
     clearContainerMap
   } = useFeedData();
 
+  // Blog feed
+  const [activeFeed, setActiveFeed] = useState<'blogs' | 'snaps'>('blogs');
+  const {
+    posts: blogPosts,
+    loading: blogLoading,
+    loadingMore: blogLoadingMore,
+    error: blogError,
+    fetchPosts: fetchBlogPosts,
+    refresh: refreshBlogPosts,
+    loadMore: loadMoreBlogPosts,
+  } = useBlogFeed();
+
   // Cache management for follow/mute lists
   const { invalidateFollowingCache, invalidateMutedCache } = useFollowCacheManagement();
 
@@ -265,6 +279,7 @@ const FeedScreenRefactored = () => {
         `🏗️ [FeedScreen] About to fetch snaps using container-pagination strategy...`
       );
       hasInitialFetch.current = true;
+      void fetchBlogPosts();
       fetchSnaps(false).then(() => {
         // Log memory state after initial fetch
         const postFetchStats = getMemoryStats();
@@ -475,6 +490,9 @@ const FeedScreenRefactored = () => {
       // Clear container state to ensure fresh data and resolve refresh delays
       console.log('🧹 [FeedScreen] Clearing container map for fresh state');
       clearContainerMap();
+
+      // Refresh blog feed in parallel
+      ops.push(refreshBlogPosts());
 
       // Now refresh feed snaps with fresh muted/following data (returns a promise)
       ops.push(refreshSnaps());
@@ -878,59 +896,108 @@ const FeedScreenRefactored = () => {
             style={styles.filterScrollView}
           >
             {[
-              { key: 'following', label: 'Following', icon: 'users' },
-              { key: 'newest', label: 'Newest', icon: 'clock-o' },
-              { key: 'trending', label: 'Trending', icon: 'fire' },
-              { key: 'my', label: 'My Snaps', icon: 'user' },
-            ].map((filter, index) => (
-              <TouchableOpacity
-                key={filter.key}
-                style={[
-                  styles.filterBtnScrollable,
-                  {
-                    backgroundColor:
-                      currentFilter === filter.key
-                        ? colors.button
-                        : colors.buttonInactive,
-                    marginLeft: index === 0 ? 0 : 8,
-                    marginRight: index === 3 ? 0 : 0,
-                  },
-                ]}
-                onPress={() => handleFilterPress(filter.key as FeedFilter)}
-                activeOpacity={0.7}
-              >
-                <FontAwesome
-                  name={filter.icon as any}
-                  size={16}
-                  color={
-                    currentFilter === filter.key
-                      ? colors.buttonText
-                      : colors.text
-                  }
-                  style={{ marginRight: 6 }}
-                />
-                <Text
+              { key: 'blogs', label: 'Blogs', icon: 'newspaper-o', feed: 'blogs' as const },
+              { key: 'following', label: 'Following', icon: 'users', feed: 'snaps' as const },
+              { key: 'newest', label: 'Newest', icon: 'clock-o', feed: 'snaps' as const },
+              { key: 'trending', label: 'Trending', icon: 'fire', feed: 'snaps' as const },
+              { key: 'my', label: 'My Snaps', icon: 'user', feed: 'snaps' as const },
+            ].map((filter, index) => {
+              const isActive = filter.key === 'blogs'
+                ? activeFeed === 'blogs'
+                : activeFeed === 'snaps' && currentFilter === filter.key;
+              return (
+                <TouchableOpacity
+                  key={filter.key}
                   style={[
-                    styles.filterTextScrollable,
+                    styles.filterBtnScrollable,
                     {
-                      color:
-                        currentFilter === filter.key
-                          ? colors.buttonText
-                          : colors.text,
+                      backgroundColor: isActive ? colors.button : colors.buttonInactive,
+                      marginLeft: index === 0 ? 0 : 8,
                     },
                   ]}
+                  onPress={() => {
+                    if (filter.key === 'blogs') {
+                      setActiveFeed('blogs');
+                    } else {
+                      setActiveFeed('snaps');
+                      handleFilterPress(filter.key as FeedFilter);
+                    }
+                  }}
+                  activeOpacity={0.7}
                 >
-                  {filter.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
+                  <FontAwesome
+                    name={filter.icon as any}
+                    size={16}
+                    color={isActive ? colors.buttonText : colors.text}
+                    style={{ marginRight: 6 }}
+                  />
+                  <Text
+                    style={[
+                      styles.filterTextScrollable,
+                      { color: isActive ? colors.buttonText : colors.text },
+                    ]}
+                  >
+                    {filter.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
           </ScrollView>
         </View>
       </SafeAreaView>
 
       {/* Feed list */}
       <View style={styles.feedContainer}>
-        {feedLoading ? (
+        {activeFeed === 'blogs' ? (
+          blogLoading ? (
+            <View style={{ alignItems: 'center', marginTop: 40 }}>
+              <ActivityIndicator size="large" color={colors.button} />
+              <Text style={{ color: colors.text, fontSize: 16, marginTop: 12 }}>
+                Loading blogs...
+              </Text>
+            </View>
+          ) : blogError ? (
+            <View style={{ alignItems: 'center', marginTop: 40, paddingHorizontal: 24 }}>
+              <Text style={{ color: colors.text, fontSize: 16, textAlign: 'center' }}>
+                {blogError}
+              </Text>
+            </View>
+          ) : (
+            <FlatList
+              data={blogPosts}
+              keyExtractor={(item) => `${item.author}-${item.permlink}`}
+              renderItem={({ item }) => (
+                <BlogCard
+                  post={item}
+                  onPress={() => router.push({
+                    pathname: '/screens/ConversationScreen',
+                    params: { author: item.author, permlink: item.permlink },
+                  })}
+                  onAuthorPress={(u) => router.push(`/screens/ProfileScreen?username=${u}` as any)}
+                />
+              )}
+              contentContainerStyle={{ paddingTop: 12, paddingBottom: 40 }}
+              onEndReached={loadMoreBlogPosts}
+              onEndReachedThreshold={0.3}
+              refreshing={globalRefreshing}
+              onRefresh={handleGlobalRefresh}
+              ListFooterComponent={
+                blogLoadingMore ? (
+                  <View style={{ paddingVertical: 20, alignItems: 'center' }}>
+                    <ActivityIndicator size="small" color={colors.button} />
+                  </View>
+                ) : null
+              }
+              ListEmptyComponent={
+                <View style={{ alignItems: 'center', marginTop: 40, paddingHorizontal: 24 }}>
+                  <Text style={{ color: colors.text, fontSize: 16, textAlign: 'center' }}>
+                    No blog posts yet. Be the first!
+                  </Text>
+                </View>
+              }
+            />
+          )
+        ) : feedLoading ? (
           <View style={{ alignItems: 'center', marginTop: 40 }}>
             <FontAwesome
               name='hourglass-half'

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -17,6 +17,7 @@ import {
   KeyboardAvoidingView,
 } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
+import type { ComponentProps } from 'react';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -53,6 +54,13 @@ import { addPromiseIfValid } from '../../utils/promiseUtils';
 import { subscribeGlobalRefresh } from '../../utils/globalEvents';
 import { getTheme } from '../../constants/Colors';
 
+
+type FeedTab = {
+  key: 'blogs' | FeedFilter;
+  label: string;
+  icon: ComponentProps<typeof FontAwesome>['name'];
+  feed: 'blogs' | 'snaps';
+};
 
 // Modal content constants
 const VP_MODAL_CONTENT = {
@@ -271,6 +279,7 @@ const FeedScreenRefactored = () => {
   // Refs
   const flatListRef = useRef<FlatList<any>>(null);
   const hasInitialFetch = useRef(false);
+  const hasOpenedBlogsRef = useRef(false);
 
   // Load recent searches on mount
   useEffect(() => {
@@ -292,7 +301,6 @@ const FeedScreenRefactored = () => {
         `🏗️ [FeedScreen] About to fetch snaps using container-pagination strategy...`
       );
       hasInitialFetch.current = true;
-      void fetchBlogPosts();
       fetchSnaps(false).then(() => {
         // Log memory state after initial fetch
         const postFetchStats = getMemoryStats();
@@ -308,6 +316,14 @@ const FeedScreenRefactored = () => {
       }); // Force fresh fetch on mount
     }
   }, []); // Empty deps - only run once on mount
+
+  // Lazy blog fetch — only load when the user first opens the Blogs tab
+  useEffect(() => {
+    if (activeFeed === 'blogs' && !hasOpenedBlogsRef.current) {
+      hasOpenedBlogsRef.current = true;
+      void fetchBlogPosts();
+    }
+  }, [activeFeed, fetchBlogPosts]);
 
   // Log filter changes (client-side filtering happens automatically in useFeedData)
   useEffect(() => {
@@ -504,8 +520,10 @@ const FeedScreenRefactored = () => {
       console.log('🧹 [FeedScreen] Clearing container map for fresh state');
       clearContainerMap();
 
-      // Refresh blog feed in parallel
-      ops.push(refreshBlogPosts());
+      // Refresh blog feed only if user has opened the tab at least once
+      if (activeFeed === 'blogs' || hasOpenedBlogsRef.current) {
+        ops.push(refreshBlogPosts());
+      }
 
       // Now refresh feed snaps with fresh muted/following data (returns a promise)
       ops.push(refreshSnaps());
@@ -908,13 +926,13 @@ const FeedScreenRefactored = () => {
             contentContainerStyle={styles.filterScrollContent}
             style={styles.filterScrollView}
           >
-            {[
-              { key: 'blogs', label: 'Blogs', icon: 'newspaper-o', feed: 'blogs' as const },
-              { key: 'following', label: 'Following', icon: 'users', feed: 'snaps' as const },
-              { key: 'newest', label: 'Newest', icon: 'clock-o', feed: 'snaps' as const },
-              { key: 'trending', label: 'Trending', icon: 'fire', feed: 'snaps' as const },
-              { key: 'my', label: 'My Snaps', icon: 'user', feed: 'snaps' as const },
-            ].map((filter, index) => {
+            {(([
+              { key: 'blogs', label: 'Blogs', icon: 'newspaper-o', feed: 'blogs' },
+              { key: 'following', label: 'Following', icon: 'users', feed: 'snaps' },
+              { key: 'newest', label: 'Newest', icon: 'clock-o', feed: 'snaps' },
+              { key: 'trending', label: 'Trending', icon: 'fire', feed: 'snaps' },
+              { key: 'my', label: 'My Snaps', icon: 'user', feed: 'snaps' },
+            ]) as FeedTab[]).map((filter, index) => {
               const isActive = filter.key === 'blogs'
                 ? activeFeed === 'blogs'
                 : activeFeed === 'snaps' && currentFilter === filter.key;
@@ -939,7 +957,7 @@ const FeedScreenRefactored = () => {
                   activeOpacity={0.7}
                 >
                   <FontAwesome
-                    name={filter.icon as any}
+                    name={filter.icon}
                     size={16}
                     color={isActive ? colors.buttonText : colors.text}
                     style={{ marginRight: 6 }}

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -45,7 +45,17 @@ function extractThumbnail(jsonMeta: string, body: string): string | null {
   return match ? match[1] : null;
 }
 
-export function useBlogFeed() {
+export interface UseBlogFeedResult {
+  posts: BlogPost[];
+  loading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+  fetchPosts: () => Promise<void>;
+  refresh: () => Promise<void>;
+  loadMore: () => Promise<void>;
+}
+
+export function useBlogFeed(): UseBlogFeedResult {
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -114,17 +114,18 @@ export function useBlogFeed() {
 
     try {
       const client = getClient();
+      // bridge.get_ranked_posts does NOT include the cursor item in results,
+      // so no slice needed and limit stays PAGE_SIZE.
       const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
         sort: 'created',
         tag: SNAPIE_COMMUNITY,
-        limit: PAGE_SIZE + 1, // +1 because cursor item is included in results
+        limit: PAGE_SIZE,
         start_author: cursorRef.current.author,
         start_permlink: cursorRef.current.permlink,
         observer: '',
       });
 
-      // Drop the first item — it's the cursor (already shown)
-      const newRaw = (raw ?? []).slice(1);
+      const newRaw = raw ?? [];
       const parsed = parseRawPosts(newRaw);
       const enriched = await enrichWithAvatars(parsed);
       setPosts((prev) => [...prev, ...enriched]);

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -86,7 +86,7 @@ export function useBlogFeed() {
       // cursor pagination with start_author/start_permlink without "Invalid parameters"
       const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
         sort: 'created',
-        community: SNAPIE_COMMUNITY,
+        tag: SNAPIE_COMMUNITY,
         limit: PAGE_SIZE,
         observer: '',
       });
@@ -116,7 +116,7 @@ export function useBlogFeed() {
       const client = getClient();
       const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
         sort: 'created',
-        community: SNAPIE_COMMUNITY,
+        tag: SNAPIE_COMMUNITY,
         limit: PAGE_SIZE + 1, // +1 because cursor item is included in results
         start_author: cursorRef.current.author,
         start_permlink: cursorRef.current.permlink,

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { getClient } from '../services/HiveClient';
 import { avatarService } from '../services/AvatarService';
 
@@ -50,6 +50,7 @@ export interface UseBlogFeedResult {
   loading: boolean;
   loadingMore: boolean;
   error: string | null;
+  loadMoreError: string | null;
   fetchPosts: () => Promise<void>;
   refresh: () => Promise<void>;
   loadMore: () => Promise<void>;
@@ -60,9 +61,16 @@ export function useBlogFeed(): UseBlogFeedResult {
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
   const cursorRef = useRef<{ author: string; permlink: string } | null>(null);
   const hasMoreRef = useRef(true);
   const isFetchingRef = useRef(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
 
   const enrichWithAvatars = useCallback(async (rawPosts: BlogPost[]): Promise<BlogPost[]> => {
     const enriched = await Promise.all(
@@ -98,8 +106,7 @@ export function useBlogFeed(): UseBlogFeedResult {
   const fetchPosts = useCallback(async (): Promise<void> => {
     if (isFetchingRef.current) return;
     isFetchingRef.current = true;
-    setLoading(true);
-    setError(null);
+    if (isMountedRef.current) { setLoading(true); setError(null); }
     cursorRef.current = null;
     hasMoreRef.current = true;
 
@@ -116,6 +123,8 @@ export function useBlogFeed(): UseBlogFeedResult {
 
       const parsed = parseRawPosts(raw ?? []);
       const enriched = await enrichWithAvatars(parsed);
+
+      if (!isMountedRef.current) return;
       setPosts(enriched);
       hasMoreRef.current = enriched.length === PAGE_SIZE;
       if (enriched.length > 0) {
@@ -123,9 +132,11 @@ export function useBlogFeed(): UseBlogFeedResult {
         cursorRef.current = { author: last.author, permlink: last.permlink };
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load blog posts');
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load blog posts');
+      }
     } finally {
-      setLoading(false);
+      if (isMountedRef.current) setLoading(false);
       isFetchingRef.current = false;
     }
   }, [parseRawPosts, enrichWithAvatars]);
@@ -133,7 +144,7 @@ export function useBlogFeed(): UseBlogFeedResult {
   const loadMore = useCallback(async (): Promise<void> => {
     if (isFetchingRef.current || !hasMoreRef.current || !cursorRef.current) return;
     isFetchingRef.current = true;
-    setLoadingMore(true);
+    if (isMountedRef.current) { setLoadingMore(true); setLoadMoreError(null); }
 
     try {
       const client = getClient();
@@ -150,6 +161,8 @@ export function useBlogFeed(): UseBlogFeedResult {
 
       const parsed = parseRawPosts(raw ?? []);
       const enriched = await enrichWithAvatars(parsed);
+
+      if (!isMountedRef.current) return;
       setPosts((prev) => [...prev, ...enriched]);
       hasMoreRef.current = enriched.length === PAGE_SIZE;
       if (enriched.length > 0) {
@@ -157,9 +170,11 @@ export function useBlogFeed(): UseBlogFeedResult {
         cursorRef.current = { author: last.author, permlink: last.permlink };
       }
     } catch (err) {
-      if (__DEV__) console.error('[useBlogFeed] loadMore error:', err);
+      if (isMountedRef.current) {
+        setLoadMoreError(err instanceof Error ? err.message : 'Failed to load more posts');
+      }
     } finally {
-      setLoadingMore(false);
+      if (isMountedRef.current) setLoadingMore(false);
       isFetchingRef.current = false;
     }
   }, [parseRawPosts, enrichWithAvatars]);
@@ -168,5 +183,5 @@ export function useBlogFeed(): UseBlogFeedResult {
     await fetchPosts();
   }, [fetchPosts]);
 
-  return { posts, loading, loadingMore, error, fetchPosts, refresh, loadMore };
+  return { posts, loading, loadingMore, error, loadMoreError, fetchPosts, refresh, loadMore };
 }

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -5,6 +5,19 @@ import { avatarService } from '../services/AvatarService';
 export const SNAPIE_COMMUNITY = 'hive-178315';
 const PAGE_SIZE = 20;
 
+interface RawBlogPost {
+  author: string;
+  permlink: string;
+  title?: string;
+  body?: string;
+  json_metadata?: string;
+  created: string;
+  pending_payout_value?: string;
+  total_payout_value?: string;
+  net_votes?: number;
+  children?: number;
+}
+
 export interface BlogPost {
   author: string;
   permlink: string;
@@ -55,7 +68,7 @@ export function useBlogFeed() {
     return enriched;
   }, []);
 
-  const parseRawPosts = useCallback((raw: any[]): BlogPost[] => {
+  const parseRawPosts = useCallback((raw: RawBlogPost[]): BlogPost[] => {
     return raw.map((item) => ({
       author: item.author,
       permlink: item.permlink,
@@ -84,12 +97,12 @@ export function useBlogFeed() {
       const client = getClient();
       // bridge.get_ranked_posts is the correct API for community posts — supports
       // cursor pagination with start_author/start_permlink without "Invalid parameters"
-      const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
+      const raw = await client.call('bridge', 'get_ranked_posts', {
         sort: 'created',
         tag: SNAPIE_COMMUNITY,
         limit: PAGE_SIZE,
         observer: '',
-      });
+      }) as RawBlogPost[];
 
       const parsed = parseRawPosts(raw ?? []);
       const enriched = await enrichWithAvatars(parsed);
@@ -116,17 +129,16 @@ export function useBlogFeed() {
       const client = getClient();
       // bridge.get_ranked_posts does NOT include the cursor item in results,
       // so no slice needed and limit stays PAGE_SIZE.
-      const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
+      const raw = await client.call('bridge', 'get_ranked_posts', {
         sort: 'created',
         tag: SNAPIE_COMMUNITY,
         limit: PAGE_SIZE,
         start_author: cursorRef.current.author,
         start_permlink: cursorRef.current.permlink,
         observer: '',
-      });
+      }) as RawBlogPost[];
 
-      const newRaw = raw ?? [];
-      const parsed = parseRawPosts(newRaw);
+      const parsed = parseRawPosts(raw ?? []);
       const enriched = await enrichWithAvatars(parsed);
       setPosts((prev) => [...prev, ...enriched]);
       hasMoreRef.current = enriched.length === PAGE_SIZE;

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -82,10 +82,14 @@ export function useBlogFeed() {
 
     try {
       const client = getClient();
-      const raw: any[] = await client.database.call('get_discussions_by_created', [{
-        tag: SNAPIE_COMMUNITY,
+      // bridge.get_ranked_posts is the correct API for community posts — supports
+      // cursor pagination with start_author/start_permlink without "Invalid parameters"
+      const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
+        sort: 'created',
+        community: SNAPIE_COMMUNITY,
         limit: PAGE_SIZE,
-      }]);
+        observer: '',
+      });
 
       const parsed = parseRawPosts(raw ?? []);
       const enriched = await enrichWithAvatars(parsed);
@@ -110,12 +114,14 @@ export function useBlogFeed() {
 
     try {
       const client = getClient();
-      const raw: any[] = await client.database.call('get_discussions_by_created', [{
-        tag: SNAPIE_COMMUNITY,
+      const raw: any[] = await client.call('bridge', 'get_ranked_posts', {
+        sort: 'created',
+        community: SNAPIE_COMMUNITY,
         limit: PAGE_SIZE + 1, // +1 because cursor item is included in results
         start_author: cursorRef.current.author,
         start_permlink: cursorRef.current.permlink,
-      }]);
+        observer: '',
+      });
 
       // Drop the first item — it's the cursor (already shown)
       const newRaw = (raw ?? []).slice(1);
@@ -128,7 +134,6 @@ export function useBlogFeed() {
         cursorRef.current = { author: last.author, permlink: last.permlink };
       }
     } catch (err) {
-      // Non-fatal — user can retry by scrolling again
       if (__DEV__) console.error('[useBlogFeed] loadMore error:', err);
     } finally {
       setLoadingMore(false);

--- a/hooks/useBlogFeed.ts
+++ b/hooks/useBlogFeed.ts
@@ -1,0 +1,144 @@
+import { useState, useCallback, useRef } from 'react';
+import { getClient } from '../services/HiveClient';
+import { avatarService } from '../services/AvatarService';
+
+export const SNAPIE_COMMUNITY = 'hive-178315';
+const PAGE_SIZE = 20;
+
+export interface BlogPost {
+  author: string;
+  permlink: string;
+  title: string;
+  body: string;
+  json_metadata: string;
+  created: string;
+  pending_payout_value: string;
+  total_payout_value: string;
+  net_votes: number;
+  children: number;
+  thumbnailUrl: string | null;
+  avatarUrl: string;
+}
+
+/** Extract first image URL from json_metadata or body */
+function extractThumbnail(jsonMeta: string, body: string): string | null {
+  try {
+    const meta = JSON.parse(jsonMeta);
+    if (Array.isArray(meta.image) && meta.image.length > 0 && typeof meta.image[0] === 'string') {
+      return meta.image[0];
+    }
+  } catch { /* ignore */ }
+  const match = body.match(/!\[.*?\]\((https?:\/\/[^)]+)\)/);
+  return match ? match[1] : null;
+}
+
+export function useBlogFeed() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cursorRef = useRef<{ author: string; permlink: string } | null>(null);
+  const hasMoreRef = useRef(true);
+  const isFetchingRef = useRef(false);
+
+  const enrichWithAvatars = useCallback(async (rawPosts: BlogPost[]): Promise<BlogPost[]> => {
+    const enriched = await Promise.all(
+      rawPosts.map(async (post) => {
+        try {
+          const result = await avatarService.getAvatarUrl(post.author);
+          return { ...post, avatarUrl: result.url };
+        } catch {
+          return post;
+        }
+      })
+    );
+    return enriched;
+  }, []);
+
+  const parseRawPosts = useCallback((raw: any[]): BlogPost[] => {
+    return raw.map((item) => ({
+      author: item.author,
+      permlink: item.permlink,
+      title: item.title ?? '',
+      body: item.body ?? '',
+      json_metadata: item.json_metadata ?? '{}',
+      created: item.created,
+      pending_payout_value: item.pending_payout_value ?? '0.000 HBD',
+      total_payout_value: item.total_payout_value ?? '0.000 HBD',
+      net_votes: item.net_votes ?? 0,
+      children: item.children ?? 0,
+      thumbnailUrl: extractThumbnail(item.json_metadata ?? '{}', item.body ?? ''),
+      avatarUrl: '',
+    }));
+  }, []);
+
+  const fetchPosts = useCallback(async (): Promise<void> => {
+    if (isFetchingRef.current) return;
+    isFetchingRef.current = true;
+    setLoading(true);
+    setError(null);
+    cursorRef.current = null;
+    hasMoreRef.current = true;
+
+    try {
+      const client = getClient();
+      const raw: any[] = await client.database.call('get_discussions_by_created', [{
+        tag: SNAPIE_COMMUNITY,
+        limit: PAGE_SIZE,
+      }]);
+
+      const parsed = parseRawPosts(raw ?? []);
+      const enriched = await enrichWithAvatars(parsed);
+      setPosts(enriched);
+      hasMoreRef.current = enriched.length === PAGE_SIZE;
+      if (enriched.length > 0) {
+        const last = enriched[enriched.length - 1];
+        cursorRef.current = { author: last.author, permlink: last.permlink };
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load blog posts');
+    } finally {
+      setLoading(false);
+      isFetchingRef.current = false;
+    }
+  }, [parseRawPosts, enrichWithAvatars]);
+
+  const loadMore = useCallback(async (): Promise<void> => {
+    if (isFetchingRef.current || !hasMoreRef.current || !cursorRef.current) return;
+    isFetchingRef.current = true;
+    setLoadingMore(true);
+
+    try {
+      const client = getClient();
+      const raw: any[] = await client.database.call('get_discussions_by_created', [{
+        tag: SNAPIE_COMMUNITY,
+        limit: PAGE_SIZE + 1, // +1 because cursor item is included in results
+        start_author: cursorRef.current.author,
+        start_permlink: cursorRef.current.permlink,
+      }]);
+
+      // Drop the first item — it's the cursor (already shown)
+      const newRaw = (raw ?? []).slice(1);
+      const parsed = parseRawPosts(newRaw);
+      const enriched = await enrichWithAvatars(parsed);
+      setPosts((prev) => [...prev, ...enriched]);
+      hasMoreRef.current = enriched.length === PAGE_SIZE;
+      if (enriched.length > 0) {
+        const last = enriched[enriched.length - 1];
+        cursorRef.current = { author: last.author, permlink: last.permlink };
+      }
+    } catch (err) {
+      // Non-fatal — user can retry by scrolling again
+      if (__DEV__) console.error('[useBlogFeed] loadMore error:', err);
+    } finally {
+      setLoadingMore(false);
+      isFetchingRef.current = false;
+    }
+  }, [parseRawPosts, enrichWithAvatars]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    await fetchPosts();
+  }, [fetchPosts]);
+
+  return { posts, loading, loadingMore, error, fetchPosts, refresh, loadMore };
+}


### PR DESCRIPTION
## Summary

- Adds a **Blogs** tab to the feed screen showing posts from the Snapie Hive community (`hive-178315`)
- New `useBlogFeed` hook fetches from `bridge.get_ranked_posts` with cursor-based pagination
- New `BlogCard` component renders post previews: thumbnail, title, excerpt, author/avatar, payout, votes, comments
- Blog posts are filtered through the same muted-user list as snaps
- Snaps feed (Newest) remains the default on app open — Blogs is an opt-in tab
- Tapping a blog card navigates to the existing `ConversationScreen`

## New files

- `hooks/useBlogFeed.ts` — community post fetching + pagination
- `app/components/BlogCard.tsx` — blog preview card component

## Modified files

- `app/screens/FeedScreen.tsx` — Blogs tab added; conditional rendering of blogs vs snaps feed

## Notes for review

- `bridge.get_ranked_posts` uses `tag` (not `community`) for community filtering
- Unlike condenser API, the bridge API **excludes** the cursor item from paginated results — no `slice(1)` needed
- Both FlatLists have distinct `key` props (`"blogs-feed"` / `"snaps-feed"`) to prevent React reconciliation crash when switching tabs (`onViewableItemsChanged` nullability violation)

## Test plan

- [ ] App opens to Newest snaps feed by default
- [ ] Tapping Blogs tab loads blog cards from the Snapie community
- [ ] Scrolling to end of blogs loads next page without errors
- [ ] Authors on the muted list are filtered out of blogs
- [ ] Tapping a blog card navigates to the full post
- [ ] Tapping author name navigates to profile
- [ ] Pull-to-refresh refreshes both feeds
- [ ] Switching between Blogs and snaps tabs works without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle between Blogs and Snaps in the feed.
  * Tappable Blog cards with thumbnail/placeholder, title (or “(Untitled)”), generated excerpt, author info with avatar, “time ago”, payout, votes, and comment count.
  * Blog feed supports pull-to-refresh, integrated blog refresh, infinite-scroll pagination, muted-user filtering, and lazy loading (fetches blogs on first open).
* **Accessibility**
  * Feed tabs and interactive elements include accessibility roles and state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->