### PR TITLE
feat: Hangouts Phase 2 — LiveKit audio rooms

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,9 +25,10 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSCameraUsageDescription": "This app uses the camera to take photos and record videos for your posts.",
-        "NSMicrophoneUsageDescription": "This app needs access to the microphone to record audio for your videos.",
+        "NSMicrophoneUsageDescription": "This app needs access to the microphone to record audio for your videos and hangouts.",
         "NSPhotoLibraryUsageDescription": "This app uses the photo library to select photos and videos to share in your posts.",
-        "NSFaceIDUsageDescription": "This app uses Face ID to verify your identity."
+        "NSFaceIDUsageDescription": "This app uses Face ID to verify your identity.",
+        "UIBackgroundModes": ["audio"]
       }
     },
     "android": {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,3 +1,14 @@
+// Polyfill DOMException for LiveKit (not available in Hermes/React Native)
+if (typeof global.DOMException === 'undefined') {
+  // @ts-expect-error — global polyfill
+  global.DOMException = class DOMException extends Error {
+    constructor(message?: string, name?: string) {
+      super(message);
+      this.name = name ?? 'DOMException';
+    }
+  };
+}
+
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {
   DarkTheme,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -60,7 +60,8 @@ function RootLayoutNav() {
   const navigation = useNavigation();
 
   useEffect(() => {
-    // Log navigation state and attempted route
+    if (!__DEV__) return;
+    // Log navigation state and attempted route (dev only)
     if (navigation && navigation.getState) {
       const state = navigation.getState();
       console.log('[Navigation State]', state);
@@ -69,7 +70,9 @@ function RootLayoutNav() {
         console.log('[Attempted Route]', lastRoute);
       }
     }
-    console.log('[Router Params]', params);
+    // Redact auth tokens before logging
+    const { livekitToken: _lkt, ...safeParams } = params as Record<string, string | string[]>;
+    console.log('[Router Params]', safeParams);
   }, [navigation, params]);
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,17 +1,3 @@
-// Polyfill DOMException for LiveKit (not available in Hermes/React Native)
-if (typeof global.DOMException === 'undefined') {
-  // @ts-expect-error — global polyfill
-  global.DOMException = class DOMException extends Error {
-    constructor(message?: string, name?: string) {
-      super(message);
-      this.name = name ?? 'DOMException';
-    }
-  };
-}
-
-import { registerGlobals } from '@livekit/react-native';
-registerGlobals();
-
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {
   DarkTheme,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,9 @@ if (typeof global.DOMException === 'undefined') {
   };
 }
 
+import { registerGlobals } from '@livekit/react-native';
+registerGlobals();
+
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import {
   DarkTheme,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -94,6 +94,7 @@ function RootLayoutNav() {
                 <Stack.Screen name='screens/MigrationScreen' />
                 <Stack.Screen name='screens/WalletScreen' />
                 <Stack.Screen name='screens/HangoutsLobbyScreen' />
+                <Stack.Screen name='screens/HangoutsRoomScreen' />
                 <Stack.Screen name='modal' options={{ presentation: 'modal' }} />
               </Stack>
             </TOSWrapper>

--- a/app/components/hangouts/AudienceSection.tsx
+++ b/app/components/hangouts/AudienceSection.tsx
@@ -34,8 +34,11 @@ export default function AudienceSection({
   const participants = useParticipants();
   const { localParticipant } = useLocalParticipant();
 
-  // Audience = those who cannot publish (listeners)
-  const audience = participants.filter((p) => p.permissions?.canPublish === false);
+  // Audience = those who cannot publish (listeners). useParticipants() includes
+  // local participant, so exclude it to avoid duplicates with our manual entry.
+  const audience = participants.filter(
+    (p) => p.permissions?.canPublish === false && p.identity !== localParticipant?.identity
+  );
   const localIsAudience = localParticipant?.permissions?.canPublish === false;
 
   type AudienceEntry = { identity: string; isMicrophoneEnabled: boolean; isLocal: boolean };

--- a/app/components/hangouts/AudienceSection.tsx
+++ b/app/components/hangouts/AudienceSection.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
+import { useParticipants, useLocalParticipant } from '@livekit/react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import ParticipantTile from './ParticipantTile';
+
+interface AudienceSectionProps {
+  isHost: boolean;
+  raisedHandIdentities: string[];
+  activeSpeakerIdentities: string[];
+  onApprove: (identity: string) => void;
+  onDeny: (identity: string) => void;
+  onLongPress: (identity: string) => void;
+  colors: {
+    text: string;
+    textSecondary: string;
+    success: string;
+    card: string;
+    border: string;
+    button: string;
+    buttonText: string;
+  };
+}
+
+export default function AudienceSection({
+  isHost,
+  raisedHandIdentities,
+  activeSpeakerIdentities,
+  onApprove,
+  onDeny,
+  onLongPress,
+  colors,
+}: AudienceSectionProps): React.ReactElement {
+  const participants = useParticipants();
+  const { localParticipant } = useLocalParticipant();
+
+  // Audience = those who cannot publish (listeners)
+  const audience = participants.filter((p) => p.permissions?.canPublish === false);
+  const localIsAudience = localParticipant?.permissions?.canPublish === false;
+
+  type AudienceEntry = { identity: string; isMicrophoneEnabled: boolean; isLocal: boolean };
+  const allAudience: AudienceEntry[] = [
+    ...(localIsAudience && localParticipant
+      ? [{ identity: localParticipant.identity, isMicrophoneEnabled: localParticipant.isMicrophoneEnabled, isLocal: true }]
+      : []),
+    ...audience.map((p) => ({ identity: p.identity, isMicrophoneEnabled: p.isMicrophoneEnabled, isLocal: false })),
+  ];
+
+  if (allAudience.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={[styles.emptyText, { color: colors.textSecondary }]}>No listeners yet</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.label, { color: colors.textSecondary }]}>
+        Audience · {allAudience.length}
+      </Text>
+      <FlatList
+        data={allAudience}
+        keyExtractor={(item) => item.identity}
+        numColumns={4}
+        scrollEnabled={false}
+        contentContainerStyle={styles.grid}
+        renderItem={({ item }) => {
+          const hasHand = raisedHandIdentities.includes(item.identity);
+          return (
+            <View style={styles.tileWrap}>
+              <Pressable
+                onLongPress={() => !item.isLocal && onLongPress(item.identity)}
+              >
+                <ParticipantTile
+                  identity={item.identity}
+                  isMuted={!item.isMicrophoneEnabled}
+                  isSpeaking={activeSpeakerIdentities.includes(item.identity)}
+                  hasRaisedHand={hasHand}
+                  size='small'
+                  colors={colors}
+                />
+              </Pressable>
+              {/* Host approve/deny controls on raised hands */}
+              {isHost && hasHand && (
+                <View style={styles.approveRow}>
+                  <Pressable
+                    style={[styles.approveBtn, { backgroundColor: colors.success }]}
+                    onPress={() => onApprove(item.identity)}
+                    accessibilityRole='button'
+                    accessibilityLabel={`Approve ${item.identity} to speak`}
+                  >
+                    <FontAwesome name='check' size={10} color='#fff' />
+                  </Pressable>
+                  <Pressable
+                    style={[styles.denyBtn, { backgroundColor: colors.card, borderColor: colors.border }]}
+                    onPress={() => onDeny(item.identity)}
+                    accessibilityRole='button'
+                    accessibilityLabel={`Deny ${item.identity}`}
+                  >
+                    <FontAwesome name='times' size={10} color={colors.textSecondary} />
+                  </Pressable>
+                </View>
+              )}
+            </View>
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 16 },
+  label: { fontSize: 12, fontWeight: '600', textTransform: 'uppercase', marginBottom: 12 },
+  grid: { gap: 12 },
+  tileWrap: { flex: 1 / 4, alignItems: 'center' },
+  approveRow: { flexDirection: 'row', gap: 4, marginTop: 4 },
+  approveBtn: { width: 20, height: 20, borderRadius: 10, alignItems: 'center', justifyContent: 'center' },
+  denyBtn: { width: 20, height: 20, borderRadius: 10, alignItems: 'center', justifyContent: 'center', borderWidth: 1 },
+  empty: { flex: 1, alignItems: 'center', paddingTop: 24 },
+  emptyText: { fontSize: 13 },
+});

--- a/app/components/hangouts/ChatPanel.tsx
+++ b/app/components/hangouts/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,

--- a/app/components/hangouts/ChatPanel.tsx
+++ b/app/components/hangouts/ChatPanel.tsx
@@ -1,0 +1,199 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  FlatList,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useDataChannel, useLocalParticipant } from '@livekit/react-native';
+import { FontAwesome } from '@expo/vector-icons';
+
+interface ChatMessage {
+  id: string;
+  identity: string;
+  text: string;
+  timestamp: number;
+}
+
+interface ChatPanelProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: {
+    text: string;
+    textSecondary: string;
+    card: string;
+    border: string;
+    button: string;
+    buttonText: string;
+    background: string;
+  };
+}
+
+export default function ChatPanel({ visible, onClose, colors }: ChatPanelProps): React.ReactElement | null {
+  const insets = useSafeAreaInsets();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [draft, setDraft] = useState('');
+  const listRef = useRef<FlatList<ChatMessage>>(null);
+  const { localParticipant } = useLocalParticipant();
+
+  const { send } = useDataChannel('chat', useCallback((msg: { payload: Uint8Array; from?: { identity: string } }) => {
+    try {
+      const data = JSON.parse(new TextDecoder().decode(msg.payload)) as {
+        type: string;
+        identity: string;
+        text: string;
+        timestamp: number;
+      };
+      if (data.type === 'chat') {
+        setMessages((prev) => [...prev, { id: `${data.identity}-${data.timestamp}`, ...data }]);
+      }
+    } catch {
+      // malformed message — ignore
+    }
+  }, []));
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      listRef.current?.scrollToEnd({ animated: true });
+    }
+  }, [messages]);
+
+  const handleSend = useCallback((): void => {
+    const trimmed = draft.trim();
+    if (!trimmed || !localParticipant) return;
+    const payload = {
+      type: 'chat',
+      identity: localParticipant.identity,
+      text: trimmed,
+      timestamp: Date.now(),
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(payload));
+    send(bytes, { reliable: true });
+    // Also add to local messages so sender sees their own message
+    setMessages((prev) => [
+      ...prev,
+      { id: `local-${payload.timestamp}`, ...payload },
+    ]);
+    setDraft('');
+  }, [draft, localParticipant, send]);
+
+  if (!visible) return null;
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }]}
+    >
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Chat</Text>
+        <Pressable onPress={onClose} accessibilityRole='button' accessibilityLabel='Close chat'
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <FontAwesome name='times' size={18} color={colors.textSecondary} />
+        </Pressable>
+      </View>
+
+      {/* Message list */}
+      <FlatList
+        ref={listRef}
+        data={messages}
+        keyExtractor={(item) => item.id}
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        renderItem={({ item }) => {
+          const isMe = item.identity === localParticipant?.identity;
+          return (
+            <View style={[styles.bubble, isMe && styles.bubbleMe]}>
+              {!isMe && (
+                <Text style={[styles.bubbleAuthor, { color: colors.button }]}>@{item.identity}</Text>
+              )}
+              <Text style={[styles.bubbleText, { color: colors.text }]}>{item.text}</Text>
+            </View>
+          );
+        }}
+        ListEmptyComponent={
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>No messages yet</Text>
+        }
+      />
+
+      {/* Input */}
+      <View style={[styles.inputRow, { borderTopColor: colors.border, paddingBottom: insets.bottom + 8 }]}>
+        <TextInput
+          style={[styles.input, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
+          placeholder='Say something...'
+          placeholderTextColor={colors.textSecondary}
+          value={draft}
+          onChangeText={setDraft}
+          onSubmitEditing={handleSend}
+          returnKeyType='send'
+          maxLength={500}
+        />
+        <Pressable
+          style={[styles.sendBtn, { backgroundColor: colors.button, opacity: draft.trim() ? 1 : 0.4 }]}
+          onPress={handleSend}
+          disabled={!draft.trim()}
+          accessibilityRole='button'
+          accessibilityLabel='Send message'
+        >
+          <FontAwesome name='send' size={14} color={colors.buttonText} />
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    maxHeight: '50%',
+    borderTopWidth: 1,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  headerTitle: { fontSize: 16, fontWeight: '600' },
+  list: { flex: 1 },
+  listContent: { padding: 12, gap: 8 },
+  bubble: {
+    alignSelf: 'flex-start',
+    maxWidth: '80%',
+  },
+  bubbleMe: { alignSelf: 'flex-end' },
+  bubbleAuthor: { fontSize: 11, fontWeight: '600', marginBottom: 2 },
+  bubbleText: { fontSize: 14 },
+  emptyText: { textAlign: 'center', fontSize: 13, paddingVertical: 24 },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    borderTopWidth: 1,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    fontSize: 15,
+  },
+  sendBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/components/hangouts/ChatPanel.tsx
+++ b/app/components/hangouts/ChatPanel.tsx
@@ -1,12 +1,10 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
   TextInput,
   FlatList,
   StyleSheet,
-  KeyboardAvoidingView,
-  Platform,
   Pressable,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -42,11 +40,13 @@ export default function ChatPanel({ visible, messages, onSend, onClose, colors }
   const listRef = useRef<FlatList<ChatMessage>>(null);
   const { localParticipant } = useLocalParticipant();
 
+  // Scroll to latest when new messages arrive or panel opens
   useEffect(() => {
     if (visible && messages.length > 0) {
-      listRef.current?.scrollToEnd({ animated: true });
+      // Small delay lets the FlatList finish layout before scrolling
+      setTimeout(() => listRef.current?.scrollToEnd({ animated: false }), 50);
     }
-  }, [messages, visible]);
+  }, [messages.length, visible]);
 
   const handleSend = (): void => {
     const trimmed = draft.trim();
@@ -58,10 +58,7 @@ export default function ChatPanel({ visible, messages, onSend, onClose, colors }
   if (!visible) return null;
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }]}
-    >
+    <View style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }]}>
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <Text style={[styles.headerTitle, { color: colors.text }]}>Chat</Text>
@@ -116,7 +113,7 @@ export default function ChatPanel({ visible, messages, onSend, onClose, colors }
           <FontAwesome name='send' size={14} color={colors.buttonText} />
         </Pressable>
       </View>
-    </KeyboardAvoidingView>
+    </View>
   );
 }
 

--- a/app/components/hangouts/ChatPanel.tsx
+++ b/app/components/hangouts/ChatPanel.tsx
@@ -34,17 +34,16 @@ interface ChatPanelProps {
   };
 }
 
-export default function ChatPanel({ visible, messages, onSend, onClose, colors }: ChatPanelProps): React.ReactElement | null {
+export default function ChatPanel({ visible, messages, onSend, onClose, colors }: ChatPanelProps): React.ReactElement {
   const insets = useSafeAreaInsets();
   const [draft, setDraft] = useState('');
   const listRef = useRef<FlatList<ChatMessage>>(null);
   const { localParticipant } = useLocalParticipant();
 
-  // Scroll to latest when new messages arrive or panel opens
+  // Scroll to latest when new messages arrive or panel becomes visible
   useEffect(() => {
     if (visible && messages.length > 0) {
-      // Small delay lets the FlatList finish layout before scrolling
-      setTimeout(() => listRef.current?.scrollToEnd({ animated: false }), 50);
+      listRef.current?.scrollToEnd({ animated: false });
     }
   }, [messages.length, visible]);
 
@@ -55,10 +54,8 @@ export default function ChatPanel({ visible, messages, onSend, onClose, colors }
     setDraft('');
   };
 
-  if (!visible) return null;
-
   return (
-    <View style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }]}>
+    <View style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }, !visible && styles.hidden]}>
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <Text style={[styles.headerTitle, { color: colors.text }]}>Chat</Text>
@@ -118,8 +115,9 @@ export default function ChatPanel({ visible, messages, onSend, onClose, colors }
 }
 
 const styles = StyleSheet.create({
+  hidden: { display: 'none' },
   container: {
-    maxHeight: '50%',
+    height: '45%',
     borderTopWidth: 1,
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,

--- a/app/components/hangouts/ChatPanel.tsx
+++ b/app/components/hangouts/ChatPanel.tsx
@@ -99,6 +99,8 @@ export default function ChatPanel({ visible, messages, onSend, onClose, colors }
           onSubmitEditing={handleSend}
           returnKeyType='send'
           maxLength={500}
+          accessibilityLabel='Chat message'
+          accessibilityHint='Type a message and press Send or Return to send it'
         />
         <Pressable
           style={[styles.sendBtn, { backgroundColor: colors.button, opacity: draft.trim() ? 1 : 0.4 }]}

--- a/app/components/hangouts/ChatPanel.tsx
+++ b/app/components/hangouts/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,
@@ -10,7 +10,7 @@ import {
   Pressable,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useDataChannel, useLocalParticipant } from '@livekit/react-native';
+import { useLocalParticipant } from '@livekit/react-native';
 import { FontAwesome } from '@expo/vector-icons';
 
 interface ChatMessage {
@@ -22,6 +22,8 @@ interface ChatMessage {
 
 interface ChatPanelProps {
   visible: boolean;
+  messages: ChatMessage[];
+  onSend: (text: string) => void;
   onClose: () => void;
   colors: {
     text: string;
@@ -34,53 +36,24 @@ interface ChatPanelProps {
   };
 }
 
-export default function ChatPanel({ visible, onClose, colors }: ChatPanelProps): React.ReactElement | null {
+export default function ChatPanel({ visible, messages, onSend, onClose, colors }: ChatPanelProps): React.ReactElement | null {
   const insets = useSafeAreaInsets();
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [draft, setDraft] = useState('');
   const listRef = useRef<FlatList<ChatMessage>>(null);
   const { localParticipant } = useLocalParticipant();
 
-  const { send } = useDataChannel('chat', useCallback((msg: { payload: Uint8Array; from?: { identity: string } }) => {
-    try {
-      const data = JSON.parse(new TextDecoder().decode(msg.payload)) as {
-        type: string;
-        identity: string;
-        text: string;
-        timestamp: number;
-      };
-      if (data.type === 'chat') {
-        setMessages((prev) => [...prev, { id: `${data.identity}-${data.timestamp}`, ...data }]);
-      }
-    } catch {
-      // malformed message — ignore
-    }
-  }, []));
-
   useEffect(() => {
-    if (messages.length > 0) {
+    if (visible && messages.length > 0) {
       listRef.current?.scrollToEnd({ animated: true });
     }
-  }, [messages]);
+  }, [messages, visible]);
 
-  const handleSend = useCallback((): void => {
+  const handleSend = (): void => {
     const trimmed = draft.trim();
-    if (!trimmed || !localParticipant) return;
-    const payload = {
-      type: 'chat',
-      identity: localParticipant.identity,
-      text: trimmed,
-      timestamp: Date.now(),
-    };
-    const bytes = new TextEncoder().encode(JSON.stringify(payload));
-    send(bytes, { reliable: true });
-    // Also add to local messages so sender sees their own message
-    setMessages((prev) => [
-      ...prev,
-      { id: `local-${payload.timestamp}`, ...payload },
-    ]);
+    if (!trimmed) return;
+    onSend(trimmed);
     setDraft('');
-  }, [draft, localParticipant, send]);
+  };
 
   if (!visible) return null;
 

--- a/app/components/hangouts/HostControlsPanel.tsx
+++ b/app/components/hangouts/HostControlsPanel.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet, Modal } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { FontAwesome } from '@expo/vector-icons';
+
+interface HostControlsPanelProps {
+  identity: string | null;
+  onPromote: (identity: string) => void;
+  onMute: (identity: string) => void;
+  onKick: (identity: string) => void;
+  onClose: () => void;
+  colors: {
+    text: string;
+    textSecondary: string;
+    card: string;
+    border: string;
+    error: string;
+    success: string;
+  };
+}
+
+export default function HostControlsPanel({
+  identity,
+  onPromote,
+  onMute,
+  onKick,
+  onClose,
+  colors,
+}: HostControlsPanelProps): React.ReactElement {
+  const insets = useSafeAreaInsets();
+
+  const actions = [
+    { icon: 'arrow-up' as const, label: 'Invite to speak', color: colors.success, onPress: () => identity && onPromote(identity) },
+    { icon: 'microphone-slash' as const, label: 'Mute', color: colors.text, onPress: () => identity && onMute(identity) },
+    { icon: 'ban' as const, label: 'Remove from room', color: colors.error, onPress: () => identity && onKick(identity) },
+  ];
+
+  return (
+    <Modal visible={!!identity} transparent animationType='slide' onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <View
+          style={[styles.sheet, { backgroundColor: colors.card, borderColor: colors.border, paddingBottom: insets.bottom + 8 }]}
+          onStartShouldSetResponder={() => true}
+        >
+          <View style={[styles.handle, { backgroundColor: colors.border }]} />
+          <Text style={[styles.title, { color: colors.textSecondary }]}>@{identity}</Text>
+
+          {actions.map((action) => (
+            <Pressable
+              key={action.label}
+              style={[styles.action, { borderBottomColor: colors.border }]}
+              onPress={() => { action.onPress(); onClose(); }}
+              accessibilityRole='button'
+              accessibilityLabel={action.label}
+            >
+              <FontAwesome name={action.icon} size={18} color={action.color} style={styles.actionIcon} />
+              <Text style={[styles.actionLabel, { color: action.color }]}>{action.label}</Text>
+            </Pressable>
+          ))}
+
+          <Pressable
+            style={styles.cancel}
+            onPress={onClose}
+            accessibilityRole='button'
+            accessibilityLabel='Cancel'
+          >
+            <Text style={[styles.cancelText, { color: colors.textSecondary }]}>Cancel</Text>
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'flex-end' },
+  sheet: {
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingTop: 12,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+  },
+  handle: { width: 36, height: 4, borderRadius: 2, alignSelf: 'center', marginBottom: 16 },
+  title: { fontSize: 13, textAlign: 'center', marginBottom: 8 },
+  action: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  actionIcon: { width: 28 },
+  actionLabel: { fontSize: 16 },
+  cancel: { paddingVertical: 16, alignItems: 'center' },
+  cancelText: { fontSize: 16 },
+});

--- a/app/components/hangouts/ParticipantTile.tsx
+++ b/app/components/hangouts/ParticipantTile.tsx
@@ -34,8 +34,19 @@ export default function ParticipantTile({
     opacity: withSpring(isSpeaking ? 1 : 0, { damping: 10 }),
   }));
 
+  const a11yLabel = [
+    `@${identity}`,
+    isSpeaking ? 'speaking' : null,
+    isMuted ? 'muted' : null,
+    hasRaisedHand ? 'hand raised' : null,
+  ].filter(Boolean).join(', ');
+
   return (
-    <View style={[styles.container, size === 'small' && styles.containerSmall]}>
+    <View
+      style={[styles.container, size === 'small' && styles.containerSmall]}
+      accessible={true}
+      accessibilityLabel={a11yLabel}
+    >
       <View style={styles.avatarWrap}>
         {/* Speaking ring */}
         <Animated.View

--- a/app/components/hangouts/ParticipantTile.tsx
+++ b/app/components/hangouts/ParticipantTile.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Image as ExpoImage } from 'expo-image';
+import { FontAwesome } from '@expo/vector-icons';
+import Animated, { useAnimatedStyle, withSpring } from 'react-native-reanimated';
+
+interface ParticipantTileProps {
+  identity: string;
+  isMuted: boolean;
+  isSpeaking: boolean;
+  hasRaisedHand?: boolean;
+  size?: 'large' | 'small';
+  colors: {
+    text: string;
+    textSecondary: string;
+    success: string;
+    card: string;
+  };
+}
+
+export default function ParticipantTile({
+  identity,
+  isMuted,
+  isSpeaking,
+  hasRaisedHand = false,
+  size = 'large',
+  colors,
+}: ParticipantTileProps): React.ReactElement {
+  const avatarSize = size === 'large' ? 64 : 44;
+  const ringSize = avatarSize + 10;
+
+  const ringStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: withSpring(isSpeaking ? 1.12 : 1.0, { damping: 10, stiffness: 120 }) }],
+    opacity: withSpring(isSpeaking ? 1 : 0, { damping: 10 }),
+  }));
+
+  return (
+    <View style={[styles.container, size === 'small' && styles.containerSmall]}>
+      <View style={styles.avatarWrap}>
+        {/* Speaking ring */}
+        <Animated.View
+          style={[
+            styles.ring,
+            { width: ringSize, height: ringSize, borderRadius: ringSize / 2, borderColor: colors.success },
+            ringStyle,
+          ]}
+        />
+        <ExpoImage
+          source={{ uri: `https://images.hive.blog/u/${identity}/avatar/sm` }}
+          style={[styles.avatar, { width: avatarSize, height: avatarSize, borderRadius: avatarSize / 2 }]}
+          contentFit='cover'
+        />
+        {/* Raised hand badge */}
+        {hasRaisedHand && (
+          <View style={[styles.handBadge, { backgroundColor: colors.card }]}>
+            <Text style={styles.handEmoji}>✋</Text>
+          </View>
+        )}
+        {/* Muted indicator */}
+        {isMuted && (
+          <View style={[styles.mutedBadge, { backgroundColor: colors.card }]}>
+            <FontAwesome name='microphone-slash' size={10} color={colors.textSecondary} />
+          </View>
+        )}
+      </View>
+      <Text style={[styles.name, { color: colors.text }, size === 'small' && styles.nameSmall]} numberOfLines={1}>
+        @{identity}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', width: 80 },
+  containerSmall: { width: 60 },
+  avatarWrap: { alignItems: 'center', justifyContent: 'center', marginBottom: 6 },
+  ring: {
+    position: 'absolute',
+    borderWidth: 2.5,
+  },
+  avatar: {},
+  handBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    borderRadius: 10,
+    padding: 2,
+  },
+  handEmoji: { fontSize: 12 },
+  mutedBadge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    borderRadius: 8,
+    padding: 3,
+  },
+  name: { fontSize: 12, fontWeight: '500', textAlign: 'center' },
+  nameSmall: { fontSize: 10 },
+});

--- a/app/components/hangouts/RoomControls.tsx
+++ b/app/components/hangouts/RoomControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, Platform } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalParticipant } from '@livekit/react-native';
 import IconButton from '../IconButton';

--- a/app/components/hangouts/RoomControls.tsx
+++ b/app/components/hangouts/RoomControls.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useLocalParticipant } from '@livekit/react-native';
+import IconButton from '../IconButton';
+import PrimaryButton from '../PrimaryButton';
+
+interface RoomControlsProps {
+  isHost: boolean;
+  hasRaisedHand: boolean;
+  onToggleMute: () => void;
+  onToggleHand: () => void;
+  onToggleChat: () => void;
+  onLeave: () => void;
+  onEndRoom: () => void;
+  colors: {
+    text: string;
+    textSecondary: string;
+    icon: string;
+    card: string;
+    border: string;
+    button: string;
+    buttonText: string;
+    error: string;
+  };
+}
+
+export default function RoomControls({
+  isHost,
+  hasRaisedHand,
+  onToggleMute,
+  onToggleHand,
+  onToggleChat,
+  onLeave,
+  onEndRoom,
+  colors,
+}: RoomControlsProps): React.ReactElement {
+  const insets = useSafeAreaInsets();
+  const { localParticipant } = useLocalParticipant();
+  const isMuted = !localParticipant?.isMicrophoneEnabled;
+  const isListener = localParticipant?.permissions?.canPublish === false;
+
+  return (
+    <View
+      style={[
+        styles.bar,
+        { backgroundColor: colors.card, borderTopColor: colors.border, paddingBottom: insets.bottom + 12 },
+      ]}
+    >
+      {/* Mute/unmute — only for speakers and host */}
+      {!isListener && (
+        <IconButton
+          name={isMuted ? 'microphone-slash' : 'microphone'}
+          size={22}
+          color={isMuted ? colors.textSecondary : colors.button}
+          onPress={onToggleMute}
+          accessibilityLabel={isMuted ? 'Unmute microphone' : 'Mute microphone'}
+        />
+      )}
+
+      {/* Raise / lower hand — listeners only */}
+      {isListener && (
+        <IconButton
+          name='hand-paper-o'
+          size={22}
+          color={hasRaisedHand ? colors.button : colors.icon}
+          backgroundColor={hasRaisedHand ? `${colors.button}22` : undefined}
+          onPress={onToggleHand}
+          accessibilityLabel={hasRaisedHand ? 'Lower hand' : 'Raise hand to speak'}
+        />
+      )}
+
+      {/* Chat */}
+      <IconButton
+        name='comment-o'
+        size={22}
+        color={colors.icon}
+        onPress={onToggleChat}
+        accessibilityLabel='Toggle chat'
+      />
+
+      {/* Leave */}
+      <IconButton
+        name='phone'
+        size={20}
+        color='#fff'
+        backgroundColor='#EF4444'
+        onPress={onLeave}
+        style={styles.leaveBtn}
+        accessibilityLabel='Leave room'
+      />
+
+      {/* End room — host only */}
+      {isHost && (
+        <PrimaryButton
+          label='End'
+          variant='primary'
+          backgroundColor='#EF4444'
+          textColor='#fff'
+          onPress={onEndRoom}
+          style={styles.endBtn}
+          accessibilityHint='Ends the room for all participants'
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 20,
+    paddingTop: 14,
+    paddingHorizontal: 24,
+    borderTopWidth: 1,
+  },
+  leaveBtn: {
+    transform: [{ rotate: '135deg' }],
+  },
+  endBtn: {
+    flex: 0,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    marginLeft: 4,
+  },
+});

--- a/app/components/hangouts/SpeakerStage.tsx
+++ b/app/components/hangouts/SpeakerStage.tsx
@@ -23,8 +23,10 @@ export default function SpeakerStage({
   const participants = useParticipants();
   const { localParticipant } = useLocalParticipant();
 
-  // Speakers = host + those who can publish (have microphone track or canPublishSources includes mic)
-  const speakers = participants.filter((p) => p.permissions?.canPublish !== false);
+  // useParticipants() includes local — exclude it to avoid duplicates
+  const speakers = participants.filter(
+    (p) => p.permissions?.canPublish !== false && p.identity !== localParticipant?.identity
+  );
   const hasLocal = localParticipant?.permissions?.canPublish !== false;
 
   return (

--- a/app/components/hangouts/SpeakerStage.tsx
+++ b/app/components/hangouts/SpeakerStage.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { useParticipants, useLocalParticipant } from '@livekit/react-native';
+import ParticipantTile from './ParticipantTile';
+
+interface SpeakerStageProps {
+  activeSpeakerIdentities: string[];
+  raisedHandIdentities: string[];
+  colors: {
+    text: string;
+    textSecondary: string;
+    success: string;
+    card: string;
+    border: string;
+  };
+}
+
+export default function SpeakerStage({
+  activeSpeakerIdentities,
+  raisedHandIdentities,
+  colors,
+}: SpeakerStageProps): React.ReactElement {
+  const participants = useParticipants();
+  const { localParticipant } = useLocalParticipant();
+
+  // Speakers = host + those who can publish (have microphone track or canPublishSources includes mic)
+  const speakers = participants.filter((p) => p.permissions?.canPublish !== false);
+  const hasLocal = localParticipant?.permissions?.canPublish !== false;
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.label, { color: colors.textSecondary }]}>
+        {speakers.length + (hasLocal ? 1 : 0) === 0 ? 'No speakers yet' : 'Speakers'}
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scroll}
+      >
+        {/* Local participant (if speaker) */}
+        {hasLocal && localParticipant && (
+          <ParticipantTile
+            key='local'
+            identity={localParticipant.identity}
+            isMuted={!localParticipant.isMicrophoneEnabled}
+            isSpeaking={activeSpeakerIdentities.includes(localParticipant.identity)}
+            hasRaisedHand={false}
+            size='large'
+            colors={colors}
+          />
+        )}
+        {/* Remote speakers */}
+        {speakers.map((p) => (
+          <ParticipantTile
+            key={p.identity}
+            identity={p.identity}
+            isMuted={!p.isMicrophoneEnabled}
+            isSpeaking={activeSpeakerIdentities.includes(p.identity)}
+            hasRaisedHand={raisedHandIdentities.includes(p.identity)}
+            size='large'
+            colors={colors}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { paddingVertical: 16 },
+  label: { fontSize: 12, fontWeight: '600', textTransform: 'uppercase', marginLeft: 16, marginBottom: 12 },
+  scroll: { paddingHorizontal: 16, gap: 16 },
+});

--- a/app/config/env.ts
+++ b/app/config/env.ts
@@ -41,3 +41,4 @@ if (!THREESPEAK_IMAGE_API_KEY) {
 
 // Hive Hangouts API
 export const HANGOUTS_API_URL = process.env.EXPO_PUBLIC_HANGOUTS_API_URL || 'https://hangout-api.3speak.tv';
+export const LIVEKIT_URL = process.env.EXPO_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';

--- a/app/config/env.ts
+++ b/app/config/env.ts
@@ -42,3 +42,6 @@ if (!THREESPEAK_IMAGE_API_KEY) {
 // Hive Hangouts API
 export const HANGOUTS_API_URL = process.env.EXPO_PUBLIC_HANGOUTS_API_URL || 'https://hangout-api.3speak.tv';
 export const LIVEKIT_URL = process.env.EXPO_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
+if (__DEV__ && !process.env.EXPO_PUBLIC_LIVEKIT_URL) {
+  console.warn('LIVEKIT_URL is not set — defaulting to wss://livekit.3speak.tv');
+}

--- a/app/config/env.ts
+++ b/app/config/env.ts
@@ -41,7 +41,10 @@ if (!THREESPEAK_IMAGE_API_KEY) {
 
 // Hive Hangouts API
 export const HANGOUTS_API_URL = process.env.EXPO_PUBLIC_HANGOUTS_API_URL || 'https://hangout-api.3speak.tv';
-export const LIVEKIT_URL = process.env.EXPO_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
-if (__DEV__ && !process.env.EXPO_PUBLIC_LIVEKIT_URL) {
-  console.warn('LIVEKIT_URL is not set — defaulting to wss://livekit.3speak.tv');
+// No hardcoded fallback: a missing LIVEKIT_URL means the token minted by the
+// Hangouts API may target a different cluster, so we fail loudly instead of
+// silently connecting to the wrong (production) server.
+export const LIVEKIT_URL = process.env.EXPO_PUBLIC_LIVEKIT_URL || '';
+if (!LIVEKIT_URL) {
+  console.warn('LIVEKIT_URL is not set in .env - hangouts rooms will not work');
 }

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -35,7 +35,7 @@ export default function HangoutsLobbyScreen() {
 
   const { isAuthenticated, isLoading: authLoading, authenticate } = useHangoutsAuth();
   const { rooms, isLoading: roomsLoading, error: roomsError, refresh } = useHangoutsRoomList();
-  const { create, isLoading: createLoading } = useHangoutsRoom();
+  const { create, join, isLoading: roomOpLoading } = useHangoutsRoom();
 
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [roomTitle, setRoomTitle] = useState('');
@@ -76,18 +76,32 @@ export default function HangoutsLobbyScreen() {
     const trimmed = roomTitle.trim();
     if (!trimmed) return;
     try {
-      await create(trimmed, roomDescription.trim() || undefined);
+      const response = await create(trimmed, roomDescription.trim() || undefined);
       closeCreateModal();
-      refresh();
-      Alert.alert('Room Created', 'Your hangout is live! Audio joining coming soon.');
+      router.push({
+        pathname: '/screens/HangoutsRoomScreen',
+        params: { roomName: response.room.name, livekitToken: response.token },
+      });
     } catch (err) {
       Alert.alert('Error', err instanceof Error ? err.message : 'Failed to create room');
     }
   };
 
-  const handleRoomPress = (_room: Room): void => {
-    Alert.alert('Coming Soon', 'Audio joining is coming in Phase 2!');
-  };
+  const handleRoomPress = useCallback(async (room: Room): Promise<void> => {
+    if (!isAuthenticated) {
+      const ok = await runAuthenticate(true);
+      if (!ok) return;
+    }
+    try {
+      const result = await join(room.name);
+      router.push({
+        pathname: '/screens/HangoutsRoomScreen',
+        params: { roomName: result.roomName, livekitToken: result.token },
+      });
+    } catch (err) {
+      Alert.alert('Could not join', err instanceof Error ? err.message : 'Failed to join room');
+    }
+  }, [isAuthenticated, runAuthenticate, join, router]);
 
   const renderRoomCard = ({ item }: { item: Room }): React.ReactElement => (
     <Pressable
@@ -167,7 +181,7 @@ export default function HangoutsLobbyScreen() {
               setCreateModalVisible(true);
             }
           }}
-          disabled={createLoading || authLoading}
+          disabled={roomOpLoading || authLoading}
           accessibilityLabel='Start a new hangout'
           accessibilityHint='Opens room creation form'
         />
@@ -287,7 +301,7 @@ export default function HangoutsLobbyScreen() {
                   variant='primary'
                   backgroundColor={theme.button}
                   textColor={theme.buttonText}
-                  loading={createLoading}
+                  loading={roomOpLoading}
                   disabled={!roomTitle.trim()}
                   onPress={handleCreateRoom}
                   accessibilityHint='Creates the room and starts your hangout'

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -80,7 +80,7 @@ export default function HangoutsLobbyScreen() {
       closeCreateModal();
       router.push({
         pathname: '/screens/HangoutsRoomScreen' as any,
-        params: { roomName: response.room.name, livekitToken: response.token },
+        params: { roomName: response.room.name, livekitToken: response.token, isHost: 'true' },
       });
     } catch (err) {
       Alert.alert('Error', err instanceof Error ? err.message : 'Failed to create room');
@@ -96,7 +96,7 @@ export default function HangoutsLobbyScreen() {
       const result = await join(room.name);
       router.push({
         pathname: '/screens/HangoutsRoomScreen' as any,
-        params: { roomName: result.roomName, livekitToken: result.token },
+        params: { roomName: result.roomName, livekitToken: result.token, isHost: 'false' },
       });
     } catch (err) {
       Alert.alert('Could not join', err instanceof Error ? err.message : 'Failed to join room');

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -22,7 +22,7 @@ import type { Room } from '@snapie/hangouts-core';
 import { getTheme } from '../../constants/Colors';
 import { useHangoutsAuth } from '../../hooks/useHangoutsAuth';
 import { useHangoutsRoomList } from '../../hooks/useHangoutsRoomList';
-import { useHangoutsRoom } from '../../hooks/useHangoutsRoom';
+import { useHangoutsRoom, RoomOperationCancelledError } from '../../hooks/useHangoutsRoom';
 import IconButton from '../components/IconButton';
 import PrimaryButton from '../components/PrimaryButton';
 
@@ -79,15 +79,24 @@ export default function HangoutsLobbyScreen() {
       const response = await create(trimmed, roomDescription.trim() || undefined);
       closeCreateModal();
       router.push({
-        pathname: '/screens/HangoutsRoomScreen' as any,
-        params: { roomName: response.room.name, livekitToken: response.token, isHost: 'true' },
-      });
+        pathname: '/screens/HangoutsRoomScreen',
+        params: {
+          roomName: response.room.name,
+          livekitToken: response.token,
+          isHost: 'true',
+          roomTitle: response.room.title ?? trimmed,
+          roomHost: response.room.host ?? '',
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
     } catch (err) {
+      if (err instanceof RoomOperationCancelledError) return;
       Alert.alert('Error', err instanceof Error ? err.message : 'Failed to create room');
     }
   };
 
   const handleRoomPress = useCallback(async (room: Room): Promise<void> => {
+    if (roomOpLoading) return;
     if (!isAuthenticated) {
       const ok = await runAuthenticate(true);
       if (!ok) return;
@@ -95,13 +104,21 @@ export default function HangoutsLobbyScreen() {
     try {
       const result = await join(room.name);
       router.push({
-        pathname: '/screens/HangoutsRoomScreen' as any,
-        params: { roomName: result.roomName, livekitToken: result.token, isHost: 'false' },
-      });
+        pathname: '/screens/HangoutsRoomScreen',
+        params: {
+          roomName: result.roomName,
+          livekitToken: result.token,
+          isHost: String(result.isHost),
+          roomTitle: room.title,
+          roomHost: room.host,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
     } catch (err) {
+      if (err instanceof RoomOperationCancelledError) return;
       Alert.alert('Could not join', err instanceof Error ? err.message : 'Failed to join room');
     }
-  }, [isAuthenticated, runAuthenticate, join, router]);
+  }, [isAuthenticated, roomOpLoading, runAuthenticate, join, router]);
 
   const renderRoomCard = ({ item }: { item: Room }): React.ReactElement => (
     <Pressable

--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -79,7 +79,7 @@ export default function HangoutsLobbyScreen() {
       const response = await create(trimmed, roomDescription.trim() || undefined);
       closeCreateModal();
       router.push({
-        pathname: '/screens/HangoutsRoomScreen',
+        pathname: '/screens/HangoutsRoomScreen' as any,
         params: { roomName: response.room.name, livekitToken: response.token },
       });
     } catch (err) {
@@ -95,7 +95,7 @@ export default function HangoutsLobbyScreen() {
     try {
       const result = await join(room.name);
       router.push({
-        pathname: '/screens/HangoutsRoomScreen',
+        pathname: '/screens/HangoutsRoomScreen' as any,
         params: { roomName: result.roomName, livekitToken: result.token },
       });
     } catch (err) {

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -271,8 +271,11 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   const { roomMeta, isHost, leave: clearRoomState } = useHangoutsRoom();
 
   const [connectionState, setConnectionState] = useState<ConnectionState | 'idle'>('idle');
+  // On Android we must resolve mic permission before LiveKitRoom mounts,
+  // otherwise LiveKit tries to open the mic while the dialog is still pending.
+  const [permissionReady, setPermissionReady] = useState(Platform.OS !== 'android');
 
-  // Request Android mic permission before connecting
+  // Request Android mic permission — gate LiveKitRoom until resolved
   useEffect(() => {
     if (Platform.OS !== 'android') return;
     void PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO).then((result) => {
@@ -282,6 +285,8 @@ export default function HangoutsRoomScreen(): React.ReactElement {
           'Please grant microphone access to join audio rooms.',
           [{ text: 'OK', onPress: () => router.back() }]
         );
+      } else {
+        setPermissionReady(true);
       }
     });
   }, [router]);
@@ -307,6 +312,17 @@ export default function HangoutsRoomScreen(): React.ReactElement {
 
   const displayTitle = roomMeta?.title ?? roomName;
   const displayHost = roomMeta?.host ?? '';
+
+  if (!permissionReady) {
+    return (
+      <SafeAreaView style={[styles.center, { backgroundColor: theme.background }]}>
+        <ActivityIndicator size='large' color={theme.button} />
+        <Text style={[styles.connectingText, { color: theme.textSecondary }]}>
+          Requesting microphone access...
+        </Text>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -22,7 +22,6 @@ import {
 } from '@livekit/react-native';
 import type { ConnectionState, Participant } from 'livekit-client';
 import { DisconnectReason } from '@livekit/protocol';
-import { FontAwesome } from '@expo/vector-icons';
 import { getTheme } from '../../constants/Colors';
 import { LIVEKIT_URL } from '../config/env';
 import { hangoutsAuthService } from '../../services/HangoutsAuthService';
@@ -179,13 +178,11 @@ function RoomScreenInner({
       { text: 'Cancel', style: 'cancel' },
       {
         text: 'End Room', style: 'destructive',
-        onPress: async () => {
-          try {
-            await client.deleteRoom(roomName);
-          } catch {
-            // best-effort — leave regardless
-          }
+        onPress: () => {
+          // Navigate out first so the host doesn't see the ROOM_DELETED alert
+          // that fires for all participants. deleteRoom runs best-effort in background.
           onLeave();
+          client.deleteRoom(roomName).catch(() => {});
         },
       },
     ]);
@@ -208,7 +205,6 @@ function RoomScreenInner({
     <KeyboardAvoidingView
       style={styles.inner}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
     >
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: theme.border }]}>
@@ -383,6 +379,9 @@ export default function HangoutsRoomScreen(): React.ReactElement {
           // TS type declares () => void — cast so we can read the reason.
           ((reason?: DisconnectReason) => {
             setConnectionState('disconnected' as ConnectionState);
+            // If we already navigated away (e.g. host ended the room, user pressed Leave),
+            // don't show a redundant alert or navigate twice.
+            if (hasLeftRef.current) return;
             if (reason === DisconnectReason.ROOM_DELETED) {
               Alert.alert('Hangout ended', 'The host has ended this hangout.', [
                 { text: 'OK', onPress: handleLeave },
@@ -392,8 +391,7 @@ export default function HangoutsRoomScreen(): React.ReactElement {
                 { text: 'OK', onPress: handleLeave },
               ]);
             } else {
-              // CLIENT_INITIATED (user pressed Leave — handleLeave idempotent via ref),
-              // UNKNOWN_REASON, SERVER_SHUTDOWN, etc. — leave silently.
+              // CLIENT_INITIATED, UNKNOWN_REASON, SERVER_SHUTDOWN — leave silently.
               handleLeave();
             }
           }) as () => void

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -25,7 +25,6 @@ import { DisconnectReason } from '@livekit/protocol';
 import { getTheme } from '../../constants/Colors';
 import { LIVEKIT_URL } from '../config/env';
 import { hangoutsAuthService } from '../../services/HangoutsAuthService';
-import { useHangoutsRoom } from '../../hooks/useHangoutsRoom';
 import IconButton from '../components/IconButton';
 import SpeakerStage from '../components/hangouts/SpeakerStage';
 import AudienceSection from '../components/hangouts/AudienceSection';
@@ -147,7 +146,15 @@ function RoomScreenInner({
 
   const handleDeny = useCallback((identity: string): void => {
     setRaisedHandIdentities((prev) => prev.filter((id) => id !== identity));
-  }, []);
+    // Broadcast hand-lower so the requester's local raised-hand state resets
+    const bytes = new TextEncoder().encode(JSON.stringify({
+      type: 'hand_raise',
+      raised: false,
+      identity,
+      timestamp: Date.now(),
+    }));
+    sendHandRaise(bytes, { reliable: true }).catch(() => {});
+  }, [sendHandRaise]);
 
   const handleMuteParticipant = useCallback(async (identity: string): Promise<void> => {
     try {
@@ -298,13 +305,14 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   const colorScheme = useColorScheme();
   const theme = getTheme(colorScheme === 'dark' ? 'dark' : 'light');
   const router = useRouter();
-  const { roomName, livekitToken, isHost: isHostParam } = useLocalSearchParams<{
+  const { roomName, livekitToken, isHost: isHostParam, roomTitle: titleParam, roomHost: hostParam } = useLocalSearchParams<{
     roomName: string;
     livekitToken: string;
     isHost: string;
+    roomTitle: string;
+    roomHost: string;
   }>();
   const isHost = isHostParam === 'true';
-  const { roomMeta, leave: clearRoomState } = useHangoutsRoom();
 
   const [connectionState, setConnectionState] = useState<ConnectionState | 'idle'>('idle');
   // Prevent double-navigation: RoomScreenInner handles server-initiated disconnects;
@@ -339,9 +347,8 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   const handleLeave = useCallback((): void => {
     if (hasLeftRef.current) return;
     hasLeftRef.current = true;
-    clearRoomState();
     router.back();
-  }, [clearRoomState, router]);
+  }, [router]);
 
   if (!livekitToken || !roomName) {
     return (
@@ -351,8 +358,8 @@ export default function HangoutsRoomScreen(): React.ReactElement {
     );
   }
 
-  const displayTitle = roomMeta?.title ?? roomName;
-  const displayHost = roomMeta?.host ?? '';
+  const displayTitle = titleParam || roomName;
+  const displayHost = hostParam || '';
 
   if (!permissionReady) {
     return (

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Platform,
   PermissionsAndroid,
+  KeyboardAvoidingView,
   useColorScheme,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -203,7 +204,11 @@ function RoomScreenInner({
   };
 
   return (
-    <View style={styles.inner}>
+    <KeyboardAvoidingView
+      style={styles.inner}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
+    >
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: theme.border }]}>
         <IconButton
@@ -286,7 +291,7 @@ function RoomScreenInner({
           colors={colors}
         />
       )}
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -1,0 +1,376 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  Platform,
+  PermissionsAndroid,
+  useColorScheme,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Image as ExpoImage } from 'expo-image';
+import {
+  LiveKitRoom,
+  useDataChannel,
+  useLocalParticipant,
+  useRoomContext,
+  AudioSession,
+} from '@livekit/react-native';
+import type { ConnectionState, Participant } from 'livekit-client';
+import { FontAwesome } from '@expo/vector-icons';
+import { getTheme } from '../../constants/Colors';
+import { LIVEKIT_URL } from '../config/env';
+import { hangoutsAuthService } from '../../services/HangoutsAuthService';
+import { useHangoutsRoom } from '../../hooks/useHangoutsRoom';
+import IconButton from '../components/IconButton';
+import SpeakerStage from '../components/hangouts/SpeakerStage';
+import AudienceSection from '../components/hangouts/AudienceSection';
+import RoomControls from '../components/hangouts/RoomControls';
+import ChatPanel from '../components/hangouts/ChatPanel';
+import HostControlsPanel from '../components/hangouts/HostControlsPanel';
+
+// ─── Inner screen rendered inside <LiveKitRoom> provider ───────────────────
+
+function RoomScreenInner({
+  roomName,
+  roomTitle,
+  roomHost,
+  isHost,
+  onLeave,
+}: {
+  roomName: string;
+  roomTitle: string;
+  roomHost: string;
+  isHost: boolean;
+  onLeave: () => void;
+}): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const theme = getTheme(colorScheme === 'dark' ? 'dark' : 'light');
+  const { localParticipant } = useLocalParticipant();
+  const room = useRoomContext();
+  const client = hangoutsAuthService.getClient();
+
+  const [activeSpeakerIdentities, setActiveSpeakerIdentities] = useState<string[]>([]);
+  const [raisedHandIdentities, setRaisedHandIdentities] = useState<string[]>([]);
+  const [hasRaisedHand, setHasRaisedHand] = useState(false);
+  const [chatVisible, setChatVisible] = useState(false);
+  const [selectedParticipant, setSelectedParticipant] = useState<string | null>(null);
+
+  // Track active speakers
+  useEffect(() => {
+    const onSpeakersChanged = (speakers: Participant[]) => {
+      setActiveSpeakerIdentities(speakers.map((s) => s.identity));
+    };
+    room.on('activeSpeakersChanged', onSpeakersChanged);
+    return () => { room.off('activeSpeakersChanged', onSpeakersChanged); };
+  }, [room]);
+
+  // Receive hand-raise data messages
+  useDataChannel('hand-raise', useCallback((msg: { payload: Uint8Array }) => {
+    try {
+      const data = JSON.parse(new TextDecoder().decode(msg.payload)) as {
+        type: string;
+        raised: boolean;
+        identity: string;
+      };
+      if (data.type === 'hand_raise') {
+        setRaisedHandIdentities((prev) =>
+          data.raised ? [...new Set([...prev, data.identity])] : prev.filter((id) => id !== data.identity)
+        );
+      }
+    } catch {
+      // malformed — ignore
+    }
+  }, []));
+
+  const handleToggleMute = useCallback(async (): Promise<void> => {
+    if (!localParticipant) return;
+    await localParticipant.setMicrophoneEnabled(localParticipant.isMicrophoneEnabled ? false : true);
+  }, [localParticipant]);
+
+  const handleToggleHand = useCallback(async (): Promise<void> => {
+    if (!localParticipant) return;
+    const raised = !hasRaisedHand;
+    const payload = {
+      type: 'hand_raise',
+      raised,
+      identity: localParticipant.identity,
+      timestamp: Date.now(),
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(payload));
+    await localParticipant.publishData(bytes, { reliable: true });
+    setHasRaisedHand(raised);
+  }, [hasRaisedHand, localParticipant]);
+
+  const handleApprove = useCallback(async (identity: string): Promise<void> => {
+    try {
+      await client.setPermissions(roomName, identity, true);
+      setRaisedHandIdentities((prev) => prev.filter((id) => id !== identity));
+    } catch {
+      Alert.alert('Error', 'Could not promote participant.');
+    }
+  }, [client, roomName]);
+
+  const handleDeny = useCallback((identity: string): void => {
+    setRaisedHandIdentities((prev) => prev.filter((id) => id !== identity));
+  }, []);
+
+  const handleMuteParticipant = useCallback(async (identity: string): Promise<void> => {
+    try {
+      await client.setPermissions(roomName, identity, false);
+    } catch {
+      Alert.alert('Error', 'Could not mute participant.');
+    }
+  }, [client, roomName]);
+
+  const handleKick = useCallback(async (identity: string): Promise<void> => {
+    Alert.alert('Remove participant', `Remove @${identity} from the room?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Remove', style: 'destructive',
+        onPress: async () => {
+          try {
+            await client.kickParticipant(roomName, identity);
+          } catch {
+            Alert.alert('Error', 'Could not remove participant.');
+          }
+        },
+      },
+    ]);
+  }, [client, roomName]);
+
+  const handleEndRoom = useCallback((): void => {
+    Alert.alert('End Room', 'This will end the hangout for everyone.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'End Room', style: 'destructive',
+        onPress: async () => {
+          try {
+            await client.deleteRoom(roomName);
+          } catch {
+            // best-effort — leave regardless
+          }
+          onLeave();
+        },
+      },
+    ]);
+  }, [client, roomName, onLeave]);
+
+  const colors = {
+    text: theme.text,
+    textSecondary: theme.textSecondary,
+    card: theme.card,
+    border: theme.border,
+    success: theme.success,
+    button: theme.button,
+    buttonText: theme.buttonText,
+    icon: theme.icon,
+    error: theme.error ?? '#EF4444',
+    background: theme.background,
+  };
+
+  return (
+    <View style={styles.inner}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <IconButton
+          name='arrow-left'
+          size={20}
+          color={theme.text}
+          onPress={onLeave}
+          accessibilityLabel='Leave room'
+          style={styles.backBtn}
+        />
+        <View style={styles.headerCenter}>
+          <ExpoImage
+            source={{ uri: `https://images.hive.blog/u/${roomHost}/avatar/sm` }}
+            style={styles.headerAvatar}
+            contentFit='cover'
+          />
+          <View>
+            <Text style={[styles.headerTitle, { color: theme.text }]} numberOfLines={1}>
+              {roomTitle}
+            </Text>
+            <Text style={[styles.headerHost, { color: theme.textSecondary }]}>@{roomHost}</Text>
+          </View>
+          <View style={[styles.liveBadge, { backgroundColor: theme.success }]}>
+            <Text style={styles.liveText}>LIVE</Text>
+          </View>
+        </View>
+        <View style={styles.backBtn} />
+      </View>
+
+      {/* Speaker stage */}
+      <SpeakerStage
+        activeSpeakerIdentities={activeSpeakerIdentities}
+        raisedHandIdentities={raisedHandIdentities}
+        colors={colors}
+      />
+
+      {/* Divider */}
+      <View style={[styles.divider, { backgroundColor: theme.border }]} />
+
+      {/* Audience */}
+      <AudienceSection
+        isHost={isHost}
+        raisedHandIdentities={raisedHandIdentities}
+        activeSpeakerIdentities={activeSpeakerIdentities}
+        onApprove={handleApprove}
+        onDeny={handleDeny}
+        onLongPress={(identity) => setSelectedParticipant(identity)}
+        colors={colors}
+      />
+
+      {/* Chat panel */}
+      <ChatPanel
+        visible={chatVisible}
+        onClose={() => setChatVisible(false)}
+        colors={colors}
+      />
+
+      {/* Controls */}
+      <RoomControls
+        isHost={isHost}
+        hasRaisedHand={hasRaisedHand}
+        onToggleMute={handleToggleMute}
+        onToggleHand={handleToggleHand}
+        onToggleChat={() => setChatVisible((v) => !v)}
+        onLeave={onLeave}
+        onEndRoom={handleEndRoom}
+        colors={colors}
+      />
+
+      {/* Host action sheet */}
+      {isHost && (
+        <HostControlsPanel
+          identity={selectedParticipant}
+          onPromote={handleApprove}
+          onMute={handleMuteParticipant}
+          onKick={handleKick}
+          onClose={() => setSelectedParticipant(null)}
+          colors={colors}
+        />
+      )}
+    </View>
+  );
+}
+
+// ─── Outer screen — sets up LiveKitRoom provider ───────────────────────────
+
+export default function HangoutsRoomScreen(): React.ReactElement {
+  const colorScheme = useColorScheme();
+  const theme = getTheme(colorScheme === 'dark' ? 'dark' : 'light');
+  const router = useRouter();
+  const { roomName, livekitToken } = useLocalSearchParams<{
+    roomName: string;
+    livekitToken: string;
+  }>();
+  const { roomMeta, isHost, leave: clearRoomState } = useHangoutsRoom();
+
+  const [connectionState, setConnectionState] = useState<ConnectionState | 'idle'>('idle');
+
+  // Request Android mic permission before connecting
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    void PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO).then((result) => {
+      if (result !== PermissionsAndroid.RESULTS.GRANTED) {
+        Alert.alert(
+          'Microphone required',
+          'Please grant microphone access to join audio rooms.',
+          [{ text: 'OK', onPress: () => router.back() }]
+        );
+      }
+    });
+  }, [router]);
+
+  // Configure audio session
+  useEffect(() => {
+    void AudioSession.startAudioSession();
+    return () => { void AudioSession.stopAudioSession(); };
+  }, []);
+
+  const handleLeave = useCallback((): void => {
+    clearRoomState();
+    router.back();
+  }, [clearRoomState, router]);
+
+  if (!livekitToken || !roomName) {
+    return (
+      <SafeAreaView style={[styles.center, { backgroundColor: theme.background }]}>
+        <Text style={{ color: theme.textSecondary }}>Invalid room parameters.</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const displayTitle = roomMeta?.title ?? roomName;
+  const displayHost = roomMeta?.host ?? '';
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>
+      <LiveKitRoom
+        serverUrl={LIVEKIT_URL}
+        token={livekitToken}
+        connect={true}
+        audio={true}
+        video={false}
+        onConnected={() => setConnectionState('connected' as ConnectionState)}
+        onDisconnected={() => {
+          setConnectionState('disconnected' as ConnectionState);
+          handleLeave();
+        }}
+        onError={(err) => {
+          setConnectionState('disconnected' as ConnectionState);
+          Alert.alert('Connection error', err.message, [{ text: 'Leave', onPress: handleLeave }]);
+        }}
+      >
+        {connectionState !== 'connected' ? (
+          <View style={styles.center}>
+            <ActivityIndicator size='large' color={theme.button} />
+            <Text style={[styles.connectingText, { color: theme.textSecondary }]}>
+              Connecting to room...
+            </Text>
+          </View>
+        ) : (
+          <RoomScreenInner
+            roomName={roomName}
+            roomTitle={displayTitle}
+            roomHost={displayHost}
+            isHost={isHost}
+            onLeave={handleLeave}
+          />
+        )}
+      </LiveKitRoom>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  connectingText: { marginTop: 12, fontSize: 14 },
+  inner: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  backBtn: { width: 36 },
+  headerCenter: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    justifyContent: 'center',
+  },
+  headerAvatar: { width: 36, height: 36, borderRadius: 18 },
+  headerTitle: { fontSize: 15, fontWeight: '600', maxWidth: 160 },
+  headerHost: { fontSize: 12 },
+  liveBadge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  liveText: { color: '#fff', fontSize: 10, fontWeight: '700' },
+  divider: { height: 1, marginHorizontal: 16 },
+});

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -325,7 +325,9 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   // Request Android mic permission — gate LiveKitRoom until resolved
   useEffect(() => {
     if (Platform.OS !== 'android') return;
+    let cancelled = false;
     void PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO).then((result) => {
+      if (cancelled) return;
       if (result !== PermissionsAndroid.RESULTS.GRANTED) {
         Alert.alert(
           'Microphone required',
@@ -336,6 +338,7 @@ export default function HangoutsRoomScreen(): React.ReactElement {
         setPermissionReady(true);
       }
     });
+    return () => { cancelled = true; };
   }, [router]);
 
   // Configure audio session

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -264,11 +264,13 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   const colorScheme = useColorScheme();
   const theme = getTheme(colorScheme === 'dark' ? 'dark' : 'light');
   const router = useRouter();
-  const { roomName, livekitToken } = useLocalSearchParams<{
+  const { roomName, livekitToken, isHost: isHostParam } = useLocalSearchParams<{
     roomName: string;
     livekitToken: string;
+    isHost: string;
   }>();
-  const { roomMeta, isHost, leave: clearRoomState } = useHangoutsRoom();
+  const isHost = isHostParam === 'true';
+  const { roomMeta, leave: clearRoomState } = useHangoutsRoom();
 
   const [connectionState, setConnectionState] = useState<ConnectionState | 'idle'>('idle');
   // On Android we must resolve mic permission before LiveKitRoom mounts,
@@ -330,7 +332,7 @@ export default function HangoutsRoomScreen(): React.ReactElement {
         serverUrl={LIVEKIT_URL}
         token={livekitToken}
         connect={true}
-        audio={true}
+        audio={isHost}
         video={false}
         onConnected={() => setConnectionState('connected' as ConnectionState)}
         onDisconnected={() => {

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -57,6 +57,7 @@ function RoomScreenInner({
   const [raisedHandIdentities, setRaisedHandIdentities] = useState<string[]>([]);
   const [hasRaisedHand, setHasRaisedHand] = useState(false);
   const [chatVisible, setChatVisible] = useState(false);
+  const [chatMessages, setChatMessages] = useState<{ id: string; identity: string; text: string; timestamp: number }[]>([]);
   const [selectedParticipant, setSelectedParticipant] = useState<string | null>(null);
 
   // Track active speakers
@@ -68,8 +69,8 @@ function RoomScreenInner({
     return () => { room.off('activeSpeakersChanged', onSpeakersChanged); };
   }, [room]);
 
-  // Receive hand-raise data messages
-  useDataChannel('hand-raise', useCallback((msg: { payload: Uint8Array }) => {
+  // Receive hand-raise data messages (always mounted — topic must match sender)
+  const { send: sendHandRaise } = useDataChannel('hand-raise', useCallback((msg: { payload: Uint8Array }) => {
     try {
       const data = JSON.parse(new TextDecoder().decode(msg.payload)) as {
         type: string;
@@ -86,24 +87,53 @@ function RoomScreenInner({
     }
   }, []));
 
+  // Receive and send chat messages at room level so they're captured even when ChatPanel is closed
+  const { send: sendChatData } = useDataChannel('chat', useCallback((msg: { payload: Uint8Array }) => {
+    try {
+      const data = JSON.parse(new TextDecoder().decode(msg.payload)) as {
+        type: string;
+        identity: string;
+        text: string;
+        timestamp: number;
+      };
+      if (data.type === 'chat') {
+        setChatMessages((prev) => [...prev, { id: `${data.identity}-${data.timestamp}`, ...data }]);
+      }
+    } catch {
+      // malformed — ignore
+    }
+  }, []));
+
+  const handleSendChat = useCallback((text: string): void => {
+    if (!localParticipant || !text.trim()) return;
+    const event = {
+      type: 'chat',
+      identity: localParticipant.identity,
+      text: text.trim(),
+      timestamp: Date.now(),
+    };
+    sendChatData(new TextEncoder().encode(JSON.stringify(event)), { reliable: true });
+    setChatMessages((prev) => [...prev, { id: `local-${event.timestamp}`, ...event }]);
+  }, [localParticipant, sendChatData]);
+
   const handleToggleMute = useCallback(async (): Promise<void> => {
     if (!localParticipant) return;
-    await localParticipant.setMicrophoneEnabled(localParticipant.isMicrophoneEnabled ? false : true);
+    await localParticipant.setMicrophoneEnabled(!localParticipant.isMicrophoneEnabled);
   }, [localParticipant]);
 
-  const handleToggleHand = useCallback(async (): Promise<void> => {
+  // Use useDataChannel send so the topic header is attached — publishData sends without topic
+  const handleToggleHand = useCallback((): void => {
     if (!localParticipant) return;
     const raised = !hasRaisedHand;
-    const payload = {
+    const bytes = new TextEncoder().encode(JSON.stringify({
       type: 'hand_raise',
       raised,
       identity: localParticipant.identity,
       timestamp: Date.now(),
-    };
-    const bytes = new TextEncoder().encode(JSON.stringify(payload));
-    await localParticipant.publishData(bytes, { reliable: true });
+    }));
+    sendHandRaise(bytes, { reliable: true });
     setHasRaisedHand(raised);
-  }, [hasRaisedHand, localParticipant]);
+  }, [hasRaisedHand, localParticipant, sendHandRaise]);
 
   const handleApprove = useCallback(async (identity: string): Promise<void> => {
     try {
@@ -227,6 +257,8 @@ function RoomScreenInner({
       {/* Chat panel */}
       <ChatPanel
         visible={chatVisible}
+        messages={chatMessages}
+        onSend={handleSendChat}
         onClose={() => setChatVisible(false)}
         colors={colors}
       />

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -21,6 +21,7 @@ import {
   AudioSession,
 } from '@livekit/react-native';
 import type { ConnectionState, Participant } from 'livekit-client';
+import { DisconnectReason } from '@livekit/protocol';
 import { FontAwesome } from '@expo/vector-icons';
 import { getTheme } from '../../constants/Colors';
 import { LIVEKIT_URL } from '../config/env';
@@ -69,6 +70,24 @@ function RoomScreenInner({
     room.on('activeSpeakersChanged', onSpeakersChanged);
     return () => { room.off('activeSpeakersChanged', onSpeakersChanged); };
   }, [room]);
+
+  // Handle server-initiated disconnects with a user-friendly message
+  useEffect(() => {
+    const onDisconnected = (reason?: DisconnectReason) => {
+      if (reason === DisconnectReason.ROOM_DELETED) {
+        Alert.alert('Hangout ended', 'The host has ended this hangout.', [
+          { text: 'OK', onPress: onLeave },
+        ]);
+      } else if (reason === DisconnectReason.PARTICIPANT_REMOVED) {
+        Alert.alert('Removed', 'You were removed from this hangout.', [
+          { text: 'OK', onPress: onLeave },
+        ]);
+      }
+      // CLIENT_INITIATED: user pressed Leave — onLeave already called, do nothing
+    };
+    room.on('disconnected', onDisconnected);
+    return () => { room.off('disconnected', onDisconnected); };
+  }, [room, onLeave]);
 
   // Receive hand-raise data messages (always mounted — topic must match sender)
   const { send: sendHandRaise } = useDataChannel('hand-raise', useCallback((msg: { payload: Uint8Array }) => {
@@ -310,6 +329,9 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   const { roomMeta, leave: clearRoomState } = useHangoutsRoom();
 
   const [connectionState, setConnectionState] = useState<ConnectionState | 'idle'>('idle');
+  // Prevent double-navigation: RoomScreenInner handles server-initiated disconnects;
+  // onDisconnected fallback fires after, but only navigates if we haven't left yet.
+  const hasLeftRef = useRef(false);
   // On Android we must resolve mic permission before LiveKitRoom mounts,
   // otherwise LiveKit tries to open the mic while the dialog is still pending.
   const [permissionReady, setPermissionReady] = useState(Platform.OS !== 'android');
@@ -337,6 +359,8 @@ export default function HangoutsRoomScreen(): React.ReactElement {
   }, []);
 
   const handleLeave = useCallback((): void => {
+    if (hasLeftRef.current) return;
+    hasLeftRef.current = true;
     clearRoomState();
     router.back();
   }, [clearRoomState, router]);
@@ -374,6 +398,9 @@ export default function HangoutsRoomScreen(): React.ReactElement {
         onConnected={() => setConnectionState('connected' as ConnectionState)}
         onDisconnected={() => {
           setConnectionState('disconnected' as ConnectionState);
+          // RoomScreenInner handles ROOM_DELETED / PARTICIPANT_REMOVED with an Alert.
+          // For any other reason (CLIENT_INITIATED handled by Leave button, unknown reasons),
+          // fall back to leaving silently if we haven't already.
           handleLeave();
         }}
         onError={(err) => {

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -113,13 +113,13 @@ function RoomScreenInner({
       text: text.trim(),
       timestamp: Date.now(),
     };
-    sendChatData(new TextEncoder().encode(JSON.stringify(event)), { reliable: true });
+    sendChatData(new TextEncoder().encode(JSON.stringify(event)), { reliable: true }).catch(() => {});
     setChatMessages((prev) => [...prev, { id: `local-${event.timestamp}`, ...event }]);
   }, [localParticipant, sendChatData]);
 
-  const handleToggleMute = useCallback(async (): Promise<void> => {
+  const handleToggleMute = useCallback((): void => {
     if (!localParticipant) return;
-    await localParticipant.setMicrophoneEnabled(!localParticipant.isMicrophoneEnabled);
+    localParticipant.setMicrophoneEnabled(!localParticipant.isMicrophoneEnabled).catch(() => {});
   }, [localParticipant]);
 
   // Use useDataChannel send so the topic header is attached — publishData sends without topic
@@ -132,7 +132,7 @@ function RoomScreenInner({
       identity: localParticipant.identity,
       timestamp: Date.now(),
     }));
-    sendHandRaise(bytes, { reliable: true });
+    sendHandRaise(bytes, { reliable: true }).catch(() => {});
     setHasRaisedHand(raised);
   }, [hasRaisedHand, localParticipant, sendHandRaise]);
 

--- a/app/screens/HangoutsRoomScreen.tsx
+++ b/app/screens/HangoutsRoomScreen.tsx
@@ -71,24 +71,6 @@ function RoomScreenInner({
     return () => { room.off('activeSpeakersChanged', onSpeakersChanged); };
   }, [room]);
 
-  // Handle server-initiated disconnects with a user-friendly message
-  useEffect(() => {
-    const onDisconnected = (reason?: DisconnectReason) => {
-      if (reason === DisconnectReason.ROOM_DELETED) {
-        Alert.alert('Hangout ended', 'The host has ended this hangout.', [
-          { text: 'OK', onPress: onLeave },
-        ]);
-      } else if (reason === DisconnectReason.PARTICIPANT_REMOVED) {
-        Alert.alert('Removed', 'You were removed from this hangout.', [
-          { text: 'OK', onPress: onLeave },
-        ]);
-      }
-      // CLIENT_INITIATED: user pressed Leave — onLeave already called, do nothing
-    };
-    room.on('disconnected', onDisconnected);
-    return () => { room.off('disconnected', onDisconnected); };
-  }, [room, onLeave]);
-
   // Receive hand-raise data messages (always mounted — topic must match sender)
   const { send: sendHandRaise } = useDataChannel('hand-raise', useCallback((msg: { payload: Uint8Array }) => {
     try {
@@ -396,13 +378,26 @@ export default function HangoutsRoomScreen(): React.ReactElement {
         audio={isHost}
         video={false}
         onConnected={() => setConnectionState('connected' as ConnectionState)}
-        onDisconnected={() => {
-          setConnectionState('disconnected' as ConnectionState);
-          // RoomScreenInner handles ROOM_DELETED / PARTICIPANT_REMOVED with an Alert.
-          // For any other reason (CLIENT_INITIATED handled by Leave button, unknown reasons),
-          // fall back to leaving silently if we haven't already.
-          handleLeave();
-        }}
+        onDisconnected={
+          // LiveKit's implementation calls onDisconnected(reason) even though the
+          // TS type declares () => void — cast so we can read the reason.
+          ((reason?: DisconnectReason) => {
+            setConnectionState('disconnected' as ConnectionState);
+            if (reason === DisconnectReason.ROOM_DELETED) {
+              Alert.alert('Hangout ended', 'The host has ended this hangout.', [
+                { text: 'OK', onPress: handleLeave },
+              ]);
+            } else if (reason === DisconnectReason.PARTICIPANT_REMOVED) {
+              Alert.alert('Removed', 'You were removed from this hangout.', [
+                { text: 'OK', onPress: handleLeave },
+              ]);
+            } else {
+              // CLIENT_INITIATED (user pressed Leave — handleLeave idempotent via ref),
+              // UNKNOWN_REASON, SERVER_SHUTDOWN, etc. — leave silently.
+              handleLeave();
+            }
+          }) as () => void
+        }
         onError={(err) => {
           setConnectionState('disconnected' as ConnectionState);
           Alert.alert('Connection error', err.message, [{ text: 'Leave', onPress: handleLeave }]);

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -2,6 +2,14 @@ import { useState, useCallback, useRef } from 'react';
 import type { Room, JoinRoomResponse, CreateRoomResponse } from '@snapie/hangouts-core';
 import { hangoutsAuthService } from '../services/HangoutsAuthService';
 
+/** Thrown when a join/create operation is superseded by a subsequent leave() call. */
+export class RoomOperationCancelledError extends Error {
+  constructor() {
+    super('Room operation was cancelled');
+    this.name = 'RoomOperationCancelledError';
+  }
+}
+
 interface UseHangoutsRoomResult {
   livekitToken: string | null;
   roomName: string | null;
@@ -37,7 +45,7 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
     setError(null);
     try {
       const result = await client.joinRoom(name);
-      if (activeOpRef.current !== op) return result; // superseded by leave/create
+      if (activeOpRef.current !== op) throw new RoomOperationCancelledError();
       const joinedName = result.roomName;
       latestJoinRef.current = joinedName;
       setLivekitToken(result.token);
@@ -71,7 +79,7 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
     try {
       const response: CreateRoomResponse = await client.createRoom(title, description);
       const { room, token } = response;
-      if (activeOpRef.current !== op) return response; // superseded by leave
+      if (activeOpRef.current !== op) throw new RoomOperationCancelledError();
       setLivekitToken(token);
       setRoomName(room.name);
       setRoomMeta(room);

--- a/hooks/useHangoutsRoom.ts
+++ b/hooks/useHangoutsRoom.ts
@@ -10,7 +10,7 @@ interface UseHangoutsRoomResult {
   isLoading: boolean;
   error: string | null;
   join: (name: string) => Promise<JoinRoomResponse>;
-  create: (title: string, description?: string) => Promise<Room>;
+  create: (title: string, description?: string) => Promise<CreateRoomResponse>;
   leave: () => void;
 }
 
@@ -63,19 +63,20 @@ export function useHangoutsRoom(): UseHangoutsRoomResult {
     }
   }, [client]);
 
-  const create = useCallback(async (title: string, description?: string): Promise<Room> => {
+  const create = useCallback(async (title: string, description?: string): Promise<CreateRoomResponse> => {
     const op = ++activeOpRef.current;
     latestJoinRef.current = null; // invalidate any in-flight join metadata lookup
     setIsLoading(true);
     setError(null);
     try {
-      const { room, token }: CreateRoomResponse = await client.createRoom(title, description);
-      if (activeOpRef.current !== op) return room; // superseded by leave
+      const response: CreateRoomResponse = await client.createRoom(title, description);
+      const { room, token } = response;
+      if (activeOpRef.current !== op) return response; // superseded by leave
       setLivekitToken(token);
       setRoomName(room.name);
       setRoomMeta(room);
       setIsHost(true);
-      return room;
+      return response;
     } catch (err) {
       if (activeOpRef.current === op) {
         setError(err instanceof Error ? err.message : 'Failed to create room');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,19 @@
+// This file runs before Expo Router's file scanner, making it the right place
+// for global polyfills that LiveKit needs at module-evaluation time.
+
+// DOMException is a browser-only API not available in React Native's Hermes engine.
+if (typeof global.DOMException === 'undefined') {
+  global.DOMException = class DOMException extends Error {
+    constructor(message, name) {
+      super(message);
+      this.name = name ?? 'DOMException';
+    }
+  };
+}
+
+// Register WebRTC globals required by @livekit/react-native before any
+// LiveKit module is imported by Expo Router's eager file scan.
+const { registerGlobals } = require('@livekit/react-native');
+registerGlobals();
+
+require('expo-router/entry');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@ecency/render-helper": "^2.3.11",
         "@expo/vector-icons": "^15.0.2",
         "@hiveio/dhive": "^1.3.2",
+        "@livekit/react-native": "^2.10.0",
+        "@livekit/react-native-webrtc": "^144.0.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/slider": "5.0.1",
         "@react-navigation/native": "^7.1.6",
@@ -1573,6 +1575,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
+    },
     "node_modules/@ecency/bytebuffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@ecency/bytebuffer/-/bytebuffer-6.0.0.tgz",
@@ -2341,6 +2350,31 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@hiveio/dhive": {
       "version": "1.3.2",
@@ -3542,6 +3576,149 @@
         "react-native": "*"
       }
     },
+    "node_modules/@livekit/components-core": {
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/@livekit/components-core/-/components-core-0.12.13.tgz",
+      "integrity": "sha512-DQmi84afHoHjZ62wm8y+XPNIDHTwFHAltjd3lmyXj8UZHOY7wcza4vFt1xnghJOD5wLRY58L1dkAgAw59MgWvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/dom": "1.7.4",
+        "loglevel": "1.9.1",
+        "rxjs": "7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "livekit-client": "^2.17.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@livekit/components-core/node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.44.0.tgz",
+      "integrity": "sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/react-native": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native/-/react-native-2.10.0.tgz",
+      "integrity": "sha512-8TWJ3/TyHyF5/EVr8dRXG4cGK8Kt9k0R11O/nKYfy4xOcahax2C2yfdE1VgVD7WKT68oon/eSx58RnpoLmMhMQ==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        ".",
+        "example"
+      ],
+      "dependencies": {
+        "@livekit/components-react": "^2.9.17",
+        "@livekit/mutex": "^1.1.1",
+        "array.prototype.at": "^1.1.1",
+        "base64-js": "1.5.1",
+        "events": "^3.3.0",
+        "loglevel": "^1.8.0",
+        "promise.allsettled": "^1.0.5",
+        "react-native-url-polyfill": "^1.3.0",
+        "typed-emitter": "^2.1.0",
+        "web-streams-polyfill": "^4.1.0",
+        "well-known-symbols": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@livekit/react-native-webrtc": "^144.0.0",
+        "livekit-client": "^2.15.8",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native-webrtc/-/react-native-webrtc-144.0.0.tgz",
+      "integrity": "sha512-G5wAxTpxQcHrEQJchcEXs9COrjpfEwJVOJeadDT8+sX/slB5UrjUQC6JItg295Gqtn20Gv3zMJMmSPASJsXRHA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/@livekit/react-native/node_modules/@livekit/components-react": {
+      "version": "2.9.20",
+      "resolved": "https://registry.npmjs.org/@livekit/components-react/-/components-react-2.9.20.tgz",
+      "integrity": "sha512-hjkYOsJj9Jbghb7wM5cI8HoVisKeL6Zcy1VnRWTLm0sqVbto8GJp/17T4Udx85mCPY6Jgh8I1Cv0yVzgz7CQtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/components-core": "0.12.13",
+        "clsx": "2.1.1",
+        "events": "^3.3.0",
+        "jose": "^6.0.12",
+        "usehooks-ts": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0",
+        "livekit-client": "^2.17.2",
+        "react": ">=18",
+        "react-dom": ">=18",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "@livekit/krisp-noise-filter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@native-html/css-processor": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@native-html/css-processor/-/css-processor-1.11.0.tgz",
@@ -4584,6 +4761,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/elliptic": {
       "version": "6.4.18",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.18.tgz",
@@ -4965,6 +5149,83 @@
         "node": ">=10"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.at": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.at/-/array.prototype.at-1.1.3.tgz",
+      "integrity": "sha512-TX4J1Uig4skvpOakrvP8q/uyhUj+ZDNmQoZpHf3MsKTrXcMHDPrgJlpv2nRJMfANrsmhg1JoOGrg3yOp209SWg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.8.tgz",
+      "integrity": "sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-object-atoms": "^1.0.0",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -4991,6 +5252,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/async-limiter": {
@@ -5956,6 +6226,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6401,6 +6680,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -6840,6 +7170,80 @@
         "stackframe": "^1.3.4"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -6858,6 +7262,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6874,7 +7298,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6884,6 +7307,35 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -6984,6 +7436,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/evp_bytestokey": {
@@ -8133,6 +8594,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8219,6 +8709,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -8260,6 +8767,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8278,6 +8801,18 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8294,6 +8829,21 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8699,6 +9249,20 @@
         "css-in-js-utils": "^3.1.0"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -8724,11 +9288,78 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -8749,6 +9380,39 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8779,6 +9443,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -8818,6 +9497,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-nan": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -8834,6 +9525,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8841,6 +9544,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -8877,6 +9596,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -8889,6 +9635,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -8896,6 +9675,49 @@
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9009,6 +9831,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterate-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jackspeak": {
@@ -10951,6 +11795,15 @@
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==",
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
@@ -11425,6 +12278,27 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.1.tgz",
+      "integrity": "sha512-nGjuEEV1mVN01EcAMwGIwG3J1gpBMqwn2V4R6W/8zz9Rah1CaAohIm6AMLG7BdctQpyeh34dfAOLfDodIsWyYA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.44.0",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -11593,6 +12467,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lolight": {
@@ -12686,6 +13573,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -13153,6 +14057,26 @@
       "license": "MIT",
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/promise.allsettled": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
+      "integrity": "sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.map": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "iterate-value": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/prompts": {
@@ -13642,6 +14566,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-url-polyfill": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
+      "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-video": {
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.19.0.tgz",
@@ -13961,6 +14897,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -13984,6 +14942,26 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/regexpu-core": {
       "version": "6.3.1",
@@ -14282,6 +15260,34 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -14301,6 +15307,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -14350,6 +15372,23 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/secp256k1": {
       "version": "3.8.1",
@@ -14491,6 +15530,35 @@
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14854,6 +15922,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-buffers": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
@@ -14956,6 +16037,62 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-entities": {
@@ -15497,6 +16634,75 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -15542,6 +16748,24 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/undici": {
       "version": "6.21.3",
@@ -15755,6 +16979,21 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -15901,6 +17140,20 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz",
+      "integrity": "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==",
+      "license": "MIT",
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -15909,6 +17162,33 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.4.tgz",
+      "integrity": "sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
+    "node_modules/well-known-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-4.1.0.tgz",
+      "integrity": "sha512-lKhCpGfPkaJnPKyep1Uj44pNmyrdupYHtxci2ThUCC/Y0px44d9BWt2dbewDif4PwOqSI6KkCdwuL22CDUj4rw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.7",
+        "has-symbols": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -15990,6 +17270,70 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hivesnaps",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.1.0",
   "scripts": {
     "start": "expo start",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@ecency/render-helper": "^2.3.11",
     "@expo/vector-icons": "^15.0.2",
     "@hiveio/dhive": "^1.3.2",
+    "@livekit/react-native": "^2.10.0",
+    "@livekit/react-native-webrtc": "^144.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/slider": "5.0.1",
     "@react-navigation/native": "^7.1.6",

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -72,8 +72,7 @@ class HangoutsAuthServiceImpl {
       return true;
     } catch (error) {
       this.clearSession();
-      const name = error instanceof Error ? error.name : 'UnknownError';
-      console.error(`[HangoutsAuth] Authentication failed: ${name}`);
+      console.error('[HangoutsAuth] Authentication failed:', error);
       return false;
     }
   }

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -16,6 +16,8 @@ class HangoutsAuthServiceImpl {
   private client: HangoutsApiClient;
   private sessionToken: string | null = null;
   private ec = new EC('secp256k1');
+  // Deduplicate concurrent auth calls — if one is in-flight, return the same promise
+  private authInFlight: Promise<boolean> | null = null;
 
   constructor() {
     this.client = new HangoutsApiClient({ baseUrl: HANGOUTS_API_URL });
@@ -56,6 +58,12 @@ class HangoutsAuthServiceImpl {
    * Non-fatal — hangouts features degrade gracefully on failure.
    */
   async authenticate(): Promise<boolean> {
+    if (this.authInFlight) return this.authInFlight;
+    this.authInFlight = this._doAuthenticate().finally(() => { this.authInFlight = null; });
+    return this.authInFlight;
+  }
+
+  private async _doAuthenticate(): Promise<boolean> {
     try {
       const username = await accountStorageService.getCurrentAccountUsername();
       const postingKey = await accountStorageService.getCurrentPostingKey();

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -80,7 +80,8 @@ class HangoutsAuthServiceImpl {
       return true;
     } catch (error) {
       this.clearSession();
-      console.error('[HangoutsAuth] Authentication failed:', error);
+      // Log message only — never log the full error object (may contain key material in stack traces)
+      console.warn('[HangoutsAuth] Authentication failed:', error instanceof Error ? error.message : 'Unknown error');
       return false;
     }
   }

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -59,14 +59,18 @@ class HangoutsAuthServiceImpl {
     try {
       const username = await accountStorageService.getCurrentAccountUsername();
       const postingKey = await accountStorageService.getCurrentPostingKey();
+      console.log('[HangoutsAuth] username:', username, 'hasKey:', !!postingKey);
       if (!username || !postingKey) {
         this.clearSession();
         return false;
       }
 
       const { challenge } = await this.client.requestChallenge(username);
+      console.log('[HangoutsAuth] challenge received, signing...');
       const signature = this.signChallenge(challenge, postingKey);
+      console.log('[HangoutsAuth] sending verify...');
       const session = await this.client.verifySignature(username, challenge, signature);
+      console.log('[HangoutsAuth] session token received:', !!session.token);
       this.sessionToken = session.token;
       this.client.setSessionToken(session.token);
       return true;

--- a/services/HangoutsAuthService.ts
+++ b/services/HangoutsAuthService.ts
@@ -67,18 +67,14 @@ class HangoutsAuthServiceImpl {
     try {
       const username = await accountStorageService.getCurrentAccountUsername();
       const postingKey = await accountStorageService.getCurrentPostingKey();
-      console.log('[HangoutsAuth] username:', username, 'hasKey:', !!postingKey);
       if (!username || !postingKey) {
         this.clearSession();
         return false;
       }
 
       const { challenge } = await this.client.requestChallenge(username);
-      console.log('[HangoutsAuth] challenge received, signing...');
       const signature = this.signChallenge(challenge, postingKey);
-      console.log('[HangoutsAuth] sending verify...');
       const session = await this.client.verifySignature(username, challenge, signature);
-      console.log('[HangoutsAuth] session token received:', !!session.token);
       this.sessionToken = session.token;
       this.client.setSessionToken(session.token);
       return true;


### PR DESCRIPTION
## Summary

- Adds full LiveKit audio room support to Hive Hangouts (Phase 2)
- Host and listener roles enforced via LiveKit token permissions (`canPublish`)
- Real-time hand raise, chat, and host moderation controls over LiveKit data channels
- Graceful disconnect handling: server-initiated room deletion and participant removal show user-friendly alerts; host navigates out before `deleteRoom` so they don't see the alert meant for attendees
- Android mic permission gated before `<LiveKitRoom>` mounts to avoid a race with the permission dialog
- WebRTC globals (`registerGlobals`) and `DOMException` polyfill moved to `index.js` entry point so they run before Expo Router's eager file scan

## Key technical decisions

**Entry point polyfills (`index.js`)** — Expo Router v6 scans all `app/` files before `_layout.tsx` runs, so polyfills placed there arrive too late. `index.js` runs first and is the correct place for LiveKit's WebRTC setup.

**`useDataChannel` at room level** — Chat and hand-raise channels are registered in `RoomScreenInner` (always mounted while connected) rather than inside `ChatPanel`, so messages are captured even when the panel is closed.

**`send` from `useDataChannel` instead of `publishData`** — `publishData` sends without a topic header; receivers filtered by topic never see the message. Using the `send` returned by `useDataChannel` attaches the topic correctly.

**`onDisconnected` reason cast** — LiveKit's implementation calls `onDisconnected(reason)` even though the TS type is `() => void`. We cast to read the reason and show ROOM_DELETED / PARTICIPANT_REMOVED alerts before navigating.

**`display: none` in ChatPanel** — Previously returned `null` when hidden, causing remount on every open. FlatList height collapsed to 0 inside a `maxHeight`-only container. Staying mounted with `display: none` keeps the layout and message history intact.

**`hasLeftRef` guard** — Prevents double-navigation from the Leave button, `onDisconnected` fallback, and Alert OK handlers firing in different orders.

## Files added

| File | Purpose |
|------|---------|
| `index.js` | Entry point — DOMException polyfill + `registerGlobals()` before Expo Router scan |
| `app/screens/HangoutsRoomScreen.tsx` | Outer LiveKitRoom provider + inner room UI |
| `app/components/hangouts/SpeakerStage.tsx` | Horizontal speaker tiles with speaking ring animation |
| `app/components/hangouts/AudienceSection.tsx` | Audience grid with raise-hand approve/deny controls |
| `app/components/hangouts/ParticipantTile.tsx` | Avatar tile with speaking ring, mute badge, hand badge |
| `app/components/hangouts/RoomControls.tsx` | Mute, hand raise, chat, leave, end-room control bar |
| `app/components/hangouts/ChatPanel.tsx` | Slide-up chat panel, always mounted via display:none |
| `app/components/hangouts/HostControlsPanel.tsx` | Bottom sheet for host moderation actions |

## Test plan

- [ ] Join existing room as listener — audio does not auto-publish, no "insufficient permissions" error
- [ ] Raise hand as listener — host sees indicator; host approve → listener becomes speaker
- [ ] Host mutes / removes participant via long-press sheet
- [ ] Chat: send message from app, see it on web client; send from web, see it in app (including history on panel open)
- [ ] Host ends room → attendees see "The host has ended this hangout" alert → navigate back
- [ ] Host ends room → host does NOT see the alert, just navigates back
- [ ] Kicked participant sees "You were removed from this hangout" alert
- [ ] Leave button navigates back silently with no double-navigation
- [ ] Android: mic permission dialog appears before room connect; deny → back to lobby

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hangouts: real-time rooms with speaker stage, audience view, raise-hand workflow, participant tiles, host moderation (approve/mute/kick/end), in-room chat, and lobby create/join flows.
* **Bug Fixes / Improvements**
  * Android microphone permission handling and clearer join/create error alerts.
  * iOS privacy/update: microphone description updated and background audio enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->