### PR TITLE
feat: add recent transaction history to wallet screen

### DIFF
--- a/app/components/wallet/TransactionList.tsx
+++ b/app/components/wallet/TransactionList.tsx
@@ -109,7 +109,7 @@ const TransactionRow = ({
 export const TransactionList = ({ transactions, loading, error, colors }: Props): React.JSX.Element => {
     if (loading) {
         return (
-            <View style={styles.center}>
+            <View style={styles.loadingContainer}>
                 <ActivityIndicator size="small" color={colors.icon} />
             </View>
         );
@@ -161,6 +161,11 @@ const styles = StyleSheet.create({
         borderRadius: 18,
         justifyContent: 'center',
         alignItems: 'center',
+    },
+    loadingContainer: {
+        paddingVertical: 24,
+        alignItems: 'center',
+        justifyContent: 'center',
     },
     center: {
         flex: 1,

--- a/app/components/wallet/TransactionList.tsx
+++ b/app/components/wallet/TransactionList.tsx
@@ -40,17 +40,17 @@ const OP_META: Record<
 > = {
     transfer:             { label: 'Transfer',    icon: 'exchange' },
     transfer_to_vesting:  { label: 'Power Up',    icon: 'arrow-circle-up' },
-    fill_vesting_withdraw:{ label: 'Power Down',  icon: 'arrow-circle-down' },
+    withdraw_vesting:     { label: 'Power Down',  icon: 'arrow-circle-down' },
+    fill_vesting_withdraw:{ label: 'PD Payout',   icon: 'arrow-circle-down' },
     claim_reward_balance: { label: 'Rewards',     icon: 'star' },
 };
 
-const TransactionRow = ({
-    tx,
-    colors,
-}: {
+interface TransactionRowProps {
     tx: TransactionItem;
     colors: Colors;
-}) => {
+}
+
+const TransactionRow = ({ tx, colors }: TransactionRowProps): React.JSX.Element => {
     const meta = OP_META[tx.type] ?? { label: tx.type, icon: 'circle' as const };
     const isIn = tx.direction === 'in';
     const isOut = tx.direction === 'out';

--- a/app/components/wallet/TransactionList.tsx
+++ b/app/components/wallet/TransactionList.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import type { TransactionItem } from '../../../hooks/useAccountHistory';
+
+interface Colors {
+    text: string;
+    textSecondary: string;
+    bubble: string;
+    border: string;
+    icon: string;
+    success: string;
+    error: string;
+}
+
+interface Props {
+    transactions: TransactionItem[];
+    loading: boolean;
+    error: string | null;
+    colors: Colors;
+}
+
+const formatRelativeTime = (isoTimestamp: string): string => {
+    // Hive timestamps are UTC but lack the trailing 'Z' — add it
+    const ts = isoTimestamp.endsWith('Z') ? isoTimestamp : `${isoTimestamp}Z`;
+    const diffMs = Date.now() - new Date(ts).getTime();
+    const diffSecs = Math.floor(diffMs / 1000);
+    if (diffSecs < 60) return 'just now';
+    const diffMins = Math.floor(diffSecs / 60);
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d ago`;
+};
+
+const OP_META: Record<
+    string,
+    { label: string; icon: React.ComponentProps<typeof FontAwesome>['name'] }
+> = {
+    transfer:             { label: 'Transfer',    icon: 'exchange' },
+    transfer_to_vesting:  { label: 'Power Up',    icon: 'arrow-circle-up' },
+    fill_vesting_withdraw:{ label: 'Power Down',  icon: 'arrow-circle-down' },
+    claim_reward_balance: { label: 'Rewards',     icon: 'star' },
+};
+
+const TransactionRow = ({
+    tx,
+    colors,
+}: {
+    tx: TransactionItem;
+    colors: Colors;
+}) => {
+    const meta = OP_META[tx.type] ?? { label: tx.type, icon: 'circle' as const };
+    const isIn = tx.direction === 'in';
+    const isOut = tx.direction === 'out';
+
+    const amountColor = isIn
+        ? colors.success
+        : isOut
+        ? colors.error
+        : colors.text;
+
+    const amountPrefix = isIn ? '+' : isOut ? '-' : '';
+
+    return (
+        <View style={[styles.row, { borderBottomColor: colors.border }]}>
+            {/* Icon */}
+            <View style={[styles.iconWrap, { backgroundColor: colors.bubble }]}>
+                <FontAwesome name={meta.icon} size={15} color={colors.icon} />
+            </View>
+
+            {/* Center: label + counterparty */}
+            <View style={styles.center}>
+                <Text style={[styles.label, { color: colors.text }]} numberOfLines={1}>
+                    {meta.label}
+                    {tx.counterparty ? (
+                        <Text style={{ color: colors.textSecondary }}>
+                            {isOut ? '  →  ' : '  ←  '}
+                            <Text style={{ fontWeight: '600' }}>@{tx.counterparty}</Text>
+                        </Text>
+                    ) : null}
+                </Text>
+                {tx.memo ? (
+                    <Text style={[styles.memo, { color: colors.textSecondary }]} numberOfLines={1}>
+                        {tx.memo}
+                    </Text>
+                ) : null}
+                <Text style={[styles.time, { color: colors.textSecondary }]}>
+                    {formatRelativeTime(tx.timestamp)}
+                </Text>
+            </View>
+
+            {/* Right: amount */}
+            <View style={styles.amountWrap}>
+                <Text style={[styles.amount, { color: amountColor }]} numberOfLines={1}>
+                    {amountPrefix}{tx.amount}
+                </Text>
+                {tx.secondaryAmount ? (
+                    <Text style={[styles.secondaryAmount, { color: colors.textSecondary }]} numberOfLines={1}>
+                        +{tx.secondaryAmount}
+                    </Text>
+                ) : null}
+            </View>
+        </View>
+    );
+};
+
+export const TransactionList = ({ transactions, loading, error, colors }: Props): React.JSX.Element => {
+    if (loading) {
+        return (
+            <View style={styles.center}>
+                <ActivityIndicator size="small" color={colors.icon} />
+            </View>
+        );
+    }
+
+    if (error) {
+        return (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{error}</Text>
+        );
+    }
+
+    if (transactions.length === 0) {
+        return (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                No recent transactions
+            </Text>
+        );
+    }
+
+    return (
+        <View style={[styles.listContainer, { backgroundColor: colors.bubble }]}>
+            {transactions.map((tx, idx) => (
+                <TransactionRow
+                    key={tx.id}
+                    tx={tx}
+                    colors={colors}
+                />
+            ))}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    listContainer: {
+        borderRadius: 12,
+        overflow: 'hidden',
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: 12,
+        paddingHorizontal: 14,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        gap: 12,
+    },
+    iconWrap: {
+        width: 36,
+        height: 36,
+        borderRadius: 18,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    center: {
+        flex: 1,
+        gap: 2,
+    },
+    label: {
+        fontSize: 14,
+        fontWeight: '600',
+    },
+    memo: {
+        fontSize: 12,
+    },
+    time: {
+        fontSize: 11,
+    },
+    amountWrap: {
+        alignItems: 'flex-end',
+        flexShrink: 0,
+        maxWidth: 130,
+    },
+    amount: {
+        fontSize: 13,
+        fontWeight: '700',
+    },
+    secondaryAmount: {
+        fontSize: 11,
+        marginTop: 2,
+    },
+    emptyText: {
+        fontSize: 13,
+        textAlign: 'center',
+        paddingVertical: 16,
+    },
+});

--- a/app/screens/WalletScreen.tsx
+++ b/app/screens/WalletScreen.tsx
@@ -16,9 +16,11 @@ import { useAuth } from '../../store/context';
 import { createWalletScreenStyles } from '../../styles/WalletScreenStyles';
 import { vestsToHp } from '../../utils/hiveCalculations';
 import { useWalletOperations } from '../../hooks/useWalletOperations';
+import { useAccountHistory } from '../../hooks/useAccountHistory';
 import { TransferModal } from '../components/wallet/TransferModal';
 import { PowerUpModal } from '../components/wallet/PowerUpModal';
 import { PowerDownModal } from '../components/wallet/PowerDownModal';
+import { TransactionList } from '../components/wallet/TransactionList';
 import { AuthCancelledError } from '../../services/LocalAuthService';
 
 const client = getClient();
@@ -53,6 +55,7 @@ const WalletScreen = (): React.JSX.Element => {
         infoBoxBackground: theme.infoBoxBackground,
         warningBoxBackground: theme.warningBoxBackground,
         error: theme.error,
+        success: theme.success,
     };
 
     // Wallet data state
@@ -71,6 +74,13 @@ const WalletScreen = (): React.JSX.Element => {
     const [storedKeyAvailable, setStoredKeyAvailable] = useState(false);
 
     const fetchSeq = useRef(0);
+
+    const {
+        transactions,
+        loading: historyLoading,
+        error: historyError,
+        fetchHistory,
+    } = useAccountHistory(currentUsername, 10);
 
     // Define fetchWalletData before passing it to the hook as onRefresh
     const fetchWalletData = useCallback(async (silent = false): Promise<void> => {
@@ -141,11 +151,15 @@ const WalletScreen = (): React.JSX.Element => {
         transfer, powerUp, powerDown, cancelPowerDown,
         resetOperationSuccess,
         checkStoredKeyAvailable,
-    } = useWalletOperations(currentUsername, () => fetchWalletData(true));
+    } = useWalletOperations(currentUsername, async () => {
+        await fetchWalletData(true);
+        fetchHistory();
+    });
 
     useEffect(() => {
         fetchWalletData();
-    }, [fetchWalletData]);
+        fetchHistory();
+    }, [fetchWalletData, fetchHistory]);
 
     useEffect(() => {
         let cancelled = false;
@@ -320,6 +334,15 @@ const WalletScreen = (): React.JSX.Element => {
                             </TouchableOpacity>
                         ))}
                     </View>
+
+                    {/* Recent transactions */}
+                    <Text style={styles.sectionTitle}>Recent Transactions</Text>
+                    <TransactionList
+                        transactions={transactions}
+                        loading={historyLoading}
+                        error={historyError}
+                        colors={colors}
+                    />
                 </ScrollView>
             )}
 

--- a/app/screens/WalletScreen.tsx
+++ b/app/screens/WalletScreen.tsx
@@ -153,7 +153,7 @@ const WalletScreen = (): React.JSX.Element => {
         checkStoredKeyAvailable,
     } = useWalletOperations(currentUsername, async () => {
         await fetchWalletData(true);
-        fetchHistory();
+        await fetchHistory();
     });
 
     useEffect(() => {

--- a/hooks/useAccountHistory.ts
+++ b/hooks/useAccountHistory.ts
@@ -6,6 +6,7 @@ const client = getClient();
 const RELEVANT_OPS = new Set([
     'transfer',
     'transfer_to_vesting',
+    'withdraw_vesting',
     'fill_vesting_withdraw',
     'claim_reward_balance',
 ]);
@@ -13,6 +14,7 @@ const RELEVANT_OPS = new Set([
 export type TxOpType =
     | 'transfer'
     | 'transfer_to_vesting'
+    | 'withdraw_vesting'
     | 'fill_vesting_withdraw'
     | 'claim_reward_balance';
 
@@ -27,8 +29,10 @@ export interface TransactionItem {
     memo?: string;
 }
 
+type RawHistoryEntry = [number, { trx_id: string; timestamp: string; op: [string, Record<string, unknown>] }];
+
 const parseHistoryEntry = (
-    entry: [number, { trx_id: string; timestamp: string; op: [string, Record<string, unknown>] }],
+    entry: RawHistoryEntry,
     username: string
 ): TransactionItem | null => {
     const [index, data] = entry;
@@ -59,12 +63,21 @@ const parseHistoryEntry = (
             const amount = opData.amount as string;
             const from = opData.from as string;
             const to = opData.to as string;
-            const isOut = from === username && to === username;
+            const isSelf = from === username && to === username;
+            const isOut = from === username && to !== username;
+            const isIn = to === username && from !== username;
             return {
                 id, type, timestamp,
+                direction: isOut ? 'out' : isIn ? 'in' : undefined,
                 amount,
-                // if powering up for someone else, note that
-                counterparty: !isOut ? to : undefined,
+                counterparty: isSelf ? undefined : isOut ? to : isIn ? from : undefined,
+            };
+        }
+        case 'withdraw_vesting': {
+            const vesting_shares = opData.vesting_shares as string;
+            return {
+                id, type, timestamp,
+                amount: vesting_shares,
             };
         }
         case 'fill_vesting_withdraw': {
@@ -114,6 +127,7 @@ export const useAccountHistory = (username: string | null, limit = 10): UseAccou
 
     const fetchHistory = useCallback(async (): Promise<void> => {
         if (!username) {
+            fetchSeq.current++;
             setTransactions([]);
             setLoading(false);
             setError(null);
@@ -123,19 +137,28 @@ export const useAccountHistory = (username: string | null, limit = 10): UseAccou
         setLoading(true);
         setError(null);
         try {
-            // Fetch enough raw ops so filtering yields `limit` results.
-            // 50 gives comfortable headroom without hammering the node.
-            const raw: [number, { trx_id: string; timestamp: string; op: [string, Record<string, unknown>] }][] =
-                await client.database.call('get_account_history', [username, -1, 50]);
-
-            if (seq !== fetchSeq.current) return;
-
             const parsed: TransactionItem[] = [];
-            // History is returned oldest-first; iterate in reverse for newest first
-            for (let i = raw.length - 1; i >= 0 && parsed.length < limit; i--) {
-                const item = parseHistoryEntry(raw[i], username);
-                if (item) parsed.push(item);
+            let start = -1;
+            const batchSize = 50;
+
+            while (parsed.length < limit) {
+                const raw: RawHistoryEntry[] =
+                    await client.database.call('get_account_history', [username, start, batchSize]);
+
+                if (seq !== fetchSeq.current) return;
+                if (raw.length === 0) break;
+
+                // History is returned oldest-first; iterate in reverse for newest first
+                for (let i = raw.length - 1; i >= 0 && parsed.length < limit; i--) {
+                    const item = parseHistoryEntry(raw[i], username);
+                    if (item) parsed.push(item);
+                }
+
+                if (raw.length < batchSize) break;
+                start = raw[0][0] - 1;
+                if (start < 0) break;
             }
+
             setTransactions(parsed);
         } catch (err) {
             if (seq !== fetchSeq.current) return;

--- a/hooks/useAccountHistory.ts
+++ b/hooks/useAccountHistory.ts
@@ -1,0 +1,141 @@
+import { useState, useCallback, useRef } from 'react';
+import { getClient } from '../services/HiveClient';
+
+const client = getClient();
+
+const RELEVANT_OPS = new Set([
+    'transfer',
+    'transfer_to_vesting',
+    'fill_vesting_withdraw',
+    'claim_reward_balance',
+]);
+
+export type TxOpType =
+    | 'transfer'
+    | 'transfer_to_vesting'
+    | 'fill_vesting_withdraw'
+    | 'claim_reward_balance';
+
+export interface TransactionItem {
+    id: string;
+    type: TxOpType;
+    timestamp: string;
+    direction?: 'in' | 'out';    // only for transfer
+    amount: string;
+    secondaryAmount?: string;    // claim_reward_balance has multiple assets
+    counterparty?: string;       // the other account
+    memo?: string;
+}
+
+const parseHistoryEntry = (
+    entry: [number, { trx_id: string; timestamp: string; op: [string, Record<string, unknown>] }],
+    username: string
+): TransactionItem | null => {
+    const [index, data] = entry;
+    const [opType, opData] = data.op;
+
+    if (!RELEVANT_OPS.has(opType)) return null;
+
+    const id = `${data.trx_id}-${index}`;
+    const timestamp = data.timestamp;
+    const type = opType as TxOpType;
+
+    switch (type) {
+        case 'transfer': {
+            const from = opData.from as string;
+            const to = opData.to as string;
+            const amount = opData.amount as string;
+            const memo = opData.memo as string | undefined;
+            const isOut = from === username;
+            return {
+                id, type, timestamp,
+                direction: isOut ? 'out' : 'in',
+                amount,
+                counterparty: isOut ? to : from,
+                memo: memo || undefined,
+            };
+        }
+        case 'transfer_to_vesting': {
+            const amount = opData.amount as string;
+            const from = opData.from as string;
+            const to = opData.to as string;
+            const isOut = from === username && to === username;
+            return {
+                id, type, timestamp,
+                amount,
+                // if powering up for someone else, note that
+                counterparty: !isOut ? to : undefined,
+            };
+        }
+        case 'fill_vesting_withdraw': {
+            // Virtual op — weekly power-down payout arrives as HIVE
+            const deposited = opData.deposited as string;
+            return {
+                id, type, timestamp,
+                direction: 'in',
+                amount: deposited,
+            };
+        }
+        case 'claim_reward_balance': {
+            const rewardHive = opData.reward_hive as string;
+            const rewardHbd = opData.reward_hbd as string;
+            const rewardVests = opData.reward_vests as string;
+            // Build a readable summary of non-zero rewards
+            const parts: string[] = [];
+            if (!rewardHive.startsWith('0.000 ')) parts.push(rewardHive);
+            if (!rewardHbd.startsWith('0.000 ')) parts.push(rewardHbd);
+            if (!rewardVests.startsWith('0.000000 ')) parts.push(rewardVests);
+            const amount = parts[0] ?? rewardHive;
+            const secondaryAmount = parts.slice(1).join(' + ') || undefined;
+            return {
+                id, type, timestamp,
+                direction: 'in',
+                amount,
+                secondaryAmount,
+            };
+        }
+        default:
+            return null;
+    }
+};
+
+export const useAccountHistory = (username: string | null, limit = 10) => {
+    const [transactions, setTransactions] = useState<TransactionItem[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const fetchSeq = useRef(0);
+
+    const fetchHistory = useCallback(async (): Promise<void> => {
+        if (!username) {
+            setTransactions([]);
+            return;
+        }
+        const seq = ++fetchSeq.current;
+        setLoading(true);
+        setError(null);
+        try {
+            // Fetch enough raw ops so filtering yields `limit` results.
+            // 50 gives comfortable headroom without hammering the node.
+            const raw: [number, { trx_id: string; timestamp: string; op: [string, Record<string, unknown>] }][] =
+                await client.database.call('get_account_history', [username, -1, 50]);
+
+            if (seq !== fetchSeq.current) return;
+
+            const parsed: TransactionItem[] = [];
+            // History is returned oldest-first; iterate in reverse for newest first
+            for (let i = raw.length - 1; i >= 0 && parsed.length < limit; i--) {
+                const item = parseHistoryEntry(raw[i], username);
+                if (item) parsed.push(item);
+            }
+            setTransactions(parsed);
+        } catch (err) {
+            if (seq !== fetchSeq.current) return;
+            setError('Could not load transaction history');
+        } finally {
+            if (seq !== fetchSeq.current) return;
+            setLoading(false);
+        }
+    }, [username, limit]);
+
+    return { transactions, loading, error, fetchHistory };
+};

--- a/hooks/useAccountHistory.ts
+++ b/hooks/useAccountHistory.ts
@@ -99,7 +99,14 @@ const parseHistoryEntry = (
     }
 };
 
-export const useAccountHistory = (username: string | null, limit = 10) => {
+interface UseAccountHistoryReturn {
+    transactions: TransactionItem[];
+    loading: boolean;
+    error: string | null;
+    fetchHistory: () => Promise<void>;
+}
+
+export const useAccountHistory = (username: string | null, limit = 10): UseAccountHistoryReturn => {
     const [transactions, setTransactions] = useState<TransactionItem[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -108,6 +115,8 @@ export const useAccountHistory = (username: string | null, limit = 10) => {
     const fetchHistory = useCallback(async (): Promise<void> => {
         if (!username) {
             setTransactions([]);
+            setLoading(false);
+            setError(null);
             return;
         }
         const seq = ++fetchSeq.current;


### PR DESCRIPTION
Shows last 10 relevant wallet operations (transfers, power ups/downs, reward claims) below the action grid, with direction indicators, counterparty, relative timestamp, and post-operation auto-refresh.

## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed on iOS
- [ ] Manual testing completed on Android
- [ ] Tested with different screen sizes
- [ ] Accessibility testing completed

## Checklist
- [ ] Code follows TypeScript best practices
- [ ] No console.log statements in production code
- [ ] Proper error handling implemented
- [ ] Memory leaks checked (useEffect cleanup, etc.)
- [ ] Performance implications considered
- [ ] Security considerations reviewed
- [ ] Documentation updated (if needed)

## Screenshots/Videos
<!-- Add screenshots or videos demonstrating the changes -->

## Related Issues
<!-- Link to any related issues -->

## Notes for Reviewers
<!-- Any specific areas you'd like reviewers to focus on -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Recent Transactions" section to the wallet showing history with amount, direction, counterparty, memo, and transaction type icons/labels.
  * Timestamps are shown in relative form (e.g., "just now", "5m ago").
  * Supports reward/vesting and secondary amounts, shows loading/error states, and refreshes transaction data on pull-to-refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->