### PR TITLE
fix: Render audio player on HivePostScreen for 3Speak audio posts

### DIFF
--- a/app/screens/HivePostScreen.tsx
+++ b/app/screens/HivePostScreen.tsx
@@ -18,6 +18,8 @@ import { FontAwesome } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router';
 import { Image as ExpoImage } from 'expo-image';
 import PostBody from '../components/PostBody';
+import AudioEmbed from '../components/AudioEmbed';
+import { detectMediaInBody } from '../../utils/mediaDetection';
 import { Dimensions } from 'react-native';
 import { useCurrentUser } from '../../store/context';
 import { useUpvote } from '../../hooks/useUpvote';
@@ -153,6 +155,8 @@ const HivePostScreen = () => {
   };
 
   const windowWidth = Dimensions.get('window').width;
+
+  const postMediaInfo = useMemo(() => detectMediaInBody(post?.body ?? ''), [post?.body]);
 
   // Filter comments to exclude muted users (includes personal mutes + global blacklist)
   const filteredComments = useMemo(() => {
@@ -389,6 +393,13 @@ const HivePostScreen = () => {
             {post.title}
           </Text>
         )}
+
+        {/* Audio embed (3Speak audio posts) */}
+        {postMediaInfo.hasAudio && postMediaInfo.audioUrl ? (
+          <View style={{ marginBottom: 8 }}>
+            <AudioEmbed embedUrl={postMediaInfo.audioUrl} />
+          </View>
+        ) : null}
 
         {/* Content */}
         <PostBody body={post.body} colors={colors} isDark={isDark} />


### PR DESCRIPTION
## Summary

- `HivePostScreen` was not rendering the audio player for 3Speak audio posts — the audio URL appeared as dead text with no playback UI
- Added `detectMediaInBody` (memoized on `post.body`) and renders `AudioEmbed` above `PostBody` when audio is detected
- Mirrors the exact same pattern already used in `Snap.tsx`

## What's not in scope

The audio URL still appears as raw text inside the post body. Stripping it inline requires the `PostBody` renderer to split the body around the URL before passing it to the markdown/HTML renderer — that's a larger refactor tracked separately.

## Test plan

- [ ] Open a 3Speak audio post from the feed — audio player should appear above the post body
- [ ] Open a regular text/image post — no audio player rendered
- [ ] Open a snap with audio — still works as before (no regression)
- [ ] Dark and light mode render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posts now support embedded audio content with automatic detection and inline playback. Audio files are rendered directly in your feed for a seamless listening experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->