### PR TITLE
feat: Hangouts Phase 1 — auth, lobby screen, snap preview cards

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -93,6 +93,7 @@ function RootLayoutNav() {
                 <Stack.Screen name='screens/AddActiveKeyScreen' />
                 <Stack.Screen name='screens/MigrationScreen' />
                 <Stack.Screen name='screens/WalletScreen' />
+                <Stack.Screen name='screens/HangoutsLobbyScreen' />
                 <Stack.Screen name='modal' options={{ presentation: 'modal' }} />
               </Stack>
             </TOSWrapper>

--- a/app/components/HangoutPreviewCard.tsx
+++ b/app/components/HangoutPreviewCard.tsx
@@ -20,6 +20,7 @@ interface Props {
     border: string;
     card: string;
     background: string;
+    success: string;
   };
 }
 
@@ -90,7 +91,7 @@ export default function HangoutPreviewCard({ roomName, colors }: Props) {
           <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
             {room.title}
           </Text>
-          <View style={styles.liveBadge}>
+          <View style={[styles.liveBadge, { backgroundColor: colors.success }]}>
             <Text style={styles.liveText}>LIVE</Text>
           </View>
         </View>
@@ -123,7 +124,7 @@ const styles = StyleSheet.create({
   info: { flex: 1 },
   titleRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   title: { fontSize: 15, fontWeight: '600', flex: 1 },
-  liveBadge: { backgroundColor: '#22c55e', paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  liveBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
   liveText: { color: '#fff', fontSize: 10, fontWeight: '700' },
   host: { fontSize: 13, marginTop: 2 },
   countWrap: { alignItems: 'center', gap: 4 },

--- a/app/components/HangoutPreviewCard.tsx
+++ b/app/components/HangoutPreviewCard.tsx
@@ -6,6 +6,12 @@ import { FontAwesome } from '@expo/vector-icons';
 import type { Room } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../../services/HangoutsAuthService';
 
+type FetchState =
+  | { status: 'loading' }
+  | { status: 'found'; room: Room }
+  | { status: 'not_found' }
+  | { status: 'error' };
+
 interface Props {
   roomName: string;
   colors: {
@@ -18,37 +24,61 @@ interface Props {
 }
 
 export default function HangoutPreviewCard({ roomName, colors }: Props) {
-  const [room, setRoom] = useState<Room | null | undefined>(undefined);
+  const [state, setState] = useState<FetchState>({ status: 'loading' });
   const router = useRouter();
 
   useEffect(() => {
+    let stale = false;
+    setState({ status: 'loading' });
+
     hangoutsAuthService.getClient().getRoom(roomName)
-      .then((data) => setRoom(data))
-      .catch(() => setRoom(null));
+      .then((data) => {
+        if (stale) return;
+        setState(data ? { status: 'found', room: data } : { status: 'not_found' });
+      })
+      .catch(() => {
+        if (stale) return;
+        setState({ status: 'error' });
+      });
+
+    return () => { stale = true; };
   }, [roomName]);
 
-  if (room === undefined) {
+  if (state.status === 'loading') {
     return (
       <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}>
         <ActivityIndicator size='small' color={colors.textSecondary} />
-        <Text style={[styles.loadingText, { color: colors.textSecondary }]}>Loading hangout...</Text>
+        <Text style={[styles.statusText, { color: colors.textSecondary }]}>Loading hangout...</Text>
       </View>
     );
   }
 
-  if (room === null) {
+  if (state.status === 'not_found') {
     return (
       <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}>
         <FontAwesome name='microphone-slash' size={18} color={colors.textSecondary} />
-        <Text style={[styles.endedText, { color: colors.textSecondary }]}>This hangout has ended</Text>
+        <Text style={[styles.statusText, { color: colors.textSecondary }]}>This hangout has ended</Text>
       </View>
     );
   }
+
+  if (state.status === 'error') {
+    return (
+      <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}>
+        <FontAwesome name='exclamation-circle' size={18} color={colors.textSecondary} />
+        <Text style={[styles.statusText, { color: colors.textSecondary }]}>Could not load hangout</Text>
+      </View>
+    );
+  }
+
+  const { room } = state;
 
   return (
     <Pressable
       style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}
       onPress={() => router.push('/screens/HangoutsLobbyScreen')}
+      accessibilityRole='button'
+      accessibilityLabel={`Hangout: ${room.title}, hosted by ${room.host}`}
     >
       <ExpoImage
         source={{ uri: `https://images.hive.blog/u/${room.host}/avatar/sm` }}
@@ -88,8 +118,7 @@ const styles = StyleSheet.create({
     marginVertical: 6,
     gap: 8,
   },
-  loadingText: { fontSize: 13, marginLeft: 4 },
-  endedText: { fontSize: 13, marginLeft: 6 },
+  statusText: { fontSize: 13, marginLeft: 6 },
   avatar: { width: 44, height: 44, borderRadius: 22 },
   info: { flex: 1 },
   titleRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },

--- a/app/components/HangoutPreviewCard.tsx
+++ b/app/components/HangoutPreviewCard.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
+import { Image as ExpoImage } from 'expo-image';
+import { useRouter } from 'expo-router';
+import { FontAwesome } from '@expo/vector-icons';
+import type { Room } from '@snapie/hangouts-core';
+import { hangoutsAuthService } from '../../services/HangoutsAuthService';
+
+interface Props {
+  roomName: string;
+  colors: {
+    text: string;
+    textSecondary: string;
+    border: string;
+    card: string;
+    background: string;
+  };
+}
+
+export default function HangoutPreviewCard({ roomName, colors }: Props) {
+  const [room, setRoom] = useState<Room | null | undefined>(undefined);
+  const router = useRouter();
+
+  useEffect(() => {
+    hangoutsAuthService.getClient().getRoom(roomName)
+      .then((data) => setRoom(data))
+      .catch(() => setRoom(null));
+  }, [roomName]);
+
+  if (room === undefined) {
+    return (
+      <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}>
+        <ActivityIndicator size='small' color={colors.textSecondary} />
+        <Text style={[styles.loadingText, { color: colors.textSecondary }]}>Loading hangout...</Text>
+      </View>
+    );
+  }
+
+  if (room === null) {
+    return (
+      <View style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}>
+        <FontAwesome name='microphone-slash' size={18} color={colors.textSecondary} />
+        <Text style={[styles.endedText, { color: colors.textSecondary }]}>This hangout has ended</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      style={[styles.card, { borderColor: colors.border, backgroundColor: colors.card }]}
+      onPress={() => router.push('/screens/HangoutsLobbyScreen')}
+    >
+      <ExpoImage
+        source={{ uri: `https://images.hive.blog/u/${room.host}/avatar/sm` }}
+        style={styles.avatar}
+        contentFit='cover'
+      />
+      <View style={styles.info}>
+        <View style={styles.titleRow}>
+          <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
+            {room.title}
+          </Text>
+          <View style={styles.liveBadge}>
+            <Text style={styles.liveText}>LIVE</Text>
+          </View>
+        </View>
+        <Text style={[styles.host, { color: colors.textSecondary }]}>
+          @{room.host}
+        </Text>
+      </View>
+      <View style={styles.countWrap}>
+        <FontAwesome name='headphones' size={14} color={colors.textSecondary} />
+        <Text style={[styles.count, { color: colors.text }]}>
+          {room.numParticipants ?? 0}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderWidth: 1,
+    borderRadius: 12,
+    marginVertical: 6,
+    gap: 8,
+  },
+  loadingText: { fontSize: 13, marginLeft: 4 },
+  endedText: { fontSize: 13, marginLeft: 6 },
+  avatar: { width: 44, height: 44, borderRadius: 22 },
+  info: { flex: 1 },
+  titleRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  title: { fontSize: 15, fontWeight: '600', flex: 1 },
+  liveBadge: { backgroundColor: '#22c55e', paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  liveText: { color: '#fff', fontSize: 10, fontWeight: '700' },
+  host: { fontSize: 13, marginTop: 2 },
+  countWrap: { alignItems: 'center', gap: 4 },
+  count: { fontSize: 13, fontWeight: '600' },
+});

--- a/app/components/IconButton.tsx
+++ b/app/components/IconButton.tsx
@@ -1,0 +1,65 @@
+import React, { ComponentProps } from 'react';
+import { TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+
+type FontAwesomeIconName = ComponentProps<typeof FontAwesome>['name'];
+
+interface IconButtonProps {
+  name: FontAwesomeIconName;
+  onPress: () => void;
+  size?: number;
+  color: string;
+  backgroundColor?: string;
+  accessibilityLabel: string;
+  accessibilityHint?: string;
+  disabled?: boolean;
+  style?: ViewStyle;
+}
+
+/**
+ * Circular icon-only button. hitSlop and accessibilityRole are baked in.
+ * Use for header actions: back, create, microphone, search, bell, etc.
+ */
+export default function IconButton({
+  name,
+  onPress,
+  size = 20,
+  color,
+  backgroundColor,
+  accessibilityLabel,
+  accessibilityHint,
+  disabled = false,
+  style,
+}: IconButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      style={[
+        styles.button,
+        backgroundColor ? { backgroundColor } : undefined,
+        disabled && styles.disabled,
+        style,
+      ]}
+      accessibilityRole='button'
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+    >
+      <FontAwesome name={name} size={size} color={color} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/app/components/IconButton.tsx
+++ b/app/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps } from 'react';
-import { TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
+import { TouchableOpacity, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
 
 type FontAwesomeIconName = ComponentProps<typeof FontAwesome>['name'];
@@ -13,7 +13,7 @@ interface IconButtonProps {
   accessibilityLabel: string;
   accessibilityHint?: string;
   disabled?: boolean;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 }
 
 /**
@@ -30,7 +30,7 @@ export default function IconButton({
   accessibilityHint,
   disabled = false,
   style,
-}: IconButtonProps) {
+}: IconButtonProps): React.ReactElement {
   return (
     <TouchableOpacity
       onPress={onPress}
@@ -44,6 +44,7 @@ export default function IconButton({
       accessibilityRole='button'
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
+      accessibilityState={{ disabled }}
       hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
     >
       <FontAwesome name={name} size={size} color={color} />

--- a/app/components/PrimaryButton.tsx
+++ b/app/components/PrimaryButton.tsx
@@ -4,64 +4,66 @@ import {
   Text,
   ActivityIndicator,
   StyleSheet,
-  ViewStyle,
+  type StyleProp,
+  type ViewStyle,
 } from 'react-native';
 
-type Variant = 'primary' | 'secondary' | 'cancel';
-
-interface PrimaryButtonProps {
+interface BaseProps {
   label: string;
   onPress: () => void;
   disabled?: boolean;
   loading?: boolean;
-  variant?: Variant;
-  /** Required for primary variant */
-  backgroundColor?: string;
-  /** Required for primary variant */
-  textColor?: string;
-  /** Required for secondary/cancel variants */
-  borderColor?: string;
-  /** Text color for secondary/cancel variants */
-  labelColor?: string;
   accessibilityLabel?: string;
   accessibilityHint?: string;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 }
+
+interface FilledProps extends BaseProps {
+  variant?: 'primary';
+  backgroundColor: string;
+  textColor: string;
+  borderColor?: never;
+  labelColor?: never;
+}
+
+interface OutlinedProps extends BaseProps {
+  variant: 'secondary' | 'cancel';
+  borderColor: string;
+  labelColor: string;
+  backgroundColor?: never;
+  textColor?: never;
+}
+
+type PrimaryButtonProps = FilledProps | OutlinedProps;
 
 /**
  * Full-width labeled action button with loading state.
  * Use for modal actions: Go Live, Cancel, Retry, etc.
  *
  * Variants:
- *  - primary: filled background (pass backgroundColor + textColor)
- *  - secondary: outlined (pass borderColor + labelColor)
- *  - cancel: same as secondary
+ *  - primary (default): filled — requires backgroundColor + textColor
+ *  - secondary / cancel: outlined — requires borderColor + labelColor
  */
-export default function PrimaryButton({
-  label,
-  onPress,
-  disabled = false,
-  loading = false,
-  variant = 'primary',
-  backgroundColor,
-  textColor = '#fff',
-  borderColor,
-  labelColor,
-  accessibilityLabel,
-  accessibilityHint,
-  style,
-}: PrimaryButtonProps) {
-  const isOutlined = variant === 'secondary' || variant === 'cancel';
+export default function PrimaryButton(props: PrimaryButtonProps): React.ReactElement {
+  const { label, onPress, disabled = false, loading = false, accessibilityLabel, accessibilityHint, style } = props;
+  const isOutlined = props.variant === 'secondary' || props.variant === 'cancel';
+
+  const foreground = isOutlined
+    ? (props as OutlinedProps).labelColor
+    : (props as FilledProps).textColor;
+  const background = isOutlined ? undefined : (props as FilledProps).backgroundColor;
+  const border = isOutlined ? (props as OutlinedProps).borderColor : undefined;
 
   return (
     <TouchableOpacity
       onPress={onPress}
       disabled={disabled || loading}
+      accessibilityState={{ disabled: disabled || loading, busy: loading }}
       style={[
         styles.button,
         isOutlined
-          ? [styles.outlined, borderColor ? { borderColor } : undefined]
-          : [styles.filled, backgroundColor ? { backgroundColor } : undefined],
+          ? [styles.outlined, border ? { borderColor: border } : undefined]
+          : [styles.filled, background ? { backgroundColor: background } : undefined],
         (disabled || loading) && styles.disabled,
         style,
       ]}
@@ -70,14 +72,9 @@ export default function PrimaryButton({
       accessibilityHint={accessibilityHint}
     >
       {loading ? (
-        <ActivityIndicator size='small' color={isOutlined ? labelColor : textColor} />
+        <ActivityIndicator size='small' color={foreground} />
       ) : (
-        <Text
-          style={[
-            styles.label,
-            { color: isOutlined ? (labelColor ?? '#000') : textColor },
-          ]}
-        >
+        <Text style={[styles.label, { color: foreground }]}>
           {label}
         </Text>
       )}

--- a/app/components/PrimaryButton.tsx
+++ b/app/components/PrimaryButton.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import {
+  TouchableOpacity,
+  Text,
+  ActivityIndicator,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
+
+type Variant = 'primary' | 'secondary' | 'cancel';
+
+interface PrimaryButtonProps {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  variant?: Variant;
+  /** Required for primary variant */
+  backgroundColor?: string;
+  /** Required for primary variant */
+  textColor?: string;
+  /** Required for secondary/cancel variants */
+  borderColor?: string;
+  /** Text color for secondary/cancel variants */
+  labelColor?: string;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  style?: ViewStyle;
+}
+
+/**
+ * Full-width labeled action button with loading state.
+ * Use for modal actions: Go Live, Cancel, Retry, etc.
+ *
+ * Variants:
+ *  - primary: filled background (pass backgroundColor + textColor)
+ *  - secondary: outlined (pass borderColor + labelColor)
+ *  - cancel: same as secondary
+ */
+export default function PrimaryButton({
+  label,
+  onPress,
+  disabled = false,
+  loading = false,
+  variant = 'primary',
+  backgroundColor,
+  textColor = '#fff',
+  borderColor,
+  labelColor,
+  accessibilityLabel,
+  accessibilityHint,
+  style,
+}: PrimaryButtonProps) {
+  const isOutlined = variant === 'secondary' || variant === 'cancel';
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled || loading}
+      style={[
+        styles.button,
+        isOutlined
+          ? [styles.outlined, borderColor ? { borderColor } : undefined]
+          : [styles.filled, backgroundColor ? { backgroundColor } : undefined],
+        (disabled || loading) && styles.disabled,
+        style,
+      ]}
+      accessibilityRole='button'
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityHint={accessibilityHint}
+    >
+      {loading ? (
+        <ActivityIndicator size='small' color={isOutlined ? labelColor : textColor} />
+      ) : (
+        <Text
+          style={[
+            styles.label,
+            { color: isOutlined ? (labelColor ?? '#000') : textColor },
+          ]}
+        >
+          {label}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  filled: {},
+  outlined: {
+    borderWidth: 1,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/app/components/PrimaryButton.tsx
+++ b/app/components/PrimaryButton.tsx
@@ -46,13 +46,24 @@ type PrimaryButtonProps = FilledProps | OutlinedProps;
  */
 export default function PrimaryButton(props: PrimaryButtonProps): React.ReactElement {
   const { label, onPress, disabled = false, loading = false, accessibilityLabel, accessibilityHint, style } = props;
-  const isOutlined = props.variant === 'secondary' || props.variant === 'cancel';
 
-  const foreground = isOutlined
-    ? (props as OutlinedProps).labelColor
-    : (props as FilledProps).textColor;
-  const background = isOutlined ? undefined : (props as FilledProps).backgroundColor;
-  const border = isOutlined ? (props as OutlinedProps).borderColor : undefined;
+  let foreground: string;
+  let background: string | undefined;
+  let border: string | undefined;
+
+  if (props.variant === 'secondary' || props.variant === 'cancel') {
+    foreground = props.labelColor;
+    border = props.borderColor;
+    background = undefined;
+  } else {
+    // variant is 'primary' | undefined — both resolve to FilledProps
+    const filled = props as FilledProps;
+    foreground = filled.textColor;
+    background = filled.backgroundColor;
+    border = undefined;
+  }
+
+  const isOutlined = props.variant === 'secondary' || props.variant === 'cancel';
 
   return (
     <TouchableOpacity

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -215,7 +215,7 @@ const Snap: React.FC<SnapProps> = ({
   const embeddedContent = extractVideoInfo(body); // Renamed from videoInfo to be more accurate
   const mediaInfo = detectMediaInBody(body); // Detect audio and video media
   const hivePostUrls = extractBlogPostUrls(body); // Extract Hive post URLs for previews
-  const hangoutRoomNames = useMemo(() => extractHangoutRoomNames(body), [body]);
+  const hangoutRoomNames = useMemo(() => [...new Set(extractHangoutRoomNames(body))], [body]);
   const router = useRouter(); // For navigation in reply mode
 
   // Calculate indentation and content width for replies

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -38,6 +38,8 @@ import AudioEmbed from './AudioEmbed';
 import InstagramEmbed from './InstagramEmbed';
 import { extractBlogPostUrls } from '../../utils/extractHivePostInfo';
 import { OptimizedHivePostPreviewRenderer } from '../../components/OptimizedHivePostPreviewRenderer';
+import { extractHangoutRoomNames } from '../../utils/extractHangoutInfo';
+import HangoutPreviewCard from './HangoutPreviewCard';
 import { canBeResnapped } from '../../utils/postTypeDetector';
 import { getMarkdownStyles } from '../../styles/markdownStyles';
 import { linkStyles, useLinkTextStyle } from '../../styles/linkStyles';
@@ -213,6 +215,7 @@ const Snap: React.FC<SnapProps> = ({
   const embeddedContent = extractVideoInfo(body); // Renamed from videoInfo to be more accurate
   const mediaInfo = detectMediaInBody(body); // Detect audio and video media
   const hivePostUrls = extractBlogPostUrls(body); // Extract Hive post URLs for previews
+  const hangoutRoomNames = useMemo(() => extractHangoutRoomNames(body), [body]);
   const router = useRouter(); // For navigation in reply mode
 
   // Calculate indentation and content width for replies
@@ -1131,6 +1134,25 @@ const Snap: React.FC<SnapProps> = ({
             />
           </View>
         )}
+        {/* Hangout Preview Cards */}
+        {hangoutRoomNames.length > 0 && (
+          <View style={{ marginTop: 8 }}>
+            {hangoutRoomNames.map((name) => (
+              <HangoutPreviewCard
+                key={name}
+                roomName={name}
+                colors={{
+                  text: colors.text,
+                  textSecondary: colors.textSecondary,
+                  border: colors.border,
+                  card: colors.card,
+                  background: colors.background,
+                }}
+              />
+            ))}
+          </View>
+        )}
+
         {/* Three-dots Action Sheet */}
         <ActionSheet
           visible={moreMenuVisible}

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -1147,6 +1147,7 @@ const Snap: React.FC<SnapProps> = ({
                   border: colors.border,
                   card: colors.card,
                   background: colors.background,
+                  success: colors.success,
                 }}
               />
             ))}

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -428,6 +428,16 @@ const Snap: React.FC<SnapProps> = ({
       .join('\n');
   }
 
+  // Remove hangout URLs from text body — rendered as preview cards instead
+  if (hangoutRoomNames.length > 0) {
+    textBody = textBody.replace(/https?:\/\/hangout\.3speak\.tv\/room\/[\w-]+/g, '').trim();
+    textBody = textBody
+      .replace(/\r\n/g, '\n')
+      .split('\n')
+      .map(l => l.replace(/[ \t]{2,}/g, ' ').replace(/ +$/, ''))
+      .join('\n');
+  }
+
   // Process spoiler syntax first, before other text processing
   const spoilerData = convertSpoilerSyntax(textBody);
   textBody = spoilerData.processedText;

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -428,9 +428,20 @@ const Snap: React.FC<SnapProps> = ({
       .join('\n');
   }
 
-  // Remove hangout URLs from text body — rendered as preview cards instead
+  // Remove hangout URLs from text body — rendered as preview cards instead.
+  // Handle three forms to avoid leaving broken markup:
+  //   1. Markdown links: [label](url)
+  //   2. HTML anchors: <a href="url">...</a>
+  //   3. Bare standalone URLs (bounded by whitespace/line boundaries)
   if (hangoutRoomNames.length > 0) {
-    textBody = textBody.replace(/https?:\/\/hangout\.3speak\.tv\/room\/[\w-]+/g, '').trim();
+    textBody = textBody
+      // Remove full markdown link tokens
+      .replace(/\[[^\]]*\]\(https?:\/\/hangout\.3speak\.tv\/room\/[\w-]+\)/g, '')
+      // Remove full HTML anchor tokens
+      .replace(/<a\b[^>]*href=["']https?:\/\/hangout\.3speak\.tv\/room\/[\w-]+["'][^>]*>.*?<\/a>/gi, '')
+      // Remove remaining bare URLs (standalone — preceded/followed by whitespace or line boundary)
+      .replace(/(^|[\s])https?:\/\/hangout\.3speak\.tv\/room\/[\w-]+(\s|$)/gm, '$1$2')
+      .trim();
     textBody = textBody
       .replace(/\r\n/g, '\n')
       .split('\n')

--- a/app/config/env.ts
+++ b/app/config/env.ts
@@ -38,3 +38,6 @@ export const THREESPEAK_IMAGE_API_KEY = process.env.EXPO_PUBLIC_THREESPEAK_IMAGE
 if (!THREESPEAK_IMAGE_API_KEY) {
   console.warn('⚠️  THREESPEAK_IMAGE_API_KEY is not set - fallback image upload to 3Speak will not work');
 }
+
+// Hive Hangouts API
+export const HANGOUTS_API_URL = process.env.EXPO_PUBLIC_HANGOUTS_API_URL || 'https://hangout-api.3speak.tv';

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -898,6 +898,8 @@ const FeedScreenRefactored = () => {
               style={[styles.searchBtn, { marginRight: 12 }]}
               onPress={() => router.push('/screens/HangoutsLobbyScreen')}
               accessibilityLabel='Open Hangouts'
+              accessibilityRole='button'
+              accessibilityHint='Navigates to the Hangouts lobby'
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             >
               <FontAwesome name='microphone' size={22} color={colors.icon} />

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -133,6 +133,7 @@ const FeedScreenRefactored = () => {
     buttonInactive: theme.buttonInactive,
     icon: theme.icon,
     bubble: theme.bubble,
+    success: theme.success,
   };
 
   // Initialize styles
@@ -909,7 +910,7 @@ const FeedScreenRefactored = () => {
                 <NotificationBadge
                   count={hangoutsCount}
                   size='small'
-                  color='#22c55e'
+                  color={colors.success}
                   visible={hangoutsCount > 0}
                 />
               </View>

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -896,6 +896,14 @@ const FeedScreenRefactored = () => {
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <TouchableOpacity
               style={[styles.searchBtn, { marginRight: 12 }]}
+              onPress={() => router.push('/screens/HangoutsLobbyScreen')}
+              accessibilityLabel='Open Hangouts'
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <FontAwesome name='microphone' size={22} color={colors.icon} />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.searchBtn, { marginRight: 12 }]}
               onPress={() => setIsSearchModalVisible(true)}
               accessibilityLabel='Search posts and users'
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -35,6 +35,7 @@ import { useUpvote } from '../../hooks/useUpvote';
 import { useSearch } from '../../hooks/useSearch';
 import { useHiveData } from '../../hooks/useHiveData';
 import { useNotifications } from '../../hooks/useNotifications';
+import { useHangoutsCount } from '../../hooks/useHangoutsCount';
 import { useVotingPower } from '../../hooks/useVotingPower';
 import { useResourceCredits } from '../../hooks/useResourceCredits';
 import { useUserProfile } from '../../hooks/useUserProfile';
@@ -265,6 +266,7 @@ const FeedScreenRefactored = () => {
   } = useSearch();
 
   const { unreadCount, refresh: refreshNotifications } = useNotifications(username || null);
+  const hangoutsCount = useHangoutsCount();
 
   const [isSearchModalVisible, setIsSearchModalVisible] = useState(false);
   const [vpInfoModalVisible, setVpInfoModalVisible] = useState(false);
@@ -902,7 +904,15 @@ const FeedScreenRefactored = () => {
               accessibilityHint='Navigates to the Hangouts lobby'
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             >
-              <FontAwesome name='microphone' size={22} color={colors.icon} />
+              <View style={{ position: 'relative' }}>
+                <FontAwesome name='microphone' size={22} color={colors.icon} />
+                <NotificationBadge
+                  count={hangoutsCount}
+                  size='small'
+                  color='#22c55e'
+                  visible={hangoutsCount > 0}
+                />
+              </View>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.searchBtn, { marginRight: 12 }]}

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -52,8 +52,8 @@ export default function HangoutsLobbyScreen() {
       setRoomDescription('');
       refresh();
       Alert.alert('Room Created', 'Your hangout is live! Audio joining coming soon.');
-    } catch {
-      Alert.alert('Error', createError ?? 'Failed to create room');
+    } catch (err) {
+      Alert.alert('Error', err instanceof Error ? err.message : 'Failed to create room');
     }
   };
 
@@ -112,12 +112,21 @@ export default function HangoutsLobbyScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: theme.border }]}>
-        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={styles.backBtn}
+          accessibilityRole='button'
+          accessibilityLabel='Go back'
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
           <FontAwesome name='arrow-left' size={20} color={theme.text} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: theme.text }]}>Hangouts</Text>
         <TouchableOpacity
           style={[styles.createBtn, { backgroundColor: theme.button }]}
+          accessibilityRole='button'
+          accessibilityLabel='Start a new hangout'
+          accessibilityHint='Opens room creation form'
           onPress={() => {
             if (!isAuthenticated) {
               authenticate().then((ok) => {

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -47,14 +47,18 @@ export default function HangoutsLobbyScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-once auth check
   }, []);
 
+  const closeCreateModal = () => {
+    setCreateModalVisible(false);
+    setRoomTitle('');
+    setRoomDescription('');
+  };
+
   const handleCreateRoom = async () => {
     const trimmed = roomTitle.trim();
     if (!trimmed) return;
     try {
       await create(trimmed, roomDescription.trim() || undefined);
-      setCreateModalVisible(false);
-      setRoomTitle('');
-      setRoomDescription('');
+      closeCreateModal();
       refresh();
       Alert.alert('Room Created', 'Your hangout is live! Audio joining coming soon.');
     } catch (err) {
@@ -137,6 +141,7 @@ export default function HangoutsLobbyScreen() {
           accessibilityHint='Opens room creation form'
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           onPress={() => {
+            if (authLoading) return;
             if (!isAuthenticated) {
               authenticate().then((ok) => {
                 if (ok) setCreateModalVisible(true);
@@ -146,7 +151,7 @@ export default function HangoutsLobbyScreen() {
               setCreateModalVisible(true);
             }
           }}
-          disabled={createLoading}
+          disabled={createLoading || authLoading}
         >
           <FontAwesome name='plus' size={14} color={theme.buttonText} />
         </TouchableOpacity>
@@ -207,7 +212,7 @@ export default function HangoutsLobbyScreen() {
         visible={createModalVisible}
         transparent
         animationType='slide'
-        onRequestClose={() => setCreateModalVisible(false)}
+        onRequestClose={closeCreateModal}
       >
         <KeyboardAvoidingView
           style={styles.modalOverlay}
@@ -247,11 +252,7 @@ export default function HangoutsLobbyScreen() {
                   style={[styles.modalBtn, styles.modalBtnCancel, { borderColor: theme.border }]}
                   accessibilityRole='button'
                   accessibilityLabel='Cancel'
-                  onPress={() => {
-                    setCreateModalVisible(false);
-                    setRoomTitle('');
-                    setRoomDescription('');
-                  }}
+                  onPress={closeCreateModal}
                 >
                   <Text style={[styles.modalBtnText, { color: theme.text }]}>Cancel</Text>
                 </TouchableOpacity>

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -1,0 +1,313 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  Modal,
+  TextInput,
+  Alert,
+  Pressable,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Image as ExpoImage } from 'expo-image';
+import { FontAwesome } from '@expo/vector-icons';
+import { useColorScheme } from 'react-native';
+import type { Room } from '@snapie/hangouts-core';
+import { getTheme } from '../../constants/Colors';
+import { useHangoutsAuth } from '../../hooks/useHangoutsAuth';
+import { useHangoutsRoomList } from '../../hooks/useHangoutsRoomList';
+import { useHangoutsRoom } from '../../hooks/useHangoutsRoom';
+
+export default function HangoutsLobbyScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+  const theme = getTheme(isDark ? 'dark' : 'light');
+  const router = useRouter();
+
+  const { isAuthenticated, isLoading: authLoading, authenticate } = useHangoutsAuth();
+  const { rooms, isLoading: roomsLoading, error: roomsError, refresh } = useHangoutsRoomList();
+  const { create, isLoading: createLoading, error: createError } = useHangoutsRoom();
+
+  const [createModalVisible, setCreateModalVisible] = useState(false);
+  const [roomTitle, setRoomTitle] = useState('');
+  const [roomDescription, setRoomDescription] = useState('');
+
+  useEffect(() => {
+    if (!isAuthenticated && !authLoading) {
+      authenticate();
+    }
+  }, []);
+
+  const handleCreateRoom = async () => {
+    const trimmed = roomTitle.trim();
+    if (!trimmed) return;
+    try {
+      await create(trimmed, roomDescription.trim() || undefined);
+      setCreateModalVisible(false);
+      setRoomTitle('');
+      setRoomDescription('');
+      refresh();
+      Alert.alert('Room Created', 'Your hangout is live! Audio joining coming soon.');
+    } catch {
+      Alert.alert('Error', createError ?? 'Failed to create room');
+    }
+  };
+
+  const handleRoomPress = (_room: Room) => {
+    Alert.alert('Coming Soon', 'Audio joining is coming in Phase 2!');
+  };
+
+  const renderRoomCard = ({ item }: { item: Room }) => (
+    <Pressable
+      style={[styles.roomCard, { backgroundColor: theme.card, borderColor: theme.border }]}
+      onPress={() => handleRoomPress(item)}
+    >
+      <ExpoImage
+        source={{ uri: `https://images.hive.blog/u/${item.host}/avatar/sm` }}
+        style={styles.hostAvatar}
+        contentFit='cover'
+      />
+      <View style={styles.roomInfo}>
+        <View style={styles.titleRow}>
+          <Text style={[styles.roomTitle, { color: theme.text }]} numberOfLines={1}>
+            {item.title}
+          </Text>
+          <View style={styles.liveBadge}>
+            <Text style={styles.liveText}>LIVE</Text>
+          </View>
+        </View>
+        <Text style={[styles.hostName, { color: theme.textSecondary }]}>
+          @{item.host}
+        </Text>
+      </View>
+      <View style={styles.participantWrap}>
+        <FontAwesome name='headphones' size={14} color={theme.textSecondary} />
+        <Text style={[styles.participantCount, { color: theme.text }]}>
+          {item.numParticipants ?? 0}
+        </Text>
+      </View>
+    </Pressable>
+  );
+
+  const renderEmpty = () => {
+    if (roomsLoading || authLoading) return null;
+    return (
+      <View style={styles.emptyContainer}>
+        <FontAwesome name='microphone-slash' size={48} color={theme.textSecondary} />
+        <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+          No active hangouts right now
+        </Text>
+        <Text style={[styles.emptySubtext, { color: theme.textSecondary }]}>
+          Be the first to start one!
+        </Text>
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <FontAwesome name='arrow-left' size={20} color={theme.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: theme.text }]}>Hangouts</Text>
+        <TouchableOpacity
+          style={[styles.createBtn, { backgroundColor: theme.button }]}
+          onPress={() => {
+            if (!isAuthenticated) {
+              authenticate().then((ok) => {
+                if (ok) setCreateModalVisible(true);
+                else Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
+              });
+            } else {
+              setCreateModalVisible(true);
+            }
+          }}
+          disabled={createLoading}
+        >
+          <FontAwesome name='plus' size={14} color={theme.buttonText} />
+        </TouchableOpacity>
+      </View>
+
+      {/* Auth banner */}
+      {!isAuthenticated && !authLoading && (
+        <View style={[styles.authBanner, { backgroundColor: theme.card, borderColor: theme.border }]}>
+          <Text style={[styles.authBannerText, { color: theme.textSecondary }]}>
+            Sign in to create or join rooms
+          </Text>
+          <TouchableOpacity onPress={() => authenticate()}>
+            <Text style={[styles.authBannerLink, { color: theme.button }]}>Connect</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Room list */}
+      {(roomsLoading || authLoading) && rooms.length === 0 ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size='large' color={theme.button} />
+        </View>
+      ) : roomsError ? (
+        <View style={styles.errorContainer}>
+          <Text style={[styles.errorText, { color: theme.textSecondary }]}>{roomsError}</Text>
+          <TouchableOpacity onPress={refresh} style={[styles.retryBtn, { borderColor: theme.border }]}>
+            <Text style={{ color: theme.button }}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={rooms}
+          keyExtractor={(item) => item.name}
+          renderItem={renderRoomCard}
+          ListEmptyComponent={renderEmpty}
+          contentContainerStyle={styles.listContent}
+          onRefresh={refresh}
+          refreshing={roomsLoading}
+        />
+      )}
+
+      {/* Create Room Modal */}
+      <Modal
+        visible={createModalVisible}
+        transparent
+        animationType='slide'
+        onRequestClose={() => setCreateModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={[styles.modalSheet, { backgroundColor: theme.background, borderColor: theme.border }]}>
+            <Text style={[styles.modalTitle, { color: theme.text }]}>Start a Hangout</Text>
+
+            <TextInput
+              style={[styles.modalInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.card }]}
+              placeholder='Room title'
+              placeholderTextColor={theme.textSecondary}
+              value={roomTitle}
+              onChangeText={setRoomTitle}
+              maxLength={80}
+              returnKeyType='next'
+            />
+
+            <TextInput
+              style={[styles.modalInput, styles.modalInputMulti, { color: theme.text, borderColor: theme.border, backgroundColor: theme.card }]}
+              placeholder='Description (optional)'
+              placeholderTextColor={theme.textSecondary}
+              value={roomDescription}
+              onChangeText={setRoomDescription}
+              maxLength={200}
+              multiline
+              numberOfLines={3}
+            />
+
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                style={[styles.modalBtn, styles.modalBtnCancel, { borderColor: theme.border }]}
+                onPress={() => {
+                  setCreateModalVisible(false);
+                  setRoomTitle('');
+                  setRoomDescription('');
+                }}
+              >
+                <Text style={[styles.modalBtnText, { color: theme.text }]}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalBtn, styles.modalBtnCreate, { backgroundColor: theme.button, opacity: roomTitle.trim() ? 1 : 0.5 }]}
+                onPress={handleCreateRoom}
+                disabled={!roomTitle.trim() || createLoading}
+              >
+                {createLoading ? (
+                  <ActivityIndicator size='small' color={theme.buttonText} />
+                ) : (
+                  <Text style={[styles.modalBtnText, { color: theme.buttonText }]}>Go Live</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  backBtn: { width: 36, alignItems: 'flex-start' },
+  headerTitle: { fontSize: 18, fontWeight: 'bold', flex: 1, textAlign: 'center' },
+  createBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  authBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginHorizontal: 16,
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  authBannerText: { fontSize: 13 },
+  authBannerLink: { fontSize: 13, fontWeight: '600' },
+  loadingContainer: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  errorContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  errorText: { fontSize: 14, textAlign: 'center', marginBottom: 12 },
+  retryBtn: { paddingHorizontal: 20, paddingVertical: 8, borderRadius: 8, borderWidth: 1 },
+  listContent: { padding: 16, flexGrow: 1 },
+  roomCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 10,
+  },
+  hostAvatar: { width: 48, height: 48, borderRadius: 24 },
+  roomInfo: { flex: 1, marginLeft: 12 },
+  titleRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  roomTitle: { fontSize: 15, fontWeight: '600', flex: 1 },
+  liveBadge: { backgroundColor: '#22c55e', paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  liveText: { color: '#fff', fontSize: 10, fontWeight: '700' },
+  hostName: { fontSize: 13, marginTop: 3 },
+  participantWrap: { alignItems: 'center', marginLeft: 12, gap: 4 },
+  participantCount: { fontSize: 13, fontWeight: '600' },
+  emptyContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingTop: 80 },
+  emptyText: { fontSize: 16, fontWeight: '600', marginTop: 16 },
+  emptySubtext: { fontSize: 13, marginTop: 6 },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  modalSheet: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 24,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+  },
+  modalTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
+  modalInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  modalInputMulti: { minHeight: 80, textAlignVertical: 'top' },
+  modalButtons: { flexDirection: 'row', gap: 12, marginTop: 8 },
+  modalBtn: { flex: 1, paddingVertical: 14, borderRadius: 8, alignItems: 'center' },
+  modalBtnCancel: { borderWidth: 1 },
+  modalBtnCreate: {},
+  modalBtnText: { fontSize: 16, fontWeight: '600' },
+});

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -10,8 +10,11 @@ import {
   TextInput,
   Alert,
   Pressable,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Image as ExpoImage } from 'expo-image';
 import { FontAwesome } from '@expo/vector-icons';
@@ -25,6 +28,7 @@ import { useHangoutsRoom } from '../../hooks/useHangoutsRoom';
 export default function HangoutsLobbyScreen() {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
+  const insets = useSafeAreaInsets();
   const theme = getTheme(isDark ? 'dark' : 'light');
   const router = useRouter();
 
@@ -205,61 +209,70 @@ export default function HangoutsLobbyScreen() {
         animationType='slide'
         onRequestClose={() => setCreateModalVisible(false)}
       >
-        <View style={styles.modalOverlay}>
+        <KeyboardAvoidingView
+          style={styles.modalOverlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
           <View style={[styles.modalSheet, { backgroundColor: theme.background, borderColor: theme.border }]}>
-            <Text style={[styles.modalTitle, { color: theme.text }]}>Start a Hangout</Text>
+            <ScrollView
+              keyboardShouldPersistTaps='handled'
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={{ paddingBottom: insets.bottom + 8 }}
+            >
+              <Text style={[styles.modalTitle, { color: theme.text }]}>Start a Hangout</Text>
 
-            <TextInput
-              style={[styles.modalInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.card }]}
-              placeholder='Room title'
-              placeholderTextColor={theme.textSecondary}
-              value={roomTitle}
-              onChangeText={setRoomTitle}
-              maxLength={80}
-              returnKeyType='next'
-            />
+              <TextInput
+                style={[styles.modalInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.card }]}
+                placeholder='Room title'
+                placeholderTextColor={theme.textSecondary}
+                value={roomTitle}
+                onChangeText={setRoomTitle}
+                maxLength={80}
+                returnKeyType='next'
+              />
 
-            <TextInput
-              style={[styles.modalInput, styles.modalInputMulti, { color: theme.text, borderColor: theme.border, backgroundColor: theme.card }]}
-              placeholder='Description (optional)'
-              placeholderTextColor={theme.textSecondary}
-              value={roomDescription}
-              onChangeText={setRoomDescription}
-              maxLength={200}
-              multiline
-              numberOfLines={3}
-            />
+              <TextInput
+                style={[styles.modalInput, styles.modalInputMulti, { color: theme.text, borderColor: theme.border, backgroundColor: theme.card }]}
+                placeholder='Description (optional)'
+                placeholderTextColor={theme.textSecondary}
+                value={roomDescription}
+                onChangeText={setRoomDescription}
+                maxLength={200}
+                multiline
+                numberOfLines={3}
+              />
 
-            <View style={styles.modalButtons}>
-              <TouchableOpacity
-                style={[styles.modalBtn, styles.modalBtnCancel, { borderColor: theme.border }]}
-                accessibilityRole='button'
-                accessibilityLabel='Cancel'
-                onPress={() => {
-                  setCreateModalVisible(false);
-                  setRoomTitle('');
-                  setRoomDescription('');
-                }}
-              >
-                <Text style={[styles.modalBtnText, { color: theme.text }]}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.modalBtn, styles.modalBtnCreate, { backgroundColor: theme.button, opacity: roomTitle.trim() ? 1 : 0.5 }]}
-                accessibilityRole='button'
-                accessibilityLabel='Go Live'
-                accessibilityHint='Creates the room and starts your hangout'
-                onPress={handleCreateRoom}
-                disabled={!roomTitle.trim() || createLoading}
-              >
-                {createLoading ? (
-                  <ActivityIndicator size='small' color={theme.buttonText} />
-                ) : (
-                  <Text style={[styles.modalBtnText, { color: theme.buttonText }]}>Go Live</Text>
-                )}
-              </TouchableOpacity>
-            </View>
+              <View style={styles.modalButtons}>
+                <TouchableOpacity
+                  style={[styles.modalBtn, styles.modalBtnCancel, { borderColor: theme.border }]}
+                  accessibilityRole='button'
+                  accessibilityLabel='Cancel'
+                  onPress={() => {
+                    setCreateModalVisible(false);
+                    setRoomTitle('');
+                    setRoomDescription('');
+                  }}
+                >
+                  <Text style={[styles.modalBtnText, { color: theme.text }]}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.modalBtn, styles.modalBtnCreate, { backgroundColor: theme.button, opacity: roomTitle.trim() ? 1 : 0.5 }]}
+                  accessibilityRole='button'
+                  accessibilityLabel='Go Live'
+                  accessibilityHint='Creates the room and starts your hangout'
+                  onPress={handleCreateRoom}
+                  disabled={!roomTitle.trim() || createLoading}
+                >
+                  {createLoading ? (
+                    <ActivityIndicator size='small' color={theme.buttonText} />
+                  ) : (
+                    <Text style={[styles.modalBtnText, { color: theme.buttonText }]}>Go Live</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
   );

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -65,6 +65,9 @@ export default function HangoutsLobbyScreen() {
     <Pressable
       style={[styles.roomCard, { backgroundColor: theme.card, borderColor: theme.border }]}
       onPress={() => handleRoomPress(item)}
+      accessibilityRole='button'
+      accessibilityLabel={`${item.title} by @${item.host}`}
+      accessibilityHint={`${item.numParticipants ?? 0} listening. Tap to join`}
     >
       <ExpoImage
         source={{ uri: `https://images.hive.blog/u/${item.host}/avatar/sm` }}

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -41,7 +41,7 @@ export default function HangoutsLobbyScreen() {
   const [roomTitle, setRoomTitle] = useState('');
   const [roomDescription, setRoomDescription] = useState('');
 
-  const runAuthenticate = async (interactive: boolean): Promise<boolean> => {
+  const runAuthenticate = useCallback(async (interactive: boolean): Promise<boolean> => {
     try {
       const ok = await authenticate();
       if (!ok && interactive) {
@@ -57,7 +57,7 @@ export default function HangoutsLobbyScreen() {
       }
       return false;
     }
-  };
+  }, [authenticate]);
 
   useEffect(() => {
     if (!isAuthenticated && !authLoading) {

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -76,7 +76,7 @@ export default function HangoutsLobbyScreen() {
       onPress={() => handleRoomPress(item)}
       accessibilityRole='button'
       accessibilityLabel={`${item.title} by @${item.host}`}
-      accessibilityHint={`${item.numParticipants ?? 0} listening. Tap to join`}
+      accessibilityHint={`${item.numParticipants ?? 0} listening. Audio joining coming soon`}
     >
       <ExpoImage
         source={{ uri: `https://images.hive.blog/u/${item.host}/avatar/sm` }}

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -149,7 +149,11 @@ export default function HangoutsLobbyScreen() {
           <Text style={[styles.authBannerText, { color: theme.textSecondary }]}>
             Sign in to create or join rooms
           </Text>
-          <TouchableOpacity onPress={() => authenticate()}>
+          <TouchableOpacity onPress={() => {
+            authenticate().then((ok) => {
+              if (!ok) Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
+            });
+          }}>
             <Text style={[styles.authBannerLink, { color: theme.button }]}>Connect</Text>
           </TouchableOpacity>
         </View>
@@ -160,7 +164,7 @@ export default function HangoutsLobbyScreen() {
         <View style={styles.loadingContainer}>
           <ActivityIndicator size='large' color={theme.button} />
         </View>
-      ) : roomsError ? (
+      ) : roomsError && rooms.length === 0 ? (
         <View style={styles.errorContainer}>
           <Text style={[styles.errorText, { color: theme.textSecondary }]}>{roomsError}</Text>
           <TouchableOpacity onPress={refresh} style={[styles.retryBtn, { borderColor: theme.border }]}>
@@ -168,15 +172,25 @@ export default function HangoutsLobbyScreen() {
           </TouchableOpacity>
         </View>
       ) : (
-        <FlatList
-          data={rooms}
-          keyExtractor={(item) => item.name}
-          renderItem={renderRoomCard}
-          ListEmptyComponent={renderEmpty}
-          contentContainerStyle={styles.listContent}
-          onRefresh={refresh}
-          refreshing={roomsLoading}
-        />
+        <>
+          {roomsError && (
+            <View style={[styles.inlineError, { backgroundColor: theme.card, borderColor: theme.border }]}>
+              <Text style={[styles.inlineErrorText, { color: theme.textSecondary }]}>{roomsError}</Text>
+              <TouchableOpacity onPress={refresh}>
+                <Text style={[styles.inlineErrorRetry, { color: theme.button }]}>Retry</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+          <FlatList
+            data={rooms}
+            keyExtractor={(item) => item.name}
+            renderItem={renderRoomCard}
+            ListEmptyComponent={renderEmpty}
+            contentContainerStyle={styles.listContent}
+            onRefresh={refresh}
+            refreshing={roomsLoading}
+          />
+        </>
       )}
 
       {/* Create Room Modal */}
@@ -276,6 +290,19 @@ const styles = StyleSheet.create({
   errorContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
   errorText: { fontSize: 14, textAlign: 'center', marginBottom: 12 },
   retryBtn: { paddingHorizontal: 20, paddingVertical: 8, borderRadius: 8, borderWidth: 1 },
+  inlineError: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginHorizontal: 16,
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  inlineErrorText: { fontSize: 13, flex: 1 },
+  inlineErrorRetry: { fontSize: 13, fontWeight: '600', marginLeft: 12 },
   listContent: { padding: 16, flexGrow: 1 },
   roomCard: {
     flexDirection: 'row',

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -41,9 +41,27 @@ export default function HangoutsLobbyScreen() {
   const [roomTitle, setRoomTitle] = useState('');
   const [roomDescription, setRoomDescription] = useState('');
 
+  const runAuthenticate = async (interactive: boolean): Promise<boolean> => {
+    try {
+      const ok = await authenticate();
+      if (!ok && interactive) {
+        Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
+      }
+      return ok;
+    } catch (err) {
+      if (interactive) {
+        Alert.alert(
+          'Sign in required',
+          err instanceof Error ? err.message : 'Could not authenticate with Hangouts server.',
+        );
+      }
+      return false;
+    }
+  };
+
   useEffect(() => {
     if (!isAuthenticated && !authLoading) {
-      authenticate();
+      void runAuthenticate(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-once auth check
   }, []);
@@ -142,9 +160,8 @@ export default function HangoutsLobbyScreen() {
           onPress={() => {
             if (authLoading) return;
             if (!isAuthenticated) {
-              authenticate().then((ok) => {
+              void runAuthenticate(true).then((ok) => {
                 if (ok) setCreateModalVisible(true);
-                else Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
               });
             } else {
               setCreateModalVisible(true);
@@ -167,11 +184,7 @@ export default function HangoutsLobbyScreen() {
             variant='secondary'
             labelColor={theme.button}
             borderColor={theme.button}
-            onPress={() => {
-              authenticate().then((ok) => {
-                if (!ok) Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
-              });
-            }}
+            onPress={() => { void runAuthenticate(true); }}
             style={styles.authBannerBtn}
           />
         </View>

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -88,7 +88,7 @@ export default function HangoutsLobbyScreen() {
           <Text style={[styles.roomTitle, { color: theme.text }]} numberOfLines={1}>
             {item.title}
           </Text>
-          <View style={styles.liveBadge}>
+          <View style={[styles.liveBadge, { backgroundColor: theme.success }]}>
             <Text style={styles.liveText}>LIVE</Text>
           </View>
         </View>
@@ -340,7 +340,7 @@ const styles = StyleSheet.create({
   roomInfo: { flex: 1, marginLeft: 12 },
   titleRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   roomTitle: { fontSize: 15, fontWeight: '600', flex: 1 },
-  liveBadge: { backgroundColor: '#22c55e', paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  liveBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
   liveText: { color: '#fff', fontSize: 10, fontWeight: '700' },
   hostName: { fontSize: 13, marginTop: 3 },
   participantWrap: { alignItems: 'center', marginLeft: 12, gap: 4 },

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -4,15 +4,14 @@ import {
   Text,
   FlatList,
   StyleSheet,
-  TouchableOpacity,
   ActivityIndicator,
   Modal,
   TextInput,
   Alert,
-  Pressable,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  Pressable,
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -24,6 +23,8 @@ import { getTheme } from '../../constants/Colors';
 import { useHangoutsAuth } from '../../hooks/useHangoutsAuth';
 import { useHangoutsRoomList } from '../../hooks/useHangoutsRoomList';
 import { useHangoutsRoom } from '../../hooks/useHangoutsRoom';
+import IconButton from '../components/IconButton';
+import PrimaryButton from '../components/PrimaryButton';
 
 export default function HangoutsLobbyScreen() {
   const colorScheme = useColorScheme();
@@ -124,22 +125,20 @@ export default function HangoutsLobbyScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: theme.border }]}>
-        <TouchableOpacity
+        <IconButton
+          name='arrow-left'
+          size={20}
+          color={theme.text}
           onPress={() => router.back()}
-          style={styles.backBtn}
-          accessibilityRole='button'
           accessibilityLabel='Go back'
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        >
-          <FontAwesome name='arrow-left' size={20} color={theme.text} />
-        </TouchableOpacity>
+          style={styles.backBtn}
+        />
         <Text style={[styles.headerTitle, { color: theme.text }]}>Hangouts</Text>
-        <TouchableOpacity
-          style={[styles.createBtn, { backgroundColor: theme.button }]}
-          accessibilityRole='button'
-          accessibilityLabel='Start a new hangout'
-          accessibilityHint='Opens room creation form'
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        <IconButton
+          name='plus'
+          size={14}
+          color={theme.buttonText}
+          backgroundColor={theme.button}
           onPress={() => {
             if (authLoading) return;
             if (!isAuthenticated) {
@@ -152,9 +151,9 @@ export default function HangoutsLobbyScreen() {
             }
           }}
           disabled={createLoading || authLoading}
-        >
-          <FontAwesome name='plus' size={14} color={theme.buttonText} />
-        </TouchableOpacity>
+          accessibilityLabel='Start a new hangout'
+          accessibilityHint='Opens room creation form'
+        />
       </View>
 
       {/* Auth banner */}
@@ -163,13 +162,18 @@ export default function HangoutsLobbyScreen() {
           <Text style={[styles.authBannerText, { color: theme.textSecondary }]}>
             Sign in to create or join rooms
           </Text>
-          <TouchableOpacity onPress={() => {
-            authenticate().then((ok) => {
-              if (!ok) Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
-            });
-          }}>
-            <Text style={[styles.authBannerLink, { color: theme.button }]}>Connect</Text>
-          </TouchableOpacity>
+          <PrimaryButton
+            label='Connect'
+            variant='secondary'
+            labelColor={theme.button}
+            borderColor={theme.button}
+            onPress={() => {
+              authenticate().then((ok) => {
+                if (!ok) Alert.alert('Sign in required', 'Could not authenticate with Hangouts server.');
+              });
+            }}
+            style={styles.authBannerBtn}
+          />
         </View>
       )}
 
@@ -181,18 +185,28 @@ export default function HangoutsLobbyScreen() {
       ) : roomsError && rooms.length === 0 ? (
         <View style={styles.errorContainer}>
           <Text style={[styles.errorText, { color: theme.textSecondary }]}>{roomsError}</Text>
-          <TouchableOpacity onPress={refresh} style={[styles.retryBtn, { borderColor: theme.border }]}>
-            <Text style={{ color: theme.button }}>Retry</Text>
-          </TouchableOpacity>
+          <PrimaryButton
+            label='Retry'
+            variant='secondary'
+            borderColor={theme.border}
+            labelColor={theme.button}
+            onPress={refresh}
+            style={styles.retryBtn}
+          />
         </View>
       ) : (
         <>
           {roomsError && (
             <View style={[styles.inlineError, { backgroundColor: theme.card, borderColor: theme.border }]}>
               <Text style={[styles.inlineErrorText, { color: theme.textSecondary }]}>{roomsError}</Text>
-              <TouchableOpacity onPress={refresh}>
-                <Text style={[styles.inlineErrorRetry, { color: theme.button }]}>Retry</Text>
-              </TouchableOpacity>
+              <PrimaryButton
+                label='Retry'
+                variant='secondary'
+                borderColor='transparent'
+                labelColor={theme.button}
+                onPress={refresh}
+                style={styles.inlineRetryBtn}
+              />
             </View>
           )}
           <FlatList
@@ -248,28 +262,23 @@ export default function HangoutsLobbyScreen() {
               />
 
               <View style={styles.modalButtons}>
-                <TouchableOpacity
-                  style={[styles.modalBtn, styles.modalBtnCancel, { borderColor: theme.border }]}
-                  accessibilityRole='button'
-                  accessibilityLabel='Cancel'
+                <PrimaryButton
+                  label='Cancel'
+                  variant='cancel'
+                  borderColor={theme.border}
+                  labelColor={theme.text}
                   onPress={closeCreateModal}
-                >
-                  <Text style={[styles.modalBtnText, { color: theme.text }]}>Cancel</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.modalBtn, styles.modalBtnCreate, { backgroundColor: theme.button, opacity: roomTitle.trim() ? 1 : 0.5 }]}
-                  accessibilityRole='button'
-                  accessibilityLabel='Go Live'
-                  accessibilityHint='Creates the room and starts your hangout'
+                />
+                <PrimaryButton
+                  label='Go Live'
+                  variant='primary'
+                  backgroundColor={theme.button}
+                  textColor={theme.buttonText}
+                  loading={createLoading}
+                  disabled={!roomTitle.trim()}
                   onPress={handleCreateRoom}
-                  disabled={!roomTitle.trim() || createLoading}
-                >
-                  {createLoading ? (
-                    <ActivityIndicator size='small' color={theme.buttonText} />
-                  ) : (
-                    <Text style={[styles.modalBtnText, { color: theme.buttonText }]}>Go Live</Text>
-                  )}
-                </TouchableOpacity>
+                  accessibilityHint='Creates the room and starts your hangout'
+                />
               </View>
             </ScrollView>
           </View>
@@ -289,15 +298,8 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderBottomWidth: 1,
   },
-  backBtn: { width: 36, alignItems: 'flex-start' },
+  backBtn: { alignItems: 'flex-start' },
   headerTitle: { fontSize: 18, fontWeight: 'bold', flex: 1, textAlign: 'center' },
-  createBtn: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
   authBanner: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -308,12 +310,12 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     borderWidth: 1,
   },
-  authBannerText: { fontSize: 13 },
-  authBannerLink: { fontSize: 13, fontWeight: '600' },
+  authBannerText: { fontSize: 13, flex: 1 },
+  authBannerBtn: { flex: 0, paddingVertical: 6, paddingHorizontal: 12 },
   loadingContainer: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   errorContainer: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
   errorText: { fontSize: 14, textAlign: 'center', marginBottom: 12 },
-  retryBtn: { paddingHorizontal: 20, paddingVertical: 8, borderRadius: 8, borderWidth: 1 },
+  retryBtn: { flex: 0, paddingHorizontal: 20, paddingVertical: 8 },
   inlineError: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -321,12 +323,12 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     marginTop: 8,
     paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingVertical: 4,
     borderRadius: 8,
     borderWidth: 1,
   },
   inlineErrorText: { fontSize: 13, flex: 1 },
-  inlineErrorRetry: { fontSize: 13, fontWeight: '600', marginLeft: 12 },
+  inlineRetryBtn: { flex: 0, paddingVertical: 8, paddingHorizontal: 12 },
   listContent: { padding: 16, flexGrow: 1 },
   roomCard: {
     flexDirection: 'row',
@@ -366,8 +368,4 @@ const styles = StyleSheet.create({
   },
   modalInputMulti: { minHeight: 80, textAlignVertical: 'top' },
   modalButtons: { flexDirection: 'row', gap: 12, marginTop: 8 },
-  modalBtn: { flex: 1, paddingVertical: 14, borderRadius: 8, alignItems: 'center' },
-  modalBtnCancel: { borderWidth: 1 },
-  modalBtnCreate: {},
-  modalBtnText: { fontSize: 16, fontWeight: '600' },
 });

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -35,7 +35,7 @@ export default function HangoutsLobbyScreen() {
 
   const { isAuthenticated, isLoading: authLoading, authenticate } = useHangoutsAuth();
   const { rooms, isLoading: roomsLoading, error: roomsError, refresh } = useHangoutsRoomList();
-  const { create, isLoading: createLoading, error: createError } = useHangoutsRoom();
+  const { create, isLoading: createLoading } = useHangoutsRoom();
 
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [roomTitle, setRoomTitle] = useState('');
@@ -66,13 +66,13 @@ export default function HangoutsLobbyScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-once auth check
   }, []);
 
-  const closeCreateModal = () => {
+  const closeCreateModal = (): void => {
     setCreateModalVisible(false);
     setRoomTitle('');
     setRoomDescription('');
   };
 
-  const handleCreateRoom = async () => {
+  const handleCreateRoom = async (): Promise<void> => {
     const trimmed = roomTitle.trim();
     if (!trimmed) return;
     try {
@@ -85,11 +85,11 @@ export default function HangoutsLobbyScreen() {
     }
   };
 
-  const handleRoomPress = (_room: Room) => {
+  const handleRoomPress = (_room: Room): void => {
     Alert.alert('Coming Soon', 'Audio joining is coming in Phase 2!');
   };
 
-  const renderRoomCard = ({ item }: { item: Room }) => (
+  const renderRoomCard = ({ item }: { item: Room }): React.ReactElement => (
     <Pressable
       style={[styles.roomCard, { backgroundColor: theme.card, borderColor: theme.border }]}
       onPress={() => handleRoomPress(item)}
@@ -124,7 +124,7 @@ export default function HangoutsLobbyScreen() {
     </Pressable>
   );
 
-  const renderEmpty = () => {
+  const renderEmpty = (): React.ReactElement | null => {
     if (roomsLoading || authLoading) return null;
     return (
       <View style={styles.emptyContainer}>

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -40,6 +40,7 @@ export default function HangoutsLobbyScreen() {
     if (!isAuthenticated && !authLoading) {
       authenticate();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-once auth check
   }, []);
 
   const handleCreateRoom = async () => {
@@ -130,6 +131,7 @@ export default function HangoutsLobbyScreen() {
           accessibilityRole='button'
           accessibilityLabel='Start a new hangout'
           accessibilityHint='Opens room creation form'
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           onPress={() => {
             if (!isAuthenticated) {
               authenticate().then((ok) => {
@@ -231,6 +233,8 @@ export default function HangoutsLobbyScreen() {
             <View style={styles.modalButtons}>
               <TouchableOpacity
                 style={[styles.modalBtn, styles.modalBtnCancel, { borderColor: theme.border }]}
+                accessibilityRole='button'
+                accessibilityLabel='Cancel'
                 onPress={() => {
                   setCreateModalVisible(false);
                   setRoomTitle('');
@@ -241,6 +245,9 @@ export default function HangoutsLobbyScreen() {
               </TouchableOpacity>
               <TouchableOpacity
                 style={[styles.modalBtn, styles.modalBtnCreate, { backgroundColor: theme.button, opacity: roomTitle.trim() ? 1 : 0.5 }]}
+                accessibilityRole='button'
+                accessibilityLabel='Go Live'
+                accessibilityHint='Creates the room and starts your hangout'
                 onPress={handleCreateRoom}
                 disabled={!roomTitle.trim() || createLoading}
               >

--- a/hooks/useHangoutsAuth.ts
+++ b/hooks/useHangoutsAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { HangoutsApiClient } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
@@ -12,18 +12,22 @@ interface UseHangoutsAuthResult {
 export function useHangoutsAuth(): UseHangoutsAuthResult {
   const [isAuthenticated, setIsAuthenticated] = useState(hangoutsAuthService.isAuthenticated());
   const [isLoading, setIsLoading] = useState(false);
+  // Ref-based guard so the closure always sees the latest in-flight state
+  const isLoadingRef = useRef(false);
 
   const authenticate = useCallback(async (): Promise<boolean> => {
-    if (isLoading) return false;
+    if (isLoadingRef.current) return false;
+    isLoadingRef.current = true;
     setIsLoading(true);
     try {
       const success = await hangoutsAuthService.authenticate();
       setIsAuthenticated(success);
       return success;
     } finally {
+      isLoadingRef.current = false;
       setIsLoading(false);
     }
-  }, [isLoading]);
+  }, []);
 
   return {
     isAuthenticated,

--- a/hooks/useHangoutsAuth.ts
+++ b/hooks/useHangoutsAuth.ts
@@ -1,11 +1,20 @@
 import { useState, useCallback } from 'react';
+import type { HangoutsApiClient } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
-export function useHangoutsAuth() {
+interface UseHangoutsAuthResult {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  authenticate: () => Promise<boolean>;
+  client: HangoutsApiClient;
+}
+
+export function useHangoutsAuth(): UseHangoutsAuthResult {
   const [isAuthenticated, setIsAuthenticated] = useState(hangoutsAuthService.isAuthenticated());
   const [isLoading, setIsLoading] = useState(false);
 
-  const authenticate = useCallback(async () => {
+  const authenticate = useCallback(async (): Promise<boolean> => {
+    if (isLoading) return false;
     setIsLoading(true);
     try {
       const success = await hangoutsAuthService.authenticate();
@@ -14,7 +23,7 @@ export function useHangoutsAuth() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [isLoading]);
 
   return {
     isAuthenticated,

--- a/hooks/useHangoutsAuth.ts
+++ b/hooks/useHangoutsAuth.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+import { hangoutsAuthService } from '../services/HangoutsAuthService';
+
+export function useHangoutsAuth() {
+  const [isAuthenticated, setIsAuthenticated] = useState(hangoutsAuthService.isAuthenticated());
+  const [isLoading, setIsLoading] = useState(false);
+
+  const authenticate = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const success = await hangoutsAuthService.authenticate();
+      setIsAuthenticated(success);
+      return success;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return {
+    isAuthenticated,
+    isLoading,
+    authenticate,
+    client: hangoutsAuthService.getClient(),
+  };
+}

--- a/hooks/useHangoutsCount.ts
+++ b/hooks/useHangoutsCount.ts
@@ -1,33 +1,38 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useCallback, useRef } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
-const POLL_INTERVAL = 30_000; // less aggressive than the lobby's 10s
+const POLL_INTERVAL = 30_000;
 
 /**
  * Lightweight hook for the feed header badge.
  * Returns the number of currently active hangout rooms.
- * Polls every 30 seconds and fails silently — a missing count is not critical.
+ * Polling only runs while the screen is focused — stops on blur to save battery.
+ * Fails silently — a missing count is not critical.
  */
 export function useHangoutsCount(): number {
   const [count, setCount] = useState(0);
   const mountedRef = useRef(true);
 
-  useEffect(() => {
-    mountedRef.current = true;
+  useFocusEffect(
+    useCallback(() => {
+      mountedRef.current = true;
 
-    const fetch = () => {
-      hangoutsAuthService.getClient().listRooms()
-        .then((rooms) => { if (mountedRef.current) setCount(rooms.length); })
-        .catch(() => {}); // non-critical — badge just stays at 0
-    };
+      const fetch = () => {
+        hangoutsAuthService.getClient().listRooms()
+          .then((rooms) => { if (mountedRef.current) setCount(rooms.length); })
+          .catch(() => {});
+      };
 
-    fetch();
-    const interval = setInterval(fetch, POLL_INTERVAL);
-    return () => {
-      mountedRef.current = false;
-      clearInterval(interval);
-    };
-  }, []);
+      fetch();
+      const interval = setInterval(fetch, POLL_INTERVAL);
+
+      return () => {
+        mountedRef.current = false;
+        clearInterval(interval);
+      };
+    }, [])
+  );
 
   return count;
 }

--- a/hooks/useHangoutsCount.ts
+++ b/hooks/useHangoutsCount.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useRef } from 'react';
+import { hangoutsAuthService } from '../services/HangoutsAuthService';
+
+const POLL_INTERVAL = 30_000; // less aggressive than the lobby's 10s
+
+/**
+ * Lightweight hook for the feed header badge.
+ * Returns the number of currently active hangout rooms.
+ * Polls every 30 seconds and fails silently — a missing count is not critical.
+ */
+export function useHangoutsCount(): number {
+  const [count, setCount] = useState(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    const fetch = () => {
+      hangoutsAuthService.getClient().listRooms()
+        .then((rooms) => { if (mountedRef.current) setCount(rooms.length); })
+        .catch(() => {}); // non-critical — badge just stays at 0
+    };
+
+    fetch();
+    const interval = setInterval(fetch, POLL_INTERVAL);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return count;
+}

--- a/hooks/useHangoutsCount.ts
+++ b/hooks/useHangoutsCount.ts
@@ -8,19 +8,20 @@ const POLL_INTERVAL = 30_000;
  * Lightweight hook for the feed header badge.
  * Returns the number of currently active hangout rooms.
  * Polling only runs while the screen is focused — stops on blur to save battery.
- * Fails silently — a missing count is not critical.
+ * Uses a generation counter so a stale response from a previous focus cycle
+ * cannot overwrite a fresh count after refocus. Fails silently.
  */
 export function useHangoutsCount(): number {
   const [count, setCount] = useState(0);
-  const mountedRef = useRef(true);
+  const generationRef = useRef(0);
 
   useFocusEffect(
     useCallback(() => {
-      mountedRef.current = true;
+      const gen = ++generationRef.current;
 
       const fetch = () => {
         hangoutsAuthService.getClient().listRooms()
-          .then((rooms) => { if (mountedRef.current) setCount(rooms.length); })
+          .then((rooms) => { if (generationRef.current === gen) setCount(rooms.length); })
           .catch(() => {});
       };
 
@@ -28,7 +29,7 @@ export function useHangoutsCount(): number {
       const interval = setInterval(fetch, POLL_INTERVAL);
 
       return () => {
-        mountedRef.current = false;
+        generationRef.current++; // invalidate in-flight requests from this cycle
         clearInterval(interval);
       };
     }, [])

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import type { Room } from '@snapie/hangouts-core';
+import { hangoutsAuthService } from '../services/HangoutsAuthService';
+
+export function useHangoutsRoom() {
+  const [livekitToken, setLivekitToken] = useState<string | null>(null);
+  const [roomName, setRoomName] = useState<string | null>(null);
+  const [roomMeta, setRoomMeta] = useState<Room | null>(null);
+  const [isHost, setIsHost] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const client = hangoutsAuthService.getClient();
+
+  const join = useCallback(async (name: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [result, meta] = await Promise.all([
+        client.joinRoom(name),
+        client.getRoom(name),
+      ]);
+      setLivekitToken(result.token);
+      setRoomName(result.roomName);
+      setRoomMeta(meta);
+      setIsHost(result.isHost);
+      return result;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to join room');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client]);
+
+  const create = useCallback(async (title: string, description?: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { room, token } = await client.createRoom(title, description);
+      setLivekitToken(token);
+      setRoomName(room.name);
+      setRoomMeta(room);
+      setIsHost(true);
+      return room;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create room');
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client]);
+
+  const leave = useCallback(() => {
+    setLivekitToken(null);
+    setRoomName(null);
+    setRoomMeta(null);
+    setIsHost(false);
+    setError(null);
+  }, []);
+
+  return { livekitToken, roomName, roomMeta, isHost, isLoading, error, join, create, leave };
+}

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -37,13 +37,16 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
       setLivekitToken(result.token);
       setRoomName(joinedName);
       setIsHost(result.isHost);
+      setRoomMeta(null); // clear stale metadata before the lookup resolves
       // Best-effort metadata using the server-normalized room name.
-      // Only commits if no newer join has started since.
+      // Only commits if no newer join/create/leave has invalidated the ref.
       client.getRoom(joinedName)
         .then((meta) => {
           if (latestJoinRef.current === joinedName) setRoomMeta(meta);
         })
-        .catch(() => {});
+        .catch(() => {
+          if (latestJoinRef.current === joinedName) setRoomMeta(null);
+        });
       return result;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to join room');
@@ -56,6 +59,7 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
   const create = useCallback(async (title: string, description?: string): Promise<Room> => {
     setIsLoading(true);
     setError(null);
+    latestJoinRef.current = null; // invalidate any in-flight join metadata lookup
     try {
       const { room, token }: CreateRoomResponse = await client.createRoom(title, description);
       setLivekitToken(token);
@@ -72,6 +76,7 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
   }, [client]);
 
   const leave = useCallback(() => {
+    latestJoinRef.current = null; // invalidate any in-flight metadata lookup
     setLivekitToken(null);
     setRoomName(null);
     setRoomMeta(null);

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -23,23 +23,28 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
   const [error, setError] = useState<string | null>(null);
 
   const client = hangoutsAuthService.getClient();
-  // Tracks the most recently joined room name so stale getRoom responses can't
-  // overwrite metadata if a second join happens before the first resolves.
+
+  // Incremented on every join/create/leave so any in-flight async completion
+  // from a previous operation cannot write state after the room has changed.
+  const activeOpRef = useRef(0);
+  // Tracks the normalized room name of the latest join for the best-effort
+  // getRoom metadata lookup.
   const latestJoinRef = useRef<string | null>(null);
 
   const join = useCallback(async (name: string): Promise<JoinRoomResponse> => {
+    const op = ++activeOpRef.current;
     setIsLoading(true);
     setError(null);
     try {
       const result = await client.joinRoom(name);
+      if (activeOpRef.current !== op) return result; // superseded by leave/create
       const joinedName = result.roomName;
       latestJoinRef.current = joinedName;
       setLivekitToken(result.token);
       setRoomName(joinedName);
       setIsHost(result.isHost);
-      setRoomMeta(null); // clear stale metadata before the lookup resolves
-      // Best-effort metadata using the server-normalized room name.
-      // Only commits if no newer join/create/leave has invalidated the ref.
+      setRoomMeta(null); // clear stale metadata before lookup
+      // Best-effort metadata — only commits if this op is still the latest.
       client.getRoom(joinedName)
         .then((meta) => {
           if (latestJoinRef.current === joinedName) setRoomMeta(meta);
@@ -49,34 +54,42 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
         });
       return result;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to join room');
+      if (activeOpRef.current === op) {
+        setError(err instanceof Error ? err.message : 'Failed to join room');
+      }
       throw err;
     } finally {
-      setIsLoading(false);
+      if (activeOpRef.current === op) setIsLoading(false);
     }
   }, [client]);
 
   const create = useCallback(async (title: string, description?: string): Promise<Room> => {
+    const op = ++activeOpRef.current;
+    latestJoinRef.current = null; // invalidate any in-flight join metadata lookup
     setIsLoading(true);
     setError(null);
-    latestJoinRef.current = null; // invalidate any in-flight join metadata lookup
     try {
       const { room, token }: CreateRoomResponse = await client.createRoom(title, description);
+      if (activeOpRef.current !== op) return room; // superseded by leave
       setLivekitToken(token);
       setRoomName(room.name);
       setRoomMeta(room);
       setIsHost(true);
       return room;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create room');
+      if (activeOpRef.current === op) {
+        setError(err instanceof Error ? err.message : 'Failed to create room');
+      }
       throw err;
     } finally {
-      setIsLoading(false);
+      if (activeOpRef.current === op) setIsLoading(false);
     }
   }, [client]);
 
   const leave = useCallback(() => {
-    latestJoinRef.current = null; // invalidate any in-flight metadata lookup
+    activeOpRef.current++; // invalidate any in-flight join/create completion
+    latestJoinRef.current = null;
+    setIsLoading(false); // clear loading if an op was in flight
     setLivekitToken(null);
     setRoomName(null);
     setRoomMeta(null);

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { Room, JoinRoomResponse, CreateRoomResponse } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
@@ -23,17 +23,27 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
   const [error, setError] = useState<string | null>(null);
 
   const client = hangoutsAuthService.getClient();
+  // Tracks the most recently joined room name so stale getRoom responses can't
+  // overwrite metadata if a second join happens before the first resolves.
+  const latestJoinRef = useRef<string | null>(null);
 
   const join = useCallback(async (name: string): Promise<JoinRoomResponse> => {
     setIsLoading(true);
     setError(null);
     try {
       const result = await client.joinRoom(name);
+      const joinedName = result.roomName;
+      latestJoinRef.current = joinedName;
       setLivekitToken(result.token);
-      setRoomName(result.roomName);
+      setRoomName(joinedName);
       setIsHost(result.isHost);
-      // Best-effort metadata — don't fail the join if this 404s
-      client.getRoom(name).then(setRoomMeta).catch(() => {});
+      // Best-effort metadata using the server-normalized room name.
+      // Only commits if no newer join has started since.
+      client.getRoom(joinedName)
+        .then((meta) => {
+          if (latestJoinRef.current === joinedName) setRoomMeta(meta);
+        })
+        .catch(() => {});
       return result;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to join room');

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -1,8 +1,20 @@
 import { useState, useCallback } from 'react';
-import type { Room } from '@snapie/hangouts-core';
+import type { Room, JoinRoomResponse, CreateRoomResponse } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
-export function useHangoutsRoom() {
+interface UseHangoutsRoomResult {
+  livekitToken: string | null;
+  roomName: string | null;
+  roomMeta: Room | null;
+  isHost: boolean;
+  isLoading: boolean;
+  error: string | null;
+  join: (name: string) => Promise<JoinRoomResponse>;
+  create: (title: string, description?: string) => Promise<Room>;
+  leave: () => void;
+}
+
+export function useHangoutsRoom(): UseHangoutsRoomResult {
   const [livekitToken, setLivekitToken] = useState<string | null>(null);
   const [roomName, setRoomName] = useState<string | null>(null);
   const [roomMeta, setRoomMeta] = useState<Room | null>(null);
@@ -12,18 +24,16 @@ export function useHangoutsRoom() {
 
   const client = hangoutsAuthService.getClient();
 
-  const join = useCallback(async (name: string) => {
+  const join = useCallback(async (name: string): Promise<JoinRoomResponse> => {
     setIsLoading(true);
     setError(null);
     try {
-      const [result, meta] = await Promise.all([
-        client.joinRoom(name),
-        client.getRoom(name),
-      ]);
+      const result = await client.joinRoom(name);
       setLivekitToken(result.token);
       setRoomName(result.roomName);
-      setRoomMeta(meta);
       setIsHost(result.isHost);
+      // Best-effort metadata — don't fail the join if this 404s
+      client.getRoom(name).then(setRoomMeta).catch(() => {});
       return result;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to join room');
@@ -33,11 +43,11 @@ export function useHangoutsRoom() {
     }
   }, [client]);
 
-  const create = useCallback(async (title: string, description?: string) => {
+  const create = useCallback(async (title: string, description?: string): Promise<Room> => {
     setIsLoading(true);
     setError(null);
     try {
-      const { room, token } = await client.createRoom(title, description);
+      const { room, token }: CreateRoomResponse = await client.createRoom(title, description);
       setLivekitToken(token);
       setRoomName(room.name);
       setRoomMeta(room);

--- a/hooks/useHangoutsRoomList.ts
+++ b/hooks/useHangoutsRoomList.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Room } from '@snapie/hangouts-core';
+import { hangoutsAuthService } from '../services/HangoutsAuthService';
+
+const POLL_INTERVAL = 10_000;
+
+export function useHangoutsRoomList() {
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await hangoutsAuthService.getClient().listRooms();
+      setRooms(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load rooms');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  return { rooms, isLoading, error, refresh };
+}

--- a/hooks/useHangoutsRoomList.ts
+++ b/hooks/useHangoutsRoomList.ts
@@ -1,30 +1,48 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Room } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
 const POLL_INTERVAL = 10_000;
 
-export function useHangoutsRoomList() {
+interface UseHangoutsRoomListResult {
+  rooms: Room[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useHangoutsRoomList(): UseHangoutsRoomListResult {
   const [rooms, setRooms] = useState<Room[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const inflightRef = useRef(false);
+  const mountedRef = useRef(true);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (): Promise<void> => {
+    if (inflightRef.current) return;
+    inflightRef.current = true;
     try {
       const data = await hangoutsAuthService.getClient().listRooms();
+      if (!mountedRef.current) return;
       setRooms(data);
       setError(null);
     } catch (err) {
+      if (!mountedRef.current) return;
       setError(err instanceof Error ? err.message : 'Failed to load rooms');
     } finally {
-      setIsLoading(false);
+      inflightRef.current = false;
+      if (mountedRef.current) setIsLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     refresh();
     const interval = setInterval(refresh, POLL_INTERVAL);
-    return () => clearInterval(interval);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(interval);
+    };
   }, [refresh]);
 
   return { rooms, isLoading, error, refresh };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/native-stack": "^7.3.10",
         "@react-navigation/stack": "^7.4.2",
+        "@snapie/hangouts-core": "^0.3.0",
         "date-fns": "^4.1.0",
         "expo": "^54.0.1",
         "expo-av": "~16.0.6",
@@ -4515,6 +4516,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@snapie/hangouts-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@snapie/hangouts-core/-/hangouts-core-0.3.0.tgz",
+      "integrity": "sha512-3GQfHptlUWK7quBi4ZQwA5eEtMT+t5ROloyI7Rh0VwsoF8mQorRdJo0UcOtBFvRNHfevdbW/mAbxiLr6HNPqow==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/native-stack": "^7.3.10",
     "@react-navigation/stack": "^7.4.2",
+    "@snapie/hangouts-core": "^0.3.0",
     "date-fns": "^4.1.0",
     "expo": "^54.0.1",
     "expo-av": "~16.0.6",
@@ -39,9 +40,11 @@
     "expo-image-picker": "~17.0.7",
     "expo-intent-launcher": "~13.0.6",
     "expo-linking": "~8.0.7",
+    "expo-local-authentication": "~17.0.8",
     "expo-media-library": "~18.1.1",
     "expo-notifications": "~0.32.10",
     "expo-router": "~6.0.0",
+    "expo-screen-orientation": "~9.0.8",
     "expo-secure-store": "~15.0.6",
     "expo-splash-screen": "~31.0.8",
     "expo-status-bar": "~3.0.7",
@@ -63,9 +66,7 @@
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0",
     "react-native-worklets": "^0.5.1",
-    "tus-js-client": "^4.3.1",
-    "expo-screen-orientation": "~9.0.8",
-    "expo-local-authentication": "~17.0.8"
+    "tus-js-client": "^4.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -33,7 +33,7 @@ class HangoutsAuthServiceImpl {
   /**
    * Sign a challenge string with the posting key.
    * The Hangouts server signs just the raw challenge (matching Keychain's requestSignBuffer behavior).
-   * Output format: r(32 bytes BE) + s(32 bytes BE) + recovery(1 byte) as hex — matches dhive Signature.
+   * Output format: [recoveryParam+31, r(32), s(32)] as hex — dhive Signature.fromString() wire format.
    */
   private signChallenge(challenge: string, postingKey: string): string {
     const decoded = bs58.decode(postingKey);
@@ -60,7 +60,10 @@ class HangoutsAuthServiceImpl {
     try {
       const username = await accountStorageService.getCurrentAccountUsername();
       const postingKey = await accountStorageService.getCurrentPostingKey();
-      if (!username || !postingKey) return false;
+      if (!username || !postingKey) {
+        this.clearSession();
+        return false;
+      }
 
       const { challenge } = await this.client.requestChallenge(username);
       const signature = this.signChallenge(challenge, postingKey);
@@ -69,7 +72,9 @@ class HangoutsAuthServiceImpl {
       this.client.setSessionToken(session.token);
       return true;
     } catch (error) {
-      console.error('[HangoutsAuth] Authentication failed:', error);
+      this.clearSession();
+      const name = error instanceof Error ? error.name : 'UnknownError';
+      console.error(`[HangoutsAuth] Authentication failed: ${name}`);
       return false;
     }
   }

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -7,7 +7,6 @@
 import { HangoutsApiClient } from '@snapie/hangouts-core';
 import { Buffer } from 'buffer';
 import { sha256 } from 'js-sha256';
-// @ts-ignore - bs58 types not needed for runtime
 import bs58 from 'bs58';
 import { ec as EC } from 'elliptic';
 import { accountStorageService } from './AccountStorageService';

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -1,0 +1,83 @@
+/**
+ * Hangouts Authentication Service
+ * Silently authenticates with the Hive Hangouts server using the stored posting key.
+ * Mirrors the signing pattern from AuthService.ts (bs58/elliptic, not dhive PrivateKey.sign).
+ */
+
+import { HangoutsApiClient } from '@snapie/hangouts-core';
+import { Buffer } from 'buffer';
+import { sha256 } from 'js-sha256';
+// @ts-ignore - bs58 types not needed for runtime
+import bs58 from 'bs58';
+import { ec as EC } from 'elliptic';
+import { accountStorageService } from './AccountStorageService';
+import { HANGOUTS_API_URL } from '../app/config/env';
+
+class HangoutsAuthServiceImpl {
+  private client: HangoutsApiClient;
+  private sessionToken: string | null = null;
+  private ec = new EC('secp256k1');
+
+  constructor() {
+    this.client = new HangoutsApiClient({ baseUrl: HANGOUTS_API_URL });
+  }
+
+  getClient(): HangoutsApiClient {
+    return this.client;
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.sessionToken;
+  }
+
+  /**
+   * Sign a challenge string with the posting key.
+   * The Hangouts server signs just the raw challenge (matching Keychain's requestSignBuffer behavior).
+   * Output format: r(32 bytes BE) + s(32 bytes BE) + recovery(1 byte) as hex — matches dhive Signature.
+   */
+  private signChallenge(challenge: string, postingKey: string): string {
+    const decoded = bs58.decode(postingKey);
+    const privateKeyBytes = decoded.slice(1, 33);
+    const key = this.ec.keyFromPrivate(privateKeyBytes);
+    const hashHex = sha256(challenge).toString();
+    const hashBuffer = Buffer.from(hashHex, 'hex');
+    const sigObj = key.sign(hashBuffer, { canonical: true });
+    const recoveryParam = sigObj.recoveryParam ?? 0;
+    // dhive Signature.fromString expects: [recoveryParam + 31, r(32), s(32)]
+    return Buffer.concat([
+      Buffer.from([recoveryParam + 31]),
+      sigObj.r.toArrayLike(Buffer, 'be', 32),
+      sigObj.s.toArrayLike(Buffer, 'be', 32),
+    ]).toString('hex');
+  }
+
+  /**
+   * Silently authenticate with the Hangouts server.
+   * Returns true on success, false if no stored key or auth fails.
+   * Non-fatal — hangouts features degrade gracefully on failure.
+   */
+  async authenticate(): Promise<boolean> {
+    try {
+      const username = await accountStorageService.getCurrentAccountUsername();
+      const postingKey = await accountStorageService.getCurrentPostingKey();
+      if (!username || !postingKey) return false;
+
+      const { challenge } = await this.client.requestChallenge(username);
+      const signature = this.signChallenge(challenge, postingKey);
+      const session = await this.client.verifySignature(username, challenge, signature);
+      this.sessionToken = session.token;
+      this.client.setSessionToken(session.token);
+      return true;
+    } catch (error) {
+      console.error('[HangoutsAuth] Authentication failed:', error);
+      return false;
+    }
+  }
+
+  clearSession(): void {
+    this.sessionToken = null;
+    this.client.clearSessionToken();
+  }
+}
+
+export const hangoutsAuthService = new HangoutsAuthServiceImpl();

--- a/utils/extractHangoutInfo.ts
+++ b/utils/extractHangoutInfo.ts
@@ -5,7 +5,7 @@
 export function extractHangoutRoomNames(content: string): string[] {
   const pattern = /https?:\/\/hangout\.3speak\.tv\/room\/([\w-]+)/g;
   const results: string[] = [];
-  let match;
+  let match: RegExpExecArray | null;
   while ((match = pattern.exec(content)) !== null) {
     results.push(match[1]);
   }

--- a/utils/extractHangoutInfo.ts
+++ b/utils/extractHangoutInfo.ts
@@ -1,0 +1,13 @@
+/**
+ * Extract hangout room names from post body content.
+ * Matches: https://hangout.3speak.tv/room/<room-name>
+ */
+export function extractHangoutRoomNames(content: string): string[] {
+  const pattern = /https?:\/\/hangout\.3speak\.tv\/room\/([\w-]+)/g;
+  const results: string[] = [];
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    results.push(match[1]);
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- **Auth**: `HangoutsAuthService` silently authenticates with the Hangouts server using the stored posting key. Signs with bs58/elliptic in dhive wire format (`[recoveryParam+31, r, s]`) so the server's `Signature.fromString()` verification passes.
- **Lobby screen**: `HangoutsLobbyScreen` lists active rooms (polling every 10s), shows LIVE badge + participant count, and lets authenticated users create rooms via a bottom-sheet modal. Accessible via microphone icon in the FeedScreen header.
- **Snap preview cards**: When a snap body contains a `hangout.3speak.tv/room/<name>` URL, `HangoutPreviewCard` fetches the room and renders a rich card (host avatar, title, LIVE badge, listener count). Gracefully shows "ended" state when the room is gone.
- **Phase 2 ready**: `useHangoutsRoom` returns a `livekitToken` for when we wire up `@livekit/react-native` audio.

## Files
| Action | File |
|--------|------|
| New | `services/HangoutsAuthService.ts` |
| New | `hooks/useHangoutsAuth.ts`, `useHangoutsRoomList.ts`, `useHangoutsRoom.ts` |
| New | `app/screens/HangoutsLobbyScreen.tsx` |
| New | `app/components/HangoutPreviewCard.tsx` |
| New | `utils/extractHangoutInfo.ts` |
| Modified | `app/screens/FeedScreen.tsx`, `app/components/Snap.tsx`, `app/_layout.tsx`, `app/config/env.ts` |

## Test plan
- [ ] Tap microphone icon in feed header → `HangoutsLobbyScreen` opens
- [ ] Lobby silently authenticates; room list loads (or shows empty state)
- [ ] "+" button → Create Room modal → submit → room appears in list
- [ ] Snap containing `https://hangout.3speak.tv/room/<name>` renders `HangoutPreviewCard`
- [ ] Active room: shows title, host avatar, LIVE badge, listener count
- [ ] Ended/not-found room: shows "This hangout has ended"
- [ ] Tapping preview card navigates to lobby

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hangouts lobby to browse, create, and join live rooms (slide-up create modal with success/error feedback).
  * Hangout preview cards in feeds showing LIVE badge, host, avatar, participant count; tapping opens the lobby.
  * Microphone button in the feed header opens the Hangouts lobby and displays a live-item badge/count.

* **Stability / UX**
  * Sign-in/connect banner, polling refresh, clear loading/error/retry states, pull-to-refresh and join alerts.

* **UI Components**
  * New reusable icon and primary button components for consistent controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->