### PR TITLE
feat: Add polls support (create, display, and vote)

### DIFF
--- a/app/components/PollCreatorModal.tsx
+++ b/app/components/PollCreatorModal.tsx
@@ -122,7 +122,7 @@ export const PollCreatorModal: React.FC<PollCreatorModalProps> = ({
     >
       <View style={styles.overlay}>
         <View style={[styles.sheet, { backgroundColor: colors.background, borderColor: colors.inputBorder }]}>
-          <View style={styles.header}>
+          <View style={[styles.header, { borderBottomColor: colors.inputBorder }]}>
             <Text style={[styles.title, { color: colors.text }]}>Create Poll</Text>
             <TouchableOpacity onPress={handleClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
               <FontAwesome name="times" size={20} color={colors.textSecondary} />
@@ -240,7 +240,7 @@ export const PollCreatorModal: React.FC<PollCreatorModalProps> = ({
                 value={allowVoteChanges}
                 onValueChange={setAllowVoteChanges}
                 trackColor={{ true: colors.button, false: colors.inputBorder }}
-                thumbColor="#fff"
+                thumbColor={colors.buttonText}
               />
             </View>
 
@@ -250,7 +250,7 @@ export const PollCreatorModal: React.FC<PollCreatorModalProps> = ({
                 value={hideResultsUntilVoted}
                 onValueChange={setHideResultsUntilVoted}
                 trackColor={{ true: colors.button, false: colors.inputBorder }}
-                thumbColor="#fff"
+                thumbColor={colors.buttonText}
               />
             </View>
 
@@ -291,7 +291,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 14,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#ccc',
   },
   title: {
     fontSize: 17,

--- a/app/components/PollCreatorModal.tsx
+++ b/app/components/PollCreatorModal.tsx
@@ -1,0 +1,389 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+  Switch,
+} from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import type { PollDraft } from '../../utils/pollDetection';
+
+export type { PollDraft };
+
+interface PollCreatorModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: (poll: PollDraft) => void;
+  colors: {
+    background: string;
+    text: string;
+    textSecondary: string;
+    inputBg: string;
+    inputBorder: string;
+    button: string;
+    buttonText: string;
+    buttonInactive: string;
+    error: string;
+    warning: string;
+  };
+}
+
+const DURATION_OPTIONS = [1, 3, 7, 14];
+
+export const PollCreatorModal: React.FC<PollCreatorModalProps> = ({
+  visible,
+  onClose,
+  onConfirm,
+  colors,
+}) => {
+  const [question, setQuestion] = useState('');
+  const [choices, setChoices] = useState(['', '']);
+  const [durationDays, setDurationDays] = useState(7);
+  const [maxChoicesVoted, setMaxChoicesVoted] = useState(1);
+  const [allowVoteChanges, setAllowVoteChanges] = useState(false);
+  const [hideResultsUntilVoted, setHideResultsUntilVoted] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const reset = () => {
+    setQuestion('');
+    setChoices(['', '']);
+    setDurationDays(7);
+    setMaxChoicesVoted(1);
+    setAllowVoteChanges(false);
+    setHideResultsUntilVoted(false);
+    setValidationError(null);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const addChoice = () => {
+    if (choices.length < 5) {
+      setChoices((prev) => [...prev, '']);
+    }
+  };
+
+  const removeChoice = (index: number) => {
+    if (choices.length <= 2) return;
+    const next = choices.filter((_, i) => i !== index);
+    setChoices(next);
+    if (maxChoicesVoted > next.length) setMaxChoicesVoted(next.length);
+  };
+
+  const updateChoice = (index: number, value: string) => {
+    setChoices((prev) => prev.map((c, i) => (i === index ? value : c)));
+  };
+
+  const validate = (): boolean => {
+    if (!question.trim()) {
+      setValidationError('Please enter a poll question.');
+      return false;
+    }
+    const filled = choices.filter((c) => c.trim());
+    if (filled.length < 2) {
+      setValidationError('Please enter at least 2 choices.');
+      return false;
+    }
+    const unique = new Set(filled.map((c) => c.trim().toLowerCase()));
+    if (unique.size !== filled.length) {
+      setValidationError('Choices must be unique.');
+      return false;
+    }
+    setValidationError(null);
+    return true;
+  };
+
+  const handleConfirm = () => {
+    if (!validate()) return;
+    const filledChoices = choices.filter((c) => c.trim());
+    onConfirm({
+      question: question.trim(),
+      choices: filledChoices,
+      durationDays,
+      maxChoicesVoted: Math.min(maxChoicesVoted, filledChoices.length),
+      allowVoteChanges,
+      hideResultsUntilVoted,
+    });
+    reset();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <View style={styles.overlay}>
+        <View style={[styles.sheet, { backgroundColor: colors.background, borderColor: colors.inputBorder }]}>
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text }]}>Create Poll</Text>
+            <TouchableOpacity onPress={handleClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <FontAwesome name="times" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView showsVerticalScrollIndicator={false} style={styles.body}>
+            {/* Question */}
+            <Text style={[styles.label, { color: colors.text }]}>Question</Text>
+            <TextInput
+              style={[styles.input, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBg }]}
+              value={question}
+              onChangeText={setQuestion}
+              placeholder="Ask a question..."
+              placeholderTextColor={colors.textSecondary}
+              maxLength={160}
+            />
+
+            {/* Choices */}
+            <Text style={[styles.label, { color: colors.text }]}>Choices</Text>
+            {choices.map((choice, index) => (
+              <View key={index} style={styles.choiceRow}>
+                <TextInput
+                  style={[styles.choiceInput, { borderColor: colors.inputBorder, color: colors.text, backgroundColor: colors.inputBg }]}
+                  value={choice}
+                  onChangeText={(val) => updateChoice(index, val)}
+                  placeholder={`Choice ${index + 1}`}
+                  placeholderTextColor={colors.textSecondary}
+                  maxLength={80}
+                />
+                {choices.length > 2 && (
+                  <TouchableOpacity
+                    onPress={() => removeChoice(index)}
+                    style={styles.removeChoiceBtn}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  >
+                    <FontAwesome name="minus-circle" size={18} color={colors.error} />
+                  </TouchableOpacity>
+                )}
+              </View>
+            ))}
+
+            {choices.length < 5 && (
+              <TouchableOpacity
+                style={[styles.addChoiceBtn, { borderColor: colors.button }]}
+                onPress={addChoice}
+              >
+                <FontAwesome name="plus" size={14} color={colors.button} />
+                <Text style={[styles.addChoiceText, { color: colors.button }]}>Add choice</Text>
+              </TouchableOpacity>
+            )}
+
+            {/* Duration */}
+            <Text style={[styles.label, { color: colors.text }]}>Duration</Text>
+            <View style={styles.durationRow}>
+              {DURATION_OPTIONS.map((d) => (
+                <TouchableOpacity
+                  key={d}
+                  style={[
+                    styles.durationBtn,
+                    {
+                      backgroundColor: durationDays === d ? colors.button : colors.inputBg,
+                      borderColor: durationDays === d ? colors.button : colors.inputBorder,
+                    },
+                  ]}
+                  onPress={() => setDurationDays(d)}
+                >
+                  <Text
+                    style={[
+                      styles.durationBtnText,
+                      { color: durationDays === d ? colors.buttonText : colors.text },
+                    ]}
+                  >
+                    {d}d
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {/* Max choices voted */}
+            {choices.filter((c) => c.trim()).length > 1 && (
+              <>
+                <Text style={[styles.label, { color: colors.text }]}>Max selections per voter</Text>
+                <View style={styles.durationRow}>
+                  {Array.from({ length: choices.filter((c) => c.trim()).length }, (_, i) => i + 1).map((n) => (
+                    <TouchableOpacity
+                      key={n}
+                      style={[
+                        styles.durationBtn,
+                        {
+                          backgroundColor: maxChoicesVoted === n ? colors.button : colors.inputBg,
+                          borderColor: maxChoicesVoted === n ? colors.button : colors.inputBorder,
+                        },
+                      ]}
+                      onPress={() => setMaxChoicesVoted(n)}
+                    >
+                      <Text
+                        style={[
+                          styles.durationBtnText,
+                          { color: maxChoicesVoted === n ? colors.buttonText : colors.text },
+                        ]}
+                      >
+                        {n}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </>
+            )}
+
+            {/* Toggles */}
+            <View style={styles.toggleRow}>
+              <Text style={[styles.toggleLabel, { color: colors.text }]}>Allow vote changes</Text>
+              <Switch
+                value={allowVoteChanges}
+                onValueChange={setAllowVoteChanges}
+                trackColor={{ true: colors.button, false: colors.inputBorder }}
+                thumbColor="#fff"
+              />
+            </View>
+
+            <View style={styles.toggleRow}>
+              <Text style={[styles.toggleLabel, { color: colors.text }]}>Hide results until voted</Text>
+              <Switch
+                value={hideResultsUntilVoted}
+                onValueChange={setHideResultsUntilVoted}
+                trackColor={{ true: colors.button, false: colors.inputBorder }}
+                thumbColor="#fff"
+              />
+            </View>
+
+            {validationError && (
+              <Text style={[styles.errorText, { color: colors.error }]}>{validationError}</Text>
+            )}
+          </ScrollView>
+
+          <TouchableOpacity
+            style={[styles.confirmBtn, { backgroundColor: colors.button }]}
+            onPress={handleConfirm}
+          >
+            <Text style={[styles.confirmBtnText, { color: colors.buttonText }]}>Add Poll</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  sheet: {
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    borderWidth: 1,
+    maxHeight: '85%',
+    paddingBottom: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ccc',
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  body: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    marginBottom: 6,
+    marginTop: 14,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+  },
+  choiceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
+  choiceInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    fontSize: 14,
+  },
+  removeChoiceBtn: {
+    padding: 4,
+  },
+  addChoiceBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderWidth: 1,
+    borderRadius: 8,
+    borderStyle: 'dashed',
+    paddingVertical: 9,
+    paddingHorizontal: 14,
+    alignSelf: 'flex-start',
+    marginTop: 4,
+  },
+  addChoiceText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  durationRow: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  durationBtn: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  durationBtnText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 14,
+  },
+  toggleLabel: {
+    fontSize: 14,
+  },
+  errorText: {
+    fontSize: 13,
+    marginTop: 12,
+  },
+  confirmBtn: {
+    marginHorizontal: 16,
+    marginTop: 16,
+    borderRadius: 10,
+    paddingVertical: 13,
+    alignItems: 'center',
+  },
+  confirmBtnText: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/app/components/PollWidget.tsx
+++ b/app/components/PollWidget.tsx
@@ -69,23 +69,30 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
     voted ||
     (!poll.ui_hide_res_until_voted && results !== null);
 
-  const totalVotes = results?.total_votes ?? 0;
+  // Total votes: prefer poll_stats, fall back to voters length
+  const totalVotes =
+    results?.poll_stats?.total_voting_accounts_num ??
+    (results?.poll_voters?.length ?? 0);
 
+  // choice_num in the API is 1-based (index + 1)
   const getVotesForChoice = (choiceIndex: number): number => {
-    return results?.choices?.find((c) => c.choice_num === choiceIndex)?.votes ?? 0;
+    const choiceNum = choiceIndex + 1;
+    const apiChoice = results?.poll_choices?.find((c) => c.choice_num === choiceNum);
+    return apiChoice?.votes?.total_votes ?? 0;
   };
 
   const toggleChoice = (index: number) => {
+    const choiceNum = index + 1; // convert to 1-based for Hive
     if (isMultiChoice) {
       setSelectedChoices((prev) =>
-        prev.includes(index)
-          ? prev.filter((c) => c !== index)
+        prev.includes(choiceNum)
+          ? prev.filter((c) => c !== choiceNum)
           : prev.length < poll.max_choices_voted
-          ? [...prev, index]
+          ? [...prev, choiceNum]
           : prev
       );
     } else {
-      setSelectedChoices([index]);
+      setSelectedChoices([choiceNum]);
     }
   };
 
@@ -110,9 +117,10 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
       {/* Choices */}
       <View style={styles.choices}>
         {poll.choices.map((choice, index) => {
+          const choiceNum = index + 1; // 1-based
           const votes = getVotesForChoice(index);
           const pct = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
-          const isSelected = selectedChoices.includes(index) || userChoices.includes(index);
+          const isSelected = selectedChoices.includes(choiceNum) || userChoices.includes(choiceNum);
 
           if (showResults) {
             return (
@@ -122,14 +130,14 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
                     styles.resultBar,
                     {
                       width: `${pct}%`,
-                      backgroundColor: userChoices.includes(index)
+                      backgroundColor: userChoices.includes(choiceNum)
                         ? colors.button + '33'
                         : colors.border,
                     },
                   ]}
                 />
                 <Text style={[styles.choiceLabel, { color: colors.text }]} numberOfLines={1}>
-                  {userChoices.includes(index) ? '✓ ' : ''}{choice}
+                  {userChoices.includes(choiceNum) ? '✓ ' : ''}{choice}
                 </Text>
                 <Text style={[styles.pctLabel, { color: colors.textSecondary }]}>
                   {pct}%

--- a/app/components/PollWidget.tsx
+++ b/app/components/PollWidget.tsx
@@ -72,7 +72,7 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
   const totalVotes = results?.total_votes ?? 0;
 
   const getVotesForChoice = (choiceIndex: number): number => {
-    return results?.choices.find((c) => c.choice_num === choiceIndex)?.votes ?? 0;
+    return results?.choices?.find((c) => c.choice_num === choiceIndex)?.votes ?? 0;
   };
 
   const toggleChoice = (index: number) => {

--- a/app/components/PollWidget.tsx
+++ b/app/components/PollWidget.tsx
@@ -64,10 +64,13 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
   const isExpired = poll.end_time * 1000 <= Date.now();
   const timeLabel = formatTimeLeft(poll.end_time);
 
-  const showResults =
+  // showPercentages: display result bars and % alongside choices (public polls show this immediately)
+  // controlsEnabled: whether the user can still select choices and vote
+  const showPercentages =
     isExpired ||
     voted ||
     (!poll.ui_hide_res_until_voted && results !== null);
+  const controlsEnabled = !isExpired && !voted;
 
   // Total votes: prefer poll_stats, fall back to voters length
   const totalVotes =
@@ -81,7 +84,8 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
     return apiChoice?.votes?.total_votes ?? 0;
   };
 
-  const toggleChoice = (index: number) => {
+  const toggleChoice = (index: number): void => {
+    if (keyInputVisible) return; // Lock selection once key entry is shown
     const choiceNum = index + 1; // convert to 1-based for Hive
     if (isMultiChoice) {
       setSelectedChoices((prev) =>
@@ -96,7 +100,7 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
     }
   };
 
-  const handleVote = async () => {
+  const handleVote = async (): Promise<void> => {
     if (keyInputVisible) {
       await vote([]);
     } else if (selectedChoices.length > 0) {
@@ -121,8 +125,10 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
           const votes = getVotesForChoice(index);
           const pct = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
           const isSelected = selectedChoices.includes(choiceNum) || userChoices.includes(choiceNum);
+          const isUserVote = userChoices.includes(choiceNum);
 
-          if (showResults) {
+          if (!controlsEnabled) {
+            // Expired or already voted: show results-only view (no interactive controls)
             return (
               <View key={index} style={[styles.resultRow, { borderColor: colors.border }]}>
                 <View
@@ -130,14 +136,12 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
                     styles.resultBar,
                     {
                       width: `${pct}%`,
-                      backgroundColor: userChoices.includes(choiceNum)
-                        ? colors.button + '33'
-                        : colors.border,
+                      backgroundColor: isUserVote ? colors.button + '33' : colors.border,
                     },
                   ]}
                 />
                 <Text style={[styles.choiceLabel, { color: colors.text }]} numberOfLines={1}>
-                  {userChoices.includes(choiceNum) ? '✓ ' : ''}{choice}
+                  {isUserVote ? '✓ ' : ''}{choice}
                 </Text>
                 <Text style={[styles.pctLabel, { color: colors.textSecondary }]}>
                   {pct}%
@@ -146,6 +150,7 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
             );
           }
 
+          // Active poll: show selectable rows, optionally with percentage overlay
           return (
             <TouchableOpacity
               key={index}
@@ -157,10 +162,26 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
                 },
               ]}
               onPress={() => toggleChoice(index)}
-              disabled={voting}
+              disabled={voting || keyInputVisible}
             >
+              {showPercentages && (
+                <View
+                  style={[
+                    styles.resultBar,
+                    {
+                      width: `${pct}%`,
+                      backgroundColor: colors.border,
+                    },
+                  ]}
+                />
+              )}
               <Text style={[styles.choiceLabel, { color: colors.text }]}>{choice}</Text>
-              {isSelected && (
+              {showPercentages && (
+                <Text style={[styles.pctLabel, { color: colors.textSecondary }]}>
+                  {pct}%
+                </Text>
+              )}
+              {isSelected && !showPercentages && (
                 <Text style={[styles.checkmark, { color: colors.button }]}>✓</Text>
               )}
             </TouchableOpacity>
@@ -195,7 +216,7 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
       {/* Vote button / loading / stats */}
       {loading && !results ? (
         <ActivityIndicator size="small" color={colors.button} style={{ marginTop: 8 }} />
-      ) : !isExpired && !voted && currentUsername ? (
+      ) : controlsEnabled && currentUsername ? (
         <TouchableOpacity
           style={[
             styles.voteButton,

--- a/app/components/PollWidget.tsx
+++ b/app/components/PollWidget.tsx
@@ -1,0 +1,323 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  TextInput,
+  ActivityIndicator,
+} from 'react-native';
+import type { PollMetadata } from '../../utils/pollDetection';
+import { usePoll } from '../../hooks/usePoll';
+
+interface PollWidgetProps {
+  poll: PollMetadata;
+  author: string;
+  permlink: string;
+  currentUsername: string | null;
+  colors: {
+    text: string;
+    textSecondary: string;
+    bubble: string;
+    border: string;
+    button: string;
+    buttonText: string;
+    buttonInactive: string;
+    payout: string;
+  };
+}
+
+function formatTimeLeft(endTime: string): string {
+  const diff = new Date(endTime).getTime() - Date.now();
+  if (diff <= 0) return 'Poll ended';
+  const days = Math.floor(diff / 86400000);
+  const hours = Math.floor((diff % 86400000) / 3600000);
+  if (days > 0) return `${days}d ${hours}h left`;
+  const mins = Math.floor((diff % 3600000) / 60000);
+  if (hours > 0) return `${hours}h ${mins}m left`;
+  return `${mins}m left`;
+}
+
+export const PollWidget: React.FC<PollWidgetProps> = ({
+  poll,
+  author,
+  permlink,
+  currentUsername,
+  colors,
+}) => {
+  const {
+    results,
+    loading,
+    error,
+    voted,
+    userChoices,
+    voting,
+    voteError,
+    keyInputVisible,
+    keyInput,
+    setKeyInput,
+    vote,
+  } = usePoll(author, permlink, currentUsername);
+
+  const [selectedChoices, setSelectedChoices] = useState<number[]>([]);
+  const isMultiChoice = poll.max_choices_voted > 1;
+  const isExpired = new Date(poll.end_time).getTime() <= Date.now();
+  const timeLabel = formatTimeLeft(poll.end_time);
+
+  const showResults =
+    isExpired ||
+    voted ||
+    (!poll.ui_hide_res_until_voted && results !== null);
+
+  const totalVotes = results?.total_votes ?? 0;
+
+  const getVotesForChoice = (choiceIndex: number): number => {
+    return results?.choices.find((c) => c.choice_num === choiceIndex)?.votes ?? 0;
+  };
+
+  const toggleChoice = (index: number) => {
+    if (isMultiChoice) {
+      setSelectedChoices((prev) =>
+        prev.includes(index)
+          ? prev.filter((c) => c !== index)
+          : prev.length < poll.max_choices_voted
+          ? [...prev, index]
+          : prev
+      );
+    } else {
+      setSelectedChoices([index]);
+    }
+  };
+
+  const handleVote = async () => {
+    if (keyInputVisible) {
+      await vote([]);
+    } else if (selectedChoices.length > 0) {
+      await vote(selectedChoices);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bubble, borderColor: colors.border }]}>
+      {/* Question */}
+      <Text style={[styles.question, { color: colors.text }]}>{poll.question}</Text>
+
+      {/* Time label */}
+      <Text style={[styles.timeLabel, { color: isExpired ? colors.textSecondary : colors.payout }]}>
+        {timeLabel}
+      </Text>
+
+      {/* Choices */}
+      <View style={styles.choices}>
+        {poll.choices.map((choice, index) => {
+          const votes = getVotesForChoice(index);
+          const pct = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
+          const isSelected = selectedChoices.includes(index) || userChoices.includes(index);
+
+          if (showResults) {
+            return (
+              <View key={index} style={[styles.resultRow, { borderColor: colors.border }]}>
+                <View
+                  style={[
+                    styles.resultBar,
+                    {
+                      width: `${pct}%`,
+                      backgroundColor: userChoices.includes(index)
+                        ? colors.button + '33'
+                        : colors.border,
+                    },
+                  ]}
+                />
+                <Text style={[styles.choiceLabel, { color: colors.text }]} numberOfLines={1}>
+                  {userChoices.includes(index) ? '✓ ' : ''}{choice}
+                </Text>
+                <Text style={[styles.pctLabel, { color: colors.textSecondary }]}>
+                  {pct}%
+                </Text>
+              </View>
+            );
+          }
+
+          return (
+            <TouchableOpacity
+              key={index}
+              style={[
+                styles.choiceButton,
+                {
+                  borderColor: isSelected ? colors.button : colors.border,
+                  backgroundColor: isSelected ? colors.button + '22' : 'transparent',
+                },
+              ]}
+              onPress={() => toggleChoice(index)}
+              disabled={voting}
+            >
+              <Text style={[styles.choiceLabel, { color: colors.text }]}>{choice}</Text>
+              {isSelected && (
+                <Text style={[styles.checkmark, { color: colors.button }]}>✓</Text>
+              )}
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {/* Inline key input */}
+      {keyInputVisible && (
+        <View style={styles.keySection}>
+          <Text style={[styles.keyHint, { color: colors.textSecondary }]}>
+            Enter your posting key to vote:
+          </Text>
+          <TextInput
+            style={[styles.keyInput, { borderColor: colors.border, color: colors.text, backgroundColor: colors.bubble }]}
+            value={keyInput}
+            onChangeText={setKeyInput}
+            placeholder="5K... posting key"
+            placeholderTextColor={colors.textSecondary}
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+      )}
+
+      {/* Errors */}
+      {(error || voteError) && (
+        <Text style={styles.errorText}>{voteError || error}</Text>
+      )}
+
+      {/* Vote button / loading / stats */}
+      {loading && !results ? (
+        <ActivityIndicator size="small" color={colors.button} style={{ marginTop: 8 }} />
+      ) : !isExpired && !voted && currentUsername ? (
+        <TouchableOpacity
+          style={[
+            styles.voteButton,
+            {
+              backgroundColor:
+                (keyInputVisible ? keyInput.trim().length > 0 : selectedChoices.length > 0)
+                  ? colors.button
+                  : colors.buttonInactive,
+            },
+          ]}
+          onPress={handleVote}
+          disabled={
+            voting ||
+            (keyInputVisible ? keyInput.trim().length === 0 : selectedChoices.length === 0)
+          }
+        >
+          {voting ? (
+            <ActivityIndicator size="small" color={colors.buttonText} />
+          ) : (
+            <Text style={[styles.voteButtonText, { color: colors.buttonText }]}>
+              {keyInputVisible ? 'Submit Vote' : 'Vote'}
+            </Text>
+          )}
+        </TouchableOpacity>
+      ) : null}
+
+      {/* Vote count */}
+      {totalVotes > 0 && (
+        <Text style={[styles.voteCount, { color: colors.textSecondary }]}>
+          {totalVotes} vote{totalVotes !== 1 ? 's' : ''}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 10,
+  },
+  question: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: 4,
+    lineHeight: 21,
+  },
+  timeLabel: {
+    fontSize: 12,
+    marginBottom: 12,
+  },
+  choices: {
+    gap: 8,
+  },
+  choiceButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  choiceLabel: {
+    fontSize: 14,
+    flex: 1,
+  },
+  checkmark: {
+    fontSize: 14,
+    fontWeight: '700',
+    marginLeft: 6,
+  },
+  resultRow: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    overflow: 'hidden',
+    position: 'relative',
+    minHeight: 40,
+  },
+  resultBar: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    borderRadius: 7,
+  },
+  pctLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    minWidth: 36,
+    textAlign: 'right',
+  },
+  keySection: {
+    marginTop: 10,
+    gap: 6,
+  },
+  keyHint: {
+    fontSize: 12,
+  },
+  keyInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+  },
+  errorText: {
+    color: '#E74C3C',
+    fontSize: 12,
+    marginTop: 8,
+  },
+  voteButton: {
+    marginTop: 12,
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  voteButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  voteCount: {
+    fontSize: 12,
+    marginTop: 8,
+    textAlign: 'right',
+  },
+});

--- a/app/components/PollWidget.tsx
+++ b/app/components/PollWidget.tsx
@@ -27,8 +27,8 @@ interface PollWidgetProps {
   };
 }
 
-function formatTimeLeft(endTime: string): string {
-  const diff = new Date(endTime).getTime() - Date.now();
+function formatTimeLeft(endTimeSeconds: number): string {
+  const diff = endTimeSeconds * 1000 - Date.now();
   if (diff <= 0) return 'Poll ended';
   const days = Math.floor(diff / 86400000);
   const hours = Math.floor((diff % 86400000) / 3600000);
@@ -61,7 +61,7 @@ export const PollWidget: React.FC<PollWidgetProps> = ({
 
   const [selectedChoices, setSelectedChoices] = useState<number[]>([]);
   const isMultiChoice = poll.max_choices_voted > 1;
-  const isExpired = new Date(poll.end_time).getTime() <= Date.now();
+  const isExpired = poll.end_time * 1000 <= Date.now();
   const timeLabel = formatTimeLeft(poll.end_time);
 
   const showResults =

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -53,6 +53,8 @@ import { useAppColors } from '../styles/colors';
 import { submitReport, mapUiReasonToApi } from '../../services/reportService';
 import { SnapData } from '../../hooks/useConversationData';
 import { wasPostedViaHiveSnaps } from '../../utils/appDetection';
+import { extractPoll } from '../../utils/pollDetection';
+import { PollWidget } from './PollWidget';
 import { preprocessForMarkdown } from '../../utils/htmlPreprocessing';
 import { renderHiveToHtml } from '../../utils/renderHive';
 import { linkifyMentions } from '../../utils/linkifyMentions';
@@ -216,6 +218,7 @@ const Snap: React.FC<SnapProps> = ({
   const mediaInfo = detectMediaInBody(body); // Detect audio and video media
   const hivePostUrls = extractBlogPostUrls(body); // Extract Hive post URLs for previews
   const hangoutRoomNames = useMemo(() => [...new Set(extractHangoutRoomNames(body))], [body]);
+  const pollData = extractPoll(snap.json_metadata ?? '{}');
   const router = useRouter(); // For navigation in reply mode
 
   // Calculate indentation and content width for replies
@@ -1136,6 +1139,28 @@ const Snap: React.FC<SnapProps> = ({
                 </Text>
               </TouchableOpacity>
             )}
+          </View>
+        )}
+
+        {/* Poll Widget */}
+        {pollData && (
+          <View style={{ marginTop: 8 }}>
+            <PollWidget
+              poll={pollData}
+              author={snap.author}
+              permlink={snap.permlink ?? ''}
+              currentUsername={currentUsername ?? null}
+              colors={{
+                text: colors.text,
+                textSecondary: colors.textSecondary,
+                bubble: colors.bubble,
+                border: colors.border,
+                button: colors.button,
+                buttonText: colors.buttonText,
+                buttonInactive: colors.buttonInactive,
+                payout: colors.payout,
+              }}
+            />
           </View>
         )}
 

--- a/app/screens/ComposeScreen.styles.ts
+++ b/app/screens/ComposeScreen.styles.ts
@@ -270,4 +270,19 @@ export const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
   },
+  pollChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginHorizontal: 16,
+    marginBottom: 8,
+  },
+  pollChipText: {
+    flex: 1,
+    fontSize: 13,
+  },
 });

--- a/app/screens/ComposeScreen.tsx
+++ b/app/screens/ComposeScreen.tsx
@@ -31,6 +31,7 @@ import { useCompose } from '../../hooks/useCompose';
 import AudioRecorderModal from '../components/AudioRecorderModal';
 import AudioPreview from '../components/AudioPreview';
 import ProgressBar from '../components/ProgressBar';
+import { PollCreatorModal } from '../components/PollCreatorModal';
 import { getTheme } from '../../constants/Colors';
 import { styles } from './ComposeScreen.styles';
 
@@ -67,6 +68,7 @@ export default function ComposeScreen() {
   // UI-only refs
   const textInputRef = useRef<TextInput>(null);
   const [avatarError, setAvatarError] = useState(false);
+  const [pollModalVisible, setPollModalVisible] = useState(false);
 
   // Reset avatar error whenever the URL changes (e.g. avatarService resolves a new URL)
   useEffect(() => { setAvatarError(false); }, [compose.state.avatarUrl]);
@@ -692,6 +694,22 @@ export default function ComposeScreen() {
             />
           )}
 
+          {/* Poll Preview Chip */}
+          {compose.state.poll && (
+            <View style={[styles.pollChip, { backgroundColor: colors.inputBg, borderColor: colors.inputBorder }]}>
+              <FontAwesome name="bar-chart" size={14} color={colors.button} />
+              <Text style={[styles.pollChipText, { color: colors.text }]} numberOfLines={1}>
+                Poll: {compose.state.poll.question}
+              </Text>
+              <TouchableOpacity
+                onPress={() => compose.setPoll(null)}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <FontAwesome name="times" size={14} color={colors.info} />
+              </TouchableOpacity>
+            </View>
+          )}
+
           {/* Action buttons */}
           <View style={styles.actions}>
             {/* Markdown formatting toolbar */}
@@ -896,6 +914,37 @@ export default function ComposeScreen() {
                   {compose.state.audioEmbedUrl ? '1' : '0'}/1
                 </Text>
               </View>
+
+              {/* Poll button — only for new top-level posts */}
+              {mode === 'compose' && (
+                <View style={styles.mediaButtonWrapper}>
+                  <TouchableOpacity
+                    style={[
+                      styles.actionButton,
+                      { backgroundColor: colors.inputBg, marginLeft: 12 },
+                    ]}
+                    onPress={() => setPollModalVisible(true)}
+                    disabled={compose.state.poll !== null}
+                    accessibilityLabel={compose.state.poll ? 'Poll already added' : 'Add poll'}
+                  >
+                    <FontAwesome
+                      name="bar-chart"
+                      size={20}
+                      color={compose.state.poll !== null ? colors.info : colors.button}
+                    />
+                    {compose.state.poll !== null && (
+                      <View style={[styles.imageBadge, { backgroundColor: colors.button }]}>
+                        <Text style={styles.imageBadgeText}>1</Text>
+                      </View>
+                    )}
+                  </TouchableOpacity>
+                  <Text
+                    style={[styles.buttonLabel, { color: compose.state.poll ? colors.info : colors.text }]}
+                  >
+                    Poll
+                  </Text>
+                </View>
+              )}
             </View>
 
             {compose.state.images.length === 0 && !compose.state.uploading && (
@@ -1061,6 +1110,28 @@ export default function ComposeScreen() {
           background: colors.background,
           text: colors.text,
           inputBorder: colors.inputBorder,
+        }}
+      />
+
+      {/* Poll Creator Modal */}
+      <PollCreatorModal
+        visible={pollModalVisible}
+        onClose={() => setPollModalVisible(false)}
+        onConfirm={(poll) => {
+          compose.setPoll(poll);
+          setPollModalVisible(false);
+        }}
+        colors={{
+          background: colors.background,
+          text: colors.text,
+          textSecondary: colors.info,
+          inputBg: colors.inputBg,
+          inputBorder: colors.inputBorder,
+          button: colors.button,
+          buttonText: colors.buttonText,
+          buttonInactive: colors.buttonInactive,
+          error: colors.error,
+          warning: colors.warning,
         }}
       />
     </SafeAreaView>

--- a/app/screens/HivePostScreen.tsx
+++ b/app/screens/HivePostScreen.tsx
@@ -20,6 +20,8 @@ import { Image as ExpoImage } from 'expo-image';
 import PostBody from '../components/PostBody';
 import AudioEmbed from '../components/AudioEmbed';
 import { detectMediaInBody } from '../../utils/mediaDetection';
+import { extractPoll } from '../../utils/pollDetection';
+import { PollWidget } from '../components/PollWidget';
 import { Dimensions } from 'react-native';
 import { useCurrentUser } from '../../store/context';
 import { useUpvote } from '../../hooks/useUpvote';
@@ -146,6 +148,8 @@ const HivePostScreen = () => {
   const colors = {
     background: theme.background,
     text: theme.text,
+    textSecondary: theme.textSecondary,
+    bubble: theme.bubble,
     border: theme.border,
     icon: theme.textSecondary,
     button: theme.button,
@@ -157,6 +161,7 @@ const HivePostScreen = () => {
   const windowWidth = Dimensions.get('window').width;
 
   const postMediaInfo = useMemo(() => detectMediaInBody(post?.body ?? ''), [post?.body]);
+  const postPollData = useMemo(() => extractPoll(post?.json_metadata ?? '{}'), [post?.json_metadata]);
 
   // Filter comments to exclude muted users (includes personal mutes + global blacklist)
   const filteredComments = useMemo(() => {
@@ -403,6 +408,19 @@ const HivePostScreen = () => {
 
         {/* Content */}
         <PostBody body={post.body} colors={colors} isDark={isDark} />
+
+        {/* Poll Widget */}
+        {postPollData && author && permlink ? (
+          <View style={{ marginTop: 12, marginBottom: 4 }}>
+            <PollWidget
+              poll={postPollData}
+              author={author}
+              permlink={permlink}
+              currentUsername={currentUsername ?? null}
+              colors={colors}
+            />
+          </View>
+        ) : null}
 
         {/* Tags */}
         {post.tags && post.tags.length > 0 && (

--- a/hooks/useCompose.ts
+++ b/hooks/useCompose.ts
@@ -530,7 +530,7 @@ export function useCompose({
         dispatch({ type: 'CLEAR_AUDIO' });
     }, []);
 
-    const setPoll = useCallback((poll: PollDraft | null) => {
+    const setPoll = useCallback((poll: PollDraft | null): void => {
         dispatch({ type: 'SET_POLL', payload: poll });
     }, []);
 
@@ -542,9 +542,10 @@ export function useCompose({
             state.images.length > 0 ||
             state.gifs.length > 0 ||
             video.videoEmbedUrl ||
-            state.audioEmbedUrl
+            state.audioEmbedUrl ||
+            state.poll
         );
-    }, [state.text, state.images.length, state.gifs.length, video.videoEmbedUrl, state.audioEmbedUrl]);
+    }, [state.text, state.images.length, state.gifs.length, video.videoEmbedUrl, state.audioEmbedUrl, state.poll]);
 
     const hasDraftContent = useMemo(() => {
         return Boolean(
@@ -553,9 +554,10 @@ export function useCompose({
             state.gifs.length > 0 ||
             video.hasVideo ||
             state.audioEmbedUrl ||
-            state.audioUploading
+            state.audioUploading ||
+            state.poll
         );
-    }, [state.text, state.images.length, state.gifs.length, video.hasVideo, state.audioEmbedUrl, state.audioUploading]);
+    }, [state.text, state.images.length, state.gifs.length, video.hasVideo, state.audioEmbedUrl, state.audioUploading, state.poll]);
 
     const isSubmitting = useMemo(() => {
         return state.posting || reply.posting || edit.editing || video.uploading || state.audioUploading;

--- a/hooks/useCompose.ts
+++ b/hooks/useCompose.ts
@@ -715,7 +715,7 @@ export function useCompose({
                     content_type: 'poll',
                     question: state.poll.question,
                     choices: state.poll.choices,
-                    end_time: new Date(Date.now() + state.poll.durationDays * 86400000).toISOString(),
+                    end_time: Math.floor((Date.now() + state.poll.durationDays * 86400000) / 1000),
                     max_choices_voted: state.poll.maxChoicesVoted,
                     allow_vote_changes: state.poll.allowVoteChanges,
                     ui_hide_res_until_voted: state.poll.hideResultsUntilVoted,

--- a/hooks/useCompose.ts
+++ b/hooks/useCompose.ts
@@ -713,12 +713,15 @@ export function useCompose({
             const pollMeta = state.poll
                 ? {
                     content_type: 'poll',
+                    version: 0.8,
                     question: state.poll.question,
                     choices: state.poll.choices,
                     end_time: Math.floor((Date.now() + state.poll.durationDays * 86400000) / 1000),
                     max_choices_voted: state.poll.maxChoicesVoted,
                     allow_vote_changes: state.poll.allowVoteChanges,
                     ui_hide_res_until_voted: state.poll.hideResultsUntilVoted,
+                    preferred_interpretation: 'number_of_votes',
+                    filters: { account_age: 0 },
                 }
                 : {};
             const json_metadata = JSON.stringify({

--- a/hooks/useCompose.ts
+++ b/hooks/useCompose.ts
@@ -14,6 +14,7 @@ import { useReply } from './useReply';
 import { useEdit } from './useEdit';
 import { useGifPicker } from './useGifPickerV2';
 import { uploadAudioTo3Speak } from '../services/audioUploadService';
+import type { PollDraft } from '../utils/pollDetection';
 
 const client = getClient();
 
@@ -42,6 +43,9 @@ interface ComposeState {
     selectionStart: number;
     selectionEnd: number;
 
+    // Poll
+    poll: PollDraft | null;
+
     // User
     currentUsername: string | null;
     avatarUrl: string | null;
@@ -66,6 +70,7 @@ type ComposeAction =
     | { type: 'SET_PREVIEW_VISIBLE'; payload: boolean }
     | { type: 'SET_SELECTION'; payload: { start: number; end: number } }
     | { type: 'SET_USER'; payload: { username: string | null; avatarUrl: string | null } }
+    | { type: 'SET_POLL'; payload: PollDraft | null }
     | { type: 'CLEAR_FORM' };
 
 const initialState: ComposeState = {
@@ -83,6 +88,7 @@ const initialState: ComposeState = {
     previewVisible: false,
     selectionStart: 0,
     selectionEnd: 0,
+    poll: null,
     currentUsername: null,
     avatarUrl: null,
 };
@@ -137,6 +143,8 @@ function composeReducer(state: ComposeState, action: ComposeAction): ComposeStat
                 currentUsername: action.payload.username,
                 avatarUrl: action.payload.avatarUrl,
             };
+        case 'SET_POLL':
+            return { ...state, poll: action.payload };
         case 'CLEAR_FORM':
             return {
                 ...state,
@@ -149,6 +157,7 @@ function composeReducer(state: ComposeState, action: ComposeAction): ComposeStat
                 audioRecorderVisible: false,
                 spoilerModalVisible: false,
                 previewVisible: false,
+                poll: null,
             };
         default:
             return state;
@@ -521,6 +530,10 @@ export function useCompose({
         dispatch({ type: 'CLEAR_AUDIO' });
     }, []);
 
+    const setPoll = useCallback((poll: PollDraft | null) => {
+        dispatch({ type: 'SET_POLL', payload: poll });
+    }, []);
+
     // ===== Validation =====
 
     const hasPostableContent = useMemo(() => {
@@ -697,6 +710,17 @@ export function useCompose({
             const permlink = `snap-${Date.now()}`;
 
             const allMedia = [...state.images, ...state.gifs];
+            const pollMeta = state.poll
+                ? {
+                    content_type: 'poll',
+                    question: state.poll.question,
+                    choices: state.poll.choices,
+                    end_time: new Date(Date.now() + state.poll.durationDays * 86400000).toISOString(),
+                    max_choices_voted: state.poll.maxChoicesVoted,
+                    allow_vote_changes: state.poll.allowVoteChanges,
+                    ui_hide_res_until_voted: state.poll.hideResultsUntilVoted,
+                }
+                : {};
             const json_metadata = JSON.stringify({
                 app: 'hivesnaps/1.0',
                 tags: ['hive-178315', 'snaps'],
@@ -711,6 +735,7 @@ export function useCompose({
                         duration: state.audioDuration
                     }
                     : undefined,
+                ...pollMeta,
             });
 
             await postSnapWithBeneficiaries(
@@ -799,6 +824,7 @@ export function useCompose({
             closeAudioRecorder,
             handleAudioRecorded,
             removeAudio,
+            setPoll,
             submit,
         }),
         [
@@ -827,6 +853,7 @@ export function useCompose({
             closeAudioRecorder,
             handleAudioRecorded,
             removeAudio,
+            setPoll,
             submit,
         ]
     );

--- a/hooks/usePoll.ts
+++ b/hooks/usePoll.ts
@@ -57,13 +57,15 @@ export function usePoll(
     void loadResults();
   }, [loadResults]);
 
+  const currentUserLower = currentUsername?.toLowerCase() ?? '';
+
   const voted = !!(
     currentUsername &&
-    results?.voters?.some((v) => v.voter === currentUsername)
+    results?.poll_voters?.some((v) => v.name?.toLowerCase() === currentUserLower)
   );
 
   const userChoices: number[] = currentUsername
-    ? (results?.voters?.find((v) => v.voter === currentUsername)?.choices ?? [])
+    ? (results?.poll_voters?.find((v) => v.name?.toLowerCase() === currentUserLower)?.choices ?? [])
     : [];
 
   const castVote = useCallback(async (choices: number[], keyStr: string) => {

--- a/hooks/usePoll.ts
+++ b/hooks/usePoll.ts
@@ -31,6 +31,7 @@ export function usePoll(
   const [keyInput, setKeyInput] = useState('');
   const pendingChoicesRef = useRef<number[] | null>(null);
   const isMountedRef = useRef(true);
+  const loadRequestIdRef = useRef(0);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -39,17 +40,18 @@ export function usePoll(
 
   const loadResults = useCallback(async () => {
     if (!isMountedRef.current) return;
+    const requestId = ++loadRequestIdRef.current;
     setLoading(true);
     setError(null);
     try {
       const data = await fetchPollResults(author, permlink);
-      if (isMountedRef.current) setResults(data);
+      if (isMountedRef.current && loadRequestIdRef.current === requestId) setResults(data);
     } catch (err) {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && loadRequestIdRef.current === requestId) {
         setError(err instanceof Error ? err.message : 'Failed to load poll results');
       }
     } finally {
-      if (isMountedRef.current) setLoading(false);
+      if (isMountedRef.current && loadRequestIdRef.current === requestId) setLoading(false);
     }
   }, [author, permlink]);
 
@@ -86,6 +88,7 @@ export function usePoll(
     } catch (err) {
       if (isMountedRef.current) {
         setVoteError(err instanceof Error ? err.message : 'Vote failed');
+        setKeyInput(''); // Clear key from memory on error
       }
     } finally {
       if (isMountedRef.current) setVoting(false);
@@ -118,16 +121,11 @@ export function usePoll(
   }, [currentUsername, castVote]);
 
   // Called from PollWidget when user submits inline key
-  const voteWithInlineKey = useCallback(async () => {
+  const voteWithInlineKey = useCallback(async (): Promise<void> => {
     const choices = pendingChoicesRef.current;
     if (!choices || !keyInput.trim()) return;
     await castVote(choices, keyInput);
   }, [keyInput, castVote]);
-
-  // Override setKeyInput to also handle submission trigger
-  const handleSetKeyInput = useCallback((val: string) => {
-    setKeyInput(val);
-  }, []);
 
   return {
     results,
@@ -139,8 +137,8 @@ export function usePoll(
     voteError,
     keyInputVisible,
     keyInput,
-    setKeyInput: handleSetKeyInput,
-    vote: async (choices) => {
+    setKeyInput,
+    vote: async (choices: number[]): Promise<void> => {
       // If key input visible, treat as submission with current keyInput
       if (keyInputVisible) {
         await voteWithInlineKey();

--- a/hooks/usePoll.ts
+++ b/hooks/usePoll.ts
@@ -1,0 +1,150 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { accountStorageService } from '../services/AccountStorageService';
+import { localAuthService, AuthCancelledError } from '../services/LocalAuthService';
+import { fetchPollResults, votePoll, PollResults } from '../services/PollService';
+
+export interface UsePollResult {
+  results: PollResults | null;
+  loading: boolean;
+  error: string | null;
+  voted: boolean;
+  userChoices: number[];
+  voting: boolean;
+  voteError: string | null;
+  keyInputVisible: boolean;
+  keyInput: string;
+  setKeyInput: (val: string) => void;
+  vote: (choices: number[]) => Promise<void>;
+}
+
+export function usePoll(
+  author: string,
+  permlink: string,
+  currentUsername: string | null
+): UsePollResult {
+  const [results, setResults] = useState<PollResults | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [voting, setVoting] = useState(false);
+  const [voteError, setVoteError] = useState<string | null>(null);
+  const [keyInputVisible, setKeyInputVisible] = useState(false);
+  const [keyInput, setKeyInput] = useState('');
+  const pendingChoicesRef = useRef<number[] | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
+
+  const loadResults = useCallback(async () => {
+    if (!isMountedRef.current) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchPollResults(author, permlink);
+      if (isMountedRef.current) setResults(data);
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to load poll results');
+      }
+    } finally {
+      if (isMountedRef.current) setLoading(false);
+    }
+  }, [author, permlink]);
+
+  useEffect(() => {
+    void loadResults();
+  }, [loadResults]);
+
+  const voted = !!(
+    currentUsername &&
+    results?.voters?.some((v) => v.voter === currentUsername)
+  );
+
+  const userChoices: number[] = currentUsername
+    ? (results?.voters?.find((v) => v.voter === currentUsername)?.choices ?? [])
+    : [];
+
+  const castVote = useCallback(async (choices: number[], keyStr: string) => {
+    if (!currentUsername) return;
+    if (!isMountedRef.current) return;
+    setVoting(true);
+    setVoteError(null);
+    try {
+      await votePoll(currentUsername, author, permlink, choices, keyStr);
+      // Refetch after a short delay for the node to process
+      await new Promise((r) => setTimeout(r, 2000));
+      await loadResults();
+      if (isMountedRef.current) {
+        setKeyInputVisible(false);
+        setKeyInput('');
+        pendingChoicesRef.current = null;
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setVoteError(err instanceof Error ? err.message : 'Vote failed');
+      }
+    } finally {
+      if (isMountedRef.current) setVoting(false);
+    }
+  }, [currentUsername, author, permlink, loadResults]);
+
+  const vote = useCallback(async (choices: number[]) => {
+    if (!currentUsername) return;
+    setVoteError(null);
+
+    // Try stored posting key + biometrics first
+    try {
+      const keys = await accountStorageService.getAccountKeys(currentUsername);
+      if (keys?.postingKey) {
+        const biometricAvailable = await localAuthService.isAvailable();
+        if (biometricAvailable) {
+          await localAuthService.authenticate();
+          await castVote(choices, keys.postingKey);
+          return;
+        }
+      }
+    } catch (err) {
+      if (err instanceof AuthCancelledError) return;
+      // Fall through to manual key entry
+    }
+
+    // No stored key (or biometric not available) — show inline key input
+    pendingChoicesRef.current = choices;
+    if (isMountedRef.current) setKeyInputVisible(true);
+  }, [currentUsername, castVote]);
+
+  // Called from PollWidget when user submits inline key
+  const voteWithInlineKey = useCallback(async () => {
+    const choices = pendingChoicesRef.current;
+    if (!choices || !keyInput.trim()) return;
+    await castVote(choices, keyInput);
+  }, [keyInput, castVote]);
+
+  // Override setKeyInput to also handle submission trigger
+  const handleSetKeyInput = useCallback((val: string) => {
+    setKeyInput(val);
+  }, []);
+
+  return {
+    results,
+    loading,
+    error,
+    voted,
+    userChoices,
+    voting,
+    voteError,
+    keyInputVisible,
+    keyInput,
+    setKeyInput: handleSetKeyInput,
+    vote: async (choices) => {
+      // If key input visible, treat as submission with current keyInput
+      if (keyInputVisible) {
+        await voteWithInlineKey();
+      } else {
+        await vote(choices);
+      }
+    },
+  };
+}

--- a/services/PollService.ts
+++ b/services/PollService.ts
@@ -1,0 +1,52 @@
+import { PrivateKey } from '@hiveio/dhive';
+import { getClient } from './HiveClient';
+
+export interface PollChoiceResult {
+  choice_num: number;
+  votes: number;
+  hive_hp_incl_proxied?: number;
+}
+
+export interface PollVoter {
+  voter: string;
+  choices: number[];
+}
+
+export interface PollResults {
+  total_votes: number;
+  choices: PollChoiceResult[];
+  voters?: PollVoter[];
+}
+
+const HIVEHUB_API = 'https://polls.hivehub.dev/rpc/poll';
+
+export async function fetchPollResults(author: string, permlink: string): Promise<PollResults> {
+  const url = `${HIVEHUB_API}?author=${encodeURIComponent(author)}&permlink=${encodeURIComponent(permlink)}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Poll results fetch failed: ${response.status}`);
+  }
+  const data = await response.json();
+  return data as PollResults;
+}
+
+export async function votePoll(
+  voter: string,
+  author: string,
+  permlink: string,
+  choices: number[],
+  postingKeyStr: string
+): Promise<void> {
+  const client = getClient();
+  const postingKey = PrivateKey.fromString(postingKeyStr.trim());
+
+  await client.broadcast.json(
+    {
+      required_auths: [],
+      required_posting_auths: [voter],
+      id: 'polls',
+      json: JSON.stringify({ voter, author, permlink, choices }),
+    },
+    postingKey
+  );
+}

--- a/services/PollService.ts
+++ b/services/PollService.ts
@@ -21,13 +21,19 @@ export interface PollResults {
 const HIVEHUB_API = 'https://polls.hivehub.dev/rpc/poll';
 
 export async function fetchPollResults(author: string, permlink: string): Promise<PollResults> {
-  const url = `${HIVEHUB_API}?author=${encodeURIComponent(author)}&permlink=${encodeURIComponent(permlink)}`;
+  // hivehub.dev uses PostgREST filter syntax: field=eq.value
+  const url = `${HIVEHUB_API}?author=eq.${encodeURIComponent(author)}&permlink=eq.${encodeURIComponent(permlink)}`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Poll results fetch failed: ${response.status}`);
   }
   const data = await response.json();
-  return data as PollResults;
+  // PostgREST returns an array; take first element
+  const result = Array.isArray(data) ? data[0] : data;
+  if (!result) {
+    return { total_votes: 0, choices: [], voters: [] };
+  }
+  return result as PollResults;
 }
 
 export async function votePoll(

--- a/services/PollService.ts
+++ b/services/PollService.ts
@@ -1,27 +1,41 @@
 import { PrivateKey } from '@hiveio/dhive';
 import { getClient } from './HiveClient';
 
+export interface PollChoiceVotes {
+  total_votes: number;
+  hive_hp: number;
+  hive_hp_incl_proxied: number;
+}
+
 export interface PollChoiceResult {
-  choice_num: number;
-  votes: number;
-  hive_hp_incl_proxied?: number;
+  choice_num: number;   // 1-based
+  choice_text: string;
+  votes: PollChoiceVotes | null;
 }
 
 export interface PollVoter {
-  voter: string;
-  choices: number[];
+  name: string;         // username
+  choices: number[];    // 1-based choice numbers
+  hive_hp: number;
+  hive_hp_incl_proxied: number;
+}
+
+export interface PollStats {
+  total_voting_accounts_num: number;
+  total_hive_hp: number;
+  total_hive_hp_incl_proxied: number;
 }
 
 export interface PollResults {
-  total_votes: number;
-  choices: PollChoiceResult[];
-  voters?: PollVoter[];
+  poll_choices: PollChoiceResult[];
+  poll_voters: PollVoter[] | null;
+  poll_stats: PollStats | null;
 }
 
 const HIVEHUB_API = 'https://polls.hivehub.dev/rpc/poll';
 
-export async function fetchPollResults(author: string, permlink: string): Promise<PollResults> {
-  // hivehub.dev uses PostgREST filter syntax: field=eq.value
+export async function fetchPollResults(author: string, permlink: string): Promise<PollResults | null> {
+  // hivehub.dev is PostgREST — filter syntax is field=eq.value
   const url = `${HIVEHUB_API}?author=eq.${encodeURIComponent(author)}&permlink=eq.${encodeURIComponent(permlink)}`;
   const response = await fetch(url);
   if (!response.ok) {
@@ -30,10 +44,7 @@ export async function fetchPollResults(author: string, permlink: string): Promis
   const data = await response.json();
   // PostgREST returns an array; take first element
   const result = Array.isArray(data) ? data[0] : data;
-  if (!result) {
-    return { total_votes: 0, choices: [], voters: [] };
-  }
-  return result as PollResults;
+  return result ?? null;
 }
 
 export async function votePoll(

--- a/utils/pollDetection.ts
+++ b/utils/pollDetection.ts
@@ -1,0 +1,62 @@
+/** Utility to detect and extract Hive poll data from json_metadata */
+
+export interface PollDraft {
+  question: string;
+  choices: string[];       // 2–5 choices
+  durationDays: number;    // 1, 3, 7, 14
+  maxChoicesVoted: number;
+  allowVoteChanges: boolean;
+  hideResultsUntilVoted: boolean;
+}
+
+export interface PollMetadata {
+  question: string;
+  choices: string[];
+  end_time: string;                  // ISO datetime
+  max_choices_voted: number;
+  allow_vote_changes: boolean;
+  filters?: { account_age?: number };
+  ui_hide_res_until_voted?: boolean;
+}
+
+function tryParse(val: unknown): any {
+  if (!val) return null;
+  if (typeof val === 'object') return val as any;
+  if (typeof val !== 'string') return null;
+  try {
+    return JSON.parse(val);
+  } catch {
+    return null;
+  }
+}
+
+export function isPoll(jsonMetadata: string): boolean {
+  const meta = tryParse(jsonMetadata);
+  return meta?.content_type === 'poll';
+}
+
+export function extractPoll(jsonMetadata: string): PollMetadata | null {
+  const meta = tryParse(jsonMetadata);
+  if (!meta || meta.content_type !== 'poll') return null;
+
+  const { question, choices, end_time, max_choices_voted, allow_vote_changes, filters, ui_hide_res_until_voted } = meta;
+
+  if (
+    typeof question !== 'string' ||
+    !Array.isArray(choices) ||
+    choices.length < 2 ||
+    typeof end_time !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    question,
+    choices: choices as string[],
+    end_time,
+    max_choices_voted: typeof max_choices_voted === 'number' ? max_choices_voted : 1,
+    allow_vote_changes: typeof allow_vote_changes === 'boolean' ? allow_vote_changes : false,
+    filters: filters ?? undefined,
+    ui_hide_res_until_voted: typeof ui_hide_res_until_voted === 'boolean' ? ui_hide_res_until_voted : false,
+  };
+}

--- a/utils/pollDetection.ts
+++ b/utils/pollDetection.ts
@@ -19,12 +19,21 @@ export interface PollMetadata {
   ui_hide_res_until_voted?: boolean;
 }
 
-function tryParse(val: unknown): any {
+interface JsonObject {
+  [key: string]: unknown;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function tryParse(val: unknown): JsonObject | null {
   if (!val) return null;
-  if (typeof val === 'object') return val as any;
+  if (isJsonObject(val)) return val;
   if (typeof val !== 'string') return null;
   try {
-    return JSON.parse(val);
+    const parsed: unknown = JSON.parse(val);
+    return isJsonObject(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -41,12 +50,18 @@ export function extractPoll(jsonMetadata: string): PollMetadata | null {
 
   const { question, choices, end_time, max_choices_voted, allow_vote_changes, filters, ui_hide_res_until_voted } = meta;
 
-  if (
-    typeof question !== 'string' ||
-    !Array.isArray(choices) ||
-    choices.length < 2 ||
-    (typeof end_time !== 'number' && typeof end_time !== 'string')
-  ) {
+  // Validate choices: must be an array of 2+ non-empty strings
+  const hasValidChoices =
+    Array.isArray(choices) &&
+    choices.length >= 2 &&
+    choices.every((c): c is string => typeof c === 'string' && c.trim().length > 0);
+
+  // Validate end_time: number (Unix seconds) or parseable ISO string
+  const hasValidEndTime =
+    typeof end_time === 'number' ||
+    (typeof end_time === 'string' && !Number.isNaN(Date.parse(end_time)));
+
+  if (typeof question !== 'string' || !hasValidChoices || !hasValidEndTime) {
     return null;
   }
 
@@ -54,15 +69,25 @@ export function extractPoll(jsonMetadata: string): PollMetadata | null {
   const endTimeSeconds: number =
     typeof end_time === 'number'
       ? end_time
-      : Math.floor(new Date(end_time).getTime() / 1000);
+      : Math.floor(new Date(end_time as string).getTime() / 1000);
+
+  const validatedChoices = choices as string[];
+
+  // Clamp max_choices_voted to [1, choices.length]
+  const normalizedMaxChoices =
+    typeof max_choices_voted === 'number' &&
+    Number.isInteger(max_choices_voted) &&
+    max_choices_voted >= 1
+      ? Math.min(max_choices_voted, validatedChoices.length)
+      : 1;
 
   return {
     question,
-    choices: choices as string[],
+    choices: validatedChoices,
     end_time: endTimeSeconds,
-    max_choices_voted: typeof max_choices_voted === 'number' ? max_choices_voted : 1,
+    max_choices_voted: normalizedMaxChoices,
     allow_vote_changes: typeof allow_vote_changes === 'boolean' ? allow_vote_changes : false,
-    filters: filters ?? undefined,
+    filters: isJsonObject(filters) ? (filters as { account_age?: number }) : undefined,
     ui_hide_res_until_voted: typeof ui_hide_res_until_voted === 'boolean' ? ui_hide_res_until_voted : false,
   };
 }

--- a/utils/pollDetection.ts
+++ b/utils/pollDetection.ts
@@ -12,7 +12,7 @@ export interface PollDraft {
 export interface PollMetadata {
   question: string;
   choices: string[];
-  end_time: string;                  // ISO datetime
+  end_time: number;                  // Unix timestamp (seconds) — PeakD/Ecency standard
   max_choices_voted: number;
   allow_vote_changes: boolean;
   filters?: { account_age?: number };
@@ -45,15 +45,21 @@ export function extractPoll(jsonMetadata: string): PollMetadata | null {
     typeof question !== 'string' ||
     !Array.isArray(choices) ||
     choices.length < 2 ||
-    typeof end_time !== 'string'
+    (typeof end_time !== 'number' && typeof end_time !== 'string')
   ) {
     return null;
   }
 
+  // Normalize end_time to Unix seconds (PeakD uses seconds; ISO strings are converted)
+  const endTimeSeconds: number =
+    typeof end_time === 'number'
+      ? end_time
+      : Math.floor(new Date(end_time).getTime() / 1000);
+
   return {
     question,
     choices: choices as string[],
-    end_time,
+    end_time: endTimeSeconds,
     max_choices_voted: typeof max_choices_voted === 'number' ? max_choices_voted : 1,
     allow_vote_changes: typeof allow_vote_changes === 'boolean' ? allow_vote_changes : false,
     filters: filters ?? undefined,


### PR DESCRIPTION
## Summary
- Detect Hive-standard polls (`content_type: 'poll'` in `json_metadata`) compatible with Ecency, Peakd, and hSnaps
- Display polls in both **Snap feed** and **HivePostScreen** with a `PollWidget` that shows choices, percentage bars, expiry countdown, and handles voting
- Vote via `custom_json` with posting key — stored key + biometrics first, inline key input as fallback
- Create polls from **ComposeScreen** using a new `PollCreatorModal` (question, 2–5 choices, duration, multi-choice, and hide-until-voted options)
- Poll metadata is injected into `json_metadata` on post submit via `useCompose`

## Architecture
- `utils/pollDetection.ts` — `extractPoll()` / `isPoll()` with safe json_metadata parse
- `services/PollService.ts` — `fetchPollResults()` (polls.hivehub.dev) and `votePoll()` (custom_json broadcast)
- `hooks/usePoll.ts` — async results fetch, vote flow with biometric + inline key fallback, `isMountedRef` guard
- `app/components/PollWidget.tsx` — full render for vote, results, expiry, and key input states
- `app/components/PollCreatorModal.tsx` — bottom sheet form for poll creation

## Files modified
- `hooks/useCompose.ts` — `poll` state + `SET_POLL` action + json_metadata injection
- `app/screens/ComposeScreen.tsx` + `ComposeScreen.styles.ts` — poll button + chip preview + modal
- `app/components/Snap.tsx` — detect and render PollWidget per snap
- `app/screens/HivePostScreen.tsx` — detect and render PollWidget per post

## Test plan
- [ ] `npx tsc --noEmit` — zero new errors
- [ ] Open a snap with known poll `json_metadata` → PollWidget renders with question and choices
- [ ] Vote with stored posting key path → biometric prompt → result bars update
- [ ] Vote with no stored key → inline key input appears → vote succeeds
- [ ] Expired poll → results-only view, no vote button
- [ ] ComposeScreen: tap poll button → modal opens → confirm → chip shows → post contains `content_type: 'poll'`
- [ ] Poll button disabled in reply/edit mode
- [ ] Multi-choice poll (`max_choices_voted > 1`) → checkboxes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create polls when composing posts via a modal: configurable duration (1/3/7/14 days), 2–5 editable choices, max selectable choices, allow vote changes, and option to hide results until voted.
  * Poll preview chip in composer with remove control and action button to open the creator.
  * Polls render inline in posts and feeds with interactive voting, secure inline key entry (or biometric/auto-key), live totals/percentages, and vote-state aware UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->