### PR TITLE
feat: Post announcement snap when host creates a hangout room

### DIFF
--- a/app/screens/HangoutsLobbyScreen.tsx
+++ b/app/screens/HangoutsLobbyScreen.tsx
@@ -23,6 +23,7 @@ import { getTheme } from '../../constants/Colors';
 import { useHangoutsAuth } from '../../hooks/useHangoutsAuth';
 import { useHangoutsRoomList } from '../../hooks/useHangoutsRoomList';
 import { useHangoutsRoom, RoomOperationCancelledError } from '../../hooks/useHangoutsRoom';
+import { useHangoutsAnnouncement } from '../../hooks/useHangoutsAnnouncement';
 import IconButton from '../components/IconButton';
 import PrimaryButton from '../components/PrimaryButton';
 
@@ -36,6 +37,7 @@ export default function HangoutsLobbyScreen() {
   const { isAuthenticated, isLoading: authLoading, authenticate } = useHangoutsAuth();
   const { rooms, isLoading: roomsLoading, error: roomsError, refresh } = useHangoutsRoomList();
   const { create, join, isLoading: roomOpLoading } = useHangoutsRoom();
+  const { announce } = useHangoutsAnnouncement();
 
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [roomTitle, setRoomTitle] = useState('');
@@ -78,6 +80,7 @@ export default function HangoutsLobbyScreen() {
     try {
       const response = await create(trimmed, roomDescription.trim() || undefined);
       closeCreateModal();
+      void announce(response.room.name, response.room.title ?? trimmed, roomDescription.trim() || undefined);
       router.push({
         pathname: '/screens/HangoutsRoomScreen',
         params: {

--- a/hooks/useHangoutsAnnouncement.ts
+++ b/hooks/useHangoutsAnnouncement.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { PrivateKey } from '@hiveio/dhive';
 import { getClient } from '../services/HiveClient';
 import { accountStorageService } from '../services/AccountStorageService';
@@ -6,55 +6,64 @@ import { postSnapWithBeneficiaries } from '../services/snapPostingService';
 
 export function useHangoutsAnnouncement() {
   const [isPosting, setIsPosting] = useState(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const announce = useCallback(async (
     roomName: string,
     roomTitle: string,
     description?: string,
   ): Promise<void> => {
-    const username = await accountStorageService.getCurrentAccountUsername();
-    const postingKeyStr = await accountStorageService.getCurrentPostingKey();
-    if (!username || !postingKeyStr) return;
-
-    const client = getClient();
-    const discussions = await client.database.call('get_discussions_by_blog', [
-      { tag: 'peak.snaps', limit: 1 },
-    ]);
-    if (!discussions || discussions.length === 0) return;
-    const container = discussions[0];
-
-    const roomUrl = `https://hangout.3speak.tv/room/${roomName}`;
-    const body = description ? `${description}\n\n${roomUrl}` : roomUrl;
-
-    const permlink = `snap-${Date.now()}`;
-    const json_metadata = JSON.stringify({
-      app: 'hivesnaps/1.0',
-      tags: ['hive-178315', 'snaps', 'hangouts'],
-    });
-
-    setIsPosting(true);
     try {
-      const postingKey = PrivateKey.fromString(postingKeyStr);
-      await postSnapWithBeneficiaries(
-        client,
-        {
-          parentAuthor: container.author,
-          parentPermlink: container.permlink,
-          author: username,
-          permlink,
-          title: roomTitle,
-          body,
-          jsonMetadata: json_metadata,
-          hasVideo: false,
-          hasAudio: false,
-          hasHangout: true,
-        },
-        postingKey,
-      );
+      const username = await accountStorageService.getCurrentAccountUsername();
+      const postingKeyStr = await accountStorageService.getCurrentPostingKey();
+      if (!username || !postingKeyStr) return;
+
+      const client = getClient();
+      const discussions = await client.database.call('get_discussions_by_blog', [
+        { tag: 'peak.snaps', limit: 1 },
+      ]);
+      if (!discussions || discussions.length === 0) return;
+      const container = discussions[0];
+
+      const roomUrl = `https://hangout.3speak.tv/room/${roomName}`;
+      const body = description ? `${description}\n\n${roomUrl}` : roomUrl;
+
+      const permlink = `snap-${Date.now()}`;
+      const json_metadata = JSON.stringify({
+        app: 'hivesnaps/1.0',
+        tags: ['hive-178315', 'snaps', 'hangouts'],
+      });
+
+      if (isMountedRef.current) setIsPosting(true);
+      try {
+        const postingKey = PrivateKey.fromString(postingKeyStr);
+        await postSnapWithBeneficiaries(
+          client,
+          {
+            parentAuthor: container.author,
+            parentPermlink: container.permlink,
+            author: username,
+            permlink,
+            title: roomTitle,
+            body,
+            jsonMetadata: json_metadata,
+            hasVideo: false,
+            hasAudio: false,
+            hasHangout: true,
+          },
+          postingKey,
+        );
+      } finally {
+        if (isMountedRef.current) setIsPosting(false);
+      }
     } catch (err) {
       console.warn('[useHangoutsAnnouncement] Failed to post snap:', err instanceof Error ? err.message : err);
-    } finally {
-      setIsPosting(false);
     }
   }, []);
 

--- a/hooks/useHangoutsAnnouncement.ts
+++ b/hooks/useHangoutsAnnouncement.ts
@@ -12,28 +12,28 @@ export function useHangoutsAnnouncement() {
     roomTitle: string,
     description?: string,
   ): Promise<void> => {
+    const username = await accountStorageService.getCurrentAccountUsername();
+    const postingKeyStr = await accountStorageService.getCurrentPostingKey();
+    if (!username || !postingKeyStr) return;
+
+    const client = getClient();
+    const discussions = await client.database.call('get_discussions_by_blog', [
+      { tag: 'peak.snaps', limit: 1 },
+    ]);
+    if (!discussions || discussions.length === 0) return;
+    const container = discussions[0];
+
+    const roomUrl = `https://hangout.3speak.tv/room/${roomName}`;
+    const body = description ? `${description}\n\n${roomUrl}` : roomUrl;
+
+    const permlink = `snap-${Date.now()}`;
+    const json_metadata = JSON.stringify({
+      app: 'hivesnaps/1.0',
+      tags: ['hive-178315', 'snaps', 'hangouts'],
+    });
+
     setIsPosting(true);
     try {
-      const username = await accountStorageService.getCurrentAccountUsername();
-      const postingKeyStr = await accountStorageService.getCurrentPostingKey();
-      if (!username || !postingKeyStr) return;
-
-      const client = getClient();
-      const discussions = await client.database.call('get_discussions_by_blog', [
-        { tag: 'peak.snaps', limit: 1 },
-      ]);
-      if (!discussions || discussions.length === 0) return;
-      const container = discussions[0];
-
-      const roomUrl = `https://hangout.3speak.tv/room/${roomName}`;
-      const body = description ? `${description}\n\n${roomUrl}` : roomUrl;
-
-      const permlink = `snap-${Date.now()}`;
-      const json_metadata = JSON.stringify({
-        app: 'hivesnaps/1.0',
-        tags: ['hive-178315', 'snaps', 'hangouts'],
-      });
-
       const postingKey = PrivateKey.fromString(postingKeyStr);
       await postSnapWithBeneficiaries(
         client,

--- a/hooks/useHangoutsAnnouncement.ts
+++ b/hooks/useHangoutsAnnouncement.ts
@@ -1,0 +1,62 @@
+import { useState, useCallback } from 'react';
+import { PrivateKey } from '@hiveio/dhive';
+import { getClient } from '../services/HiveClient';
+import { accountStorageService } from '../services/AccountStorageService';
+import { postSnapWithBeneficiaries } from '../services/snapPostingService';
+
+export function useHangoutsAnnouncement() {
+  const [isPosting, setIsPosting] = useState(false);
+
+  const announce = useCallback(async (
+    roomName: string,
+    roomTitle: string,
+    description?: string,
+  ): Promise<void> => {
+    setIsPosting(true);
+    try {
+      const username = await accountStorageService.getCurrentAccountUsername();
+      const postingKeyStr = await accountStorageService.getCurrentPostingKey();
+      if (!username || !postingKeyStr) return;
+
+      const client = getClient();
+      const discussions = await client.database.call('get_discussions_by_blog', [
+        { tag: 'peak.snaps', limit: 1 },
+      ]);
+      if (!discussions || discussions.length === 0) return;
+      const container = discussions[0];
+
+      const roomUrl = `https://hangout.3speak.tv/room/${roomName}`;
+      const body = description ? `${description}\n\n${roomUrl}` : roomUrl;
+
+      const permlink = `snap-${Date.now()}`;
+      const json_metadata = JSON.stringify({
+        app: 'hivesnaps/1.0',
+        tags: ['hive-178315', 'snaps', 'hangouts'],
+      });
+
+      const postingKey = PrivateKey.fromString(postingKeyStr);
+      await postSnapWithBeneficiaries(
+        client,
+        {
+          parentAuthor: container.author,
+          parentPermlink: container.permlink,
+          author: username,
+          permlink,
+          title: roomTitle,
+          body,
+          jsonMetadata: json_metadata,
+          hasVideo: false,
+          hasAudio: false,
+          hasHangout: true,
+        },
+        postingKey,
+      );
+    } catch (err) {
+      console.warn('[useHangoutsAnnouncement] Failed to post snap:', err instanceof Error ? err.message : err);
+    } finally {
+      setIsPosting(false);
+    }
+  }, []);
+
+  return { announce, isPosting };
+}

--- a/services/snapPostingService.ts
+++ b/services/snapPostingService.ts
@@ -15,6 +15,7 @@ interface PostSnapOptions {
   jsonMetadata: string;
   hasVideo: boolean; // Determines if beneficiaries should be added
   hasAudio?: boolean; // Determines if beneficiaries should be added for audio
+  hasHangout?: boolean; // Adds 3% beneficiary to @snapie for hangout announcements
 }
 
 /**
@@ -31,7 +32,7 @@ export async function postSnapWithBeneficiaries(
   options: PostSnapOptions,
   postingKey: PrivateKey
 ): Promise<string> {
-  const { parentAuthor, parentPermlink, author, permlink, title, body, jsonMetadata, hasVideo, hasAudio } =
+  const { parentAuthor, parentPermlink, author, permlink, title, body, jsonMetadata, hasVideo, hasAudio, hasHangout } =
     options;
 
   // Base comment operation
@@ -48,8 +49,8 @@ export async function postSnapWithBeneficiaries(
     },
   ];
 
-  // If no video or audio, just broadcast the comment
-  if (!hasVideo && !hasAudio) {
+  // If no video, audio, or hangout, just broadcast the comment
+  if (!hasVideo && !hasAudio && !hasHangout) {
     const result = await client.broadcast.comment(
       {
         parent_author: parentAuthor,
@@ -65,11 +66,12 @@ export async function postSnapWithBeneficiaries(
     return result.id || 'unknown';
   }
 
-  // If there's a video or audio, add comment_options with beneficiaries
+  // video/audio → 10%, hangout → 3%
+  const weight = hasVideo || hasAudio ? 1000 : 300;
   const beneficiaries = [
     {
       account: 'snapie',
-      weight: 1000, // 10% (1000 = 10% of 10000)
+      weight,
     },
   ];
 

--- a/services/snapPostingService.ts
+++ b/services/snapPostingService.ts
@@ -20,7 +20,7 @@ interface PostSnapOptions {
 
 /**
  * Posts a snap to the Hive blockchain
- * If the snap contains a video or audio, adds a 10% beneficiary to @snapie
+ * Adds a beneficiary to @snapie when applicable: 10% for video/audio, 3% for hangout announcements
  *
  * @param client - Hive blockchain client
  * @param options - Posting options


### PR DESCRIPTION
## Summary
- When a host creates a Hangout room, a snap is automatically posted to the Hive blockchain with the room URL (`https://hangout.3speak.tv/room/<name>`) so `HangoutPreviewCard` renders in feeds
- Snap includes a **3% beneficiary to `@snapie`** (vs 10% for video/audio) via `comment_options`
- Announcement is **fire-and-forget** — failure never blocks room creation or navigation
- `setIsPosting` only activates once preflight checks pass (has key, has container), not on early exits

## Changes
- `services/snapPostingService.ts` — added `hasHangout?: boolean` to `PostSnapOptions`; weight is now computed (`1000` for video/audio, `300` for hangout); updated JSDoc
- `hooks/useHangoutsAnnouncement.ts` — new hook that fetches the `@peak.snaps` container, builds the snap body, and posts via `postSnapWithBeneficiaries`
- `app/screens/HangoutsLobbyScreen.tsx` — calls `void announce(...)` after successful room creation, before `router.push`

## Test plan
- [ ] Create a hangout room → snap appears in the creator's Hive feed
- [ ] Snap body contains `https://hangout.3speak.tv/room/<name>` and renders `HangoutPreviewCard`
- [ ] Snap has 3% beneficiary to `@snapie` in `comment_options`
- [ ] If no posting key or no container post found → room creation and navigation still succeed (no error shown to user)
- [ ] `npx tsc --noEmit` — zero new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hangout room creation now automatically announces new rooms to the network, instantly publishing room details including name, title, and description for improved visibility and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->