### PR TITLE
feat: implement swipeable image gallery for snaps

### DIFF
--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -64,7 +64,7 @@ interface SnapProps {
   onSpeechBubblePress?: () => void; // NEW: handler for speech bubble
   onUserPress?: (username: string) => void; // NEW: handler for username/avatar press
   onContentPress?: () => void; // NEW: handler for content/text press
-  onImagePress?: (imageUrl: string) => void; // NEW: handler for image press
+  onImagePress?: (imageUrl: string, snapBody?: string) => void; // NEW: handler for image press
   showAuthor?: boolean; // Optional: show author info in Snap bubble
   onHashtagPress?: (hashtag: string) => void; // Optional: handle hashtag press
   onReplyPress?: (author: string, permlink: string) => void; // NEW: handler for reply button
@@ -247,7 +247,7 @@ const Snap: React.FC<SnapProps> = ({
           key={uniqueKey}
           onPress={() => {
             if (onImagePress) {
-              onImagePress(src);
+              onImagePress(src, body);
             } else {
               setModalImageUrl(src);
               setModalVisible(true);
@@ -739,7 +739,7 @@ const Snap: React.FC<SnapProps> = ({
                 key={url + idx}
                 onPress={() => {
                   if (onImagePress) {
-                    onImagePress(proxyImageUrl(url));
+                    onImagePress(proxyImageUrl(url), body);
                   } else {
                     setModalImageUrl(proxyImageUrl(url));
                     setModalVisible(true);
@@ -763,7 +763,7 @@ const Snap: React.FC<SnapProps> = ({
                 key={url + idx}
                 onPress={() => {
                   if (onImagePress) {
-                    onImagePress(proxyImageUrl(url));
+                    onImagePress(proxyImageUrl(url), body);
                   } else {
                     setModalImageUrl(proxyImageUrl(url));
                     setModalVisible(true);

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -247,9 +247,9 @@ const Snap: React.FC<SnapProps> = ({
           key={uniqueKey}
           onPress={() => {
             if (onImagePress) {
-              onImagePress(src, body);
+              onImagePress(proxyImageUrl(src), body);
             } else {
-              setModalImageUrl(src);
+              setModalImageUrl(proxyImageUrl(src));
               setModalVisible(true);
             }
           }}

--- a/app/screens/ConversationScreen.tsx
+++ b/app/screens/ConversationScreen.tsx
@@ -40,6 +40,7 @@ import {
   extractRawImageUrls as extractRawImageUrlsUtil,
   removeRawImageUrls as removeRawImageUrlsUtil,
 } from '../../utils/rawImageUrls';
+import { buildImageGalleryFromSnap, findImageIndexInGallery } from '../../utils/imageGallery';
 import ImageView from 'react-native-image-viewing';
 import genericAvatar from '../../assets/images/generic-avatar.png';
 import { extractBlogPostUrls } from '../../utils/extractHivePostInfo';
@@ -377,9 +378,29 @@ const ConversationScreenRefactored = () => {
     }
   };
 
-  const handleImagePress = (imageUrl: string) => {
-    setModalImages([{ uri: imageUrl }]);
-    setModalImageIndex(0);
+  const handleImagePress = (imageUrl: string, snapBody?: string) => {
+    if (!snapBody) {
+      // Fallback to single image if no body provided
+      setModalImages([{ uri: imageUrl }]);
+      setModalImageIndex(0);
+      setImageModalVisible(true);
+      return;
+    }
+    
+    // Build full gallery from snap body
+    const gallery = buildImageGalleryFromSnap(snapBody);
+    
+    if (gallery.length === 0) {
+      // If gallery extraction fails, fall back to single image
+      setModalImages([{ uri: imageUrl }]);
+      setModalImageIndex(0);
+    } else {
+      // Find the index of the tapped image
+      const index = findImageIndexInGallery(gallery, imageUrl);
+      setModalImages(gallery);
+      setModalImageIndex(index);
+    }
+    
     setImageModalVisible(true);
   };
 
@@ -1248,13 +1269,41 @@ const ConversationScreenRefactored = () => {
           doubleTapToZoomEnabled={true}
           presentationStyle='fullScreen'
           HeaderComponent={() => (
-            <TouchableOpacity
-              style={ConversationScreenStyles.modalHeader}
-              onPress={() => setImageModalVisible(false)}
-              accessibilityLabel='Close image'
-            >
-              <FontAwesome name='close' size={20} color='#fff' />
-            </TouchableOpacity>
+            <View style={{
+              position: 'absolute',
+              top: 50,
+              left: 0,
+              right: 0,
+              zIndex: 1000,
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              paddingHorizontal: 20,
+            }}>
+              {modalImages.length > 1 && (
+                <View style={{
+                  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                  borderRadius: 12,
+                  paddingHorizontal: 12,
+                  paddingVertical: 6,
+                }}>
+                  <Text style={{
+                    color: '#fff',
+                    fontSize: 14,
+                    fontWeight: '600',
+                  }}>
+                    {modalImageIndex + 1} / {modalImages.length}
+                  </Text>
+                </View>
+              )}
+              <TouchableOpacity
+                style={ConversationScreenStyles.modalHeader}
+                onPress={() => setImageModalVisible(false)}
+                accessibilityLabel='Close image'
+              >
+                <FontAwesome name='close' size={20} color='#fff' />
+              </TouchableOpacity>
+            </View>
           )}
         />
 

--- a/app/screens/ConversationScreen.tsx
+++ b/app/screens/ConversationScreen.tsx
@@ -1268,7 +1268,7 @@ const ConversationScreenRefactored = () => {
           swipeToCloseEnabled={true}
           doubleTapToZoomEnabled={true}
           presentationStyle='fullScreen'
-          HeaderComponent={() => (
+          HeaderComponent={({ imageIndex }) => (
             <View style={{
               position: 'absolute',
               top: 50,
@@ -1292,7 +1292,7 @@ const ConversationScreenRefactored = () => {
                     fontSize: 14,
                     fontWeight: '600',
                   }}>
-                    {modalImageIndex + 1} / {modalImages.length}
+                    {imageIndex + 1} / {modalImages.length}
                   </Text>
                 </View>
               )}

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -26,6 +26,7 @@ import { useRouter } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
 import ImageView from 'react-native-image-viewing';
 import { createFeedScreenStyles } from '../../styles/FeedScreenStyles';
+import { buildImageGalleryFromSnap, findImageIndexInGallery } from '../../utils/imageGallery';
 
 // Custom hooks for business logic
 import { useAuth } from '../../store/context';
@@ -482,10 +483,30 @@ const FeedScreenRefactored = () => {
     }
   };
 
-  // Handle image press
-  const handleImagePress = (imageUrl: string) => {
-    setModalImages([{ uri: imageUrl }]);
-    setModalImageIndex(0);
+  // Handle image press - opens full gallery with all images from snap
+  const handleImagePress = (imageUrl: string, snapBody?: string) => {
+    if (!snapBody) {
+      // Fallback to single image if no body provided
+      setModalImages([{ uri: imageUrl }]);
+      setModalImageIndex(0);
+      setImageModalVisible(true);
+      return;
+    }
+    
+    // Build full gallery from snap body
+    const gallery = buildImageGalleryFromSnap(snapBody);
+    
+    if (gallery.length === 0) {
+      // If gallery extraction fails, fall back to single image
+      setModalImages([{ uri: imageUrl }]);
+      setModalImageIndex(0);
+    } else {
+      // Find the index of the tapped image
+      const index = findImageIndexInGallery(gallery, imageUrl);
+      setModalImages(gallery);
+      setModalImageIndex(index);
+    }
+    
     setImageModalVisible(true);
   };
 
@@ -1228,24 +1249,48 @@ const FeedScreenRefactored = () => {
         doubleTapToZoomEnabled={true}
         presentationStyle='fullScreen'
         HeaderComponent={() => (
-          <TouchableOpacity
-            style={{
-              position: 'absolute',
-              top: 50,
-              right: 20,
-              zIndex: 1000,
-              backgroundColor: 'rgba(0, 0, 0, 0.5)',
-              borderRadius: 20,
-              width: 40,
-              height: 40,
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-            onPress={() => setImageModalVisible(false)}
-            accessibilityLabel='Close image'
-          >
-            <FontAwesome name='close' size={20} color='#fff' />
-          </TouchableOpacity>
+          <View style={{
+            position: 'absolute',
+            top: 50,
+            left: 0,
+            right: 0,
+            zIndex: 1000,
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            paddingHorizontal: 20,
+          }}>
+            {modalImages.length > 1 && (
+              <View style={{
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                paddingVertical: 6,
+              }}>
+                <Text style={{
+                  color: '#fff',
+                  fontSize: 14,
+                  fontWeight: '600',
+                }}>
+                  {modalImageIndex + 1} / {modalImages.length}
+                </Text>
+              </View>
+            )}
+            <TouchableOpacity
+              style={{
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                borderRadius: 20,
+                width: 40,
+                height: 40,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+              onPress={() => setImageModalVisible(false)}
+              accessibilityLabel='Close image'
+            >
+              <FontAwesome name='close' size={20} color='#fff' />
+            </TouchableOpacity>
+          </View>
         )}
       />
 

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -1248,7 +1248,7 @@ const FeedScreenRefactored = () => {
         swipeToCloseEnabled={true}
         doubleTapToZoomEnabled={true}
         presentationStyle='fullScreen'
-        HeaderComponent={() => (
+        HeaderComponent={({ imageIndex }) => (
           <View style={{
             position: 'absolute',
             top: 50,
@@ -1272,7 +1272,7 @@ const FeedScreenRefactored = () => {
                   fontSize: 14,
                   fontWeight: '600',
                 }}>
-                  {modalImageIndex + 1} / {modalImages.length}
+                  {imageIndex + 1} / {modalImages.length}
                 </Text>
               </View>
             )}

--- a/utils/imageGallery.ts
+++ b/utils/imageGallery.ts
@@ -1,0 +1,86 @@
+import { extractImageUrls } from './extractImageUrls';
+import { extractRawImageUrls } from './rawImageUrls';
+import { proxyImageUrl } from './proxyImageUrl';
+
+export interface ImageGalleryItem {
+  uri: string;
+}
+
+/**
+ * Extracts all images from a snap's body and returns them as a gallery array.
+ * Combines both markdown/HTML images and raw image URLs.
+ * 
+ * @param body - The snap body content (markdown/HTML)
+ * @returns Array of image gallery items with proxied URLs
+ */
+export function buildImageGalleryFromSnap(body: string): ImageGalleryItem[] {
+  if (!body || typeof body !== 'string') {
+    return [];
+  }
+
+  // Extract markdown/HTML images: ![alt](url) and <img src="url">
+  const markdownImages = extractImageUrls(body);
+  
+  // Extract raw image URLs (direct URLs to image files)
+  const rawImages = extractRawImageUrls(body);
+  
+  // Combine and deduplicate images
+  const allImageUrls = [...markdownImages, ...rawImages];
+  const uniqueUrls = Array.from(new Set(allImageUrls));
+  
+  // Convert to gallery format with proxied URLs
+  return uniqueUrls
+    .filter(url => {
+      // Filter out non-image URLs (hashtags, profiles, etc.)
+      return url && 
+             !url.startsWith('hashtag://') && 
+             !url.startsWith('profile://') &&
+             (url.includes('image') || 
+              /\.(jpg|jpeg|png|gif|webp|bmp|svg)(\?.*)?$/i.test(url) ||
+              url.startsWith('data:image/'));
+    })
+    .map(url => ({
+      uri: proxyImageUrl(url),
+    }));
+}
+
+/**
+ * Finds the index of a specific image URL in the gallery array.
+ * Handles URL normalization (query params, protocols, etc.).
+ * 
+ * @param gallery - The image gallery array
+ * @param targetUrl - The URL to find
+ * @returns The index of the image, or 0 if not found
+ */
+export function findImageIndexInGallery(
+  gallery: ImageGalleryItem[],
+  targetUrl: string
+): number {
+  if (!targetUrl || gallery.length === 0) {
+    return 0;
+  }
+  
+  // Try exact match first
+  const exactIndex = gallery.findIndex(item => item.uri === targetUrl);
+  if (exactIndex !== -1) {
+    return exactIndex;
+  }
+  
+  // Try matching without query parameters
+  const normalizeUrl = (url: string) => {
+    try {
+      const urlObj = new URL(url);
+      urlObj.search = '';
+      return urlObj.toString();
+    } catch {
+      return url.split('?')[0];
+    }
+  };
+  
+  const normalizedTarget = normalizeUrl(targetUrl);
+  const normalizedIndex = gallery.findIndex(item => 
+    normalizeUrl(item.uri) === normalizedTarget
+  );
+  
+  return normalizedIndex !== -1 ? normalizedIndex : 0;
+}

--- a/utils/imageGallery.ts
+++ b/utils/imageGallery.ts
@@ -35,8 +35,7 @@ export function buildImageGalleryFromSnap(body: string): ImageGalleryItem[] {
       return url && 
              !url.startsWith('hashtag://') && 
              !url.startsWith('profile://') &&
-             (url.includes('image') || 
-              /\.(jpg|jpeg|png|gif|webp|bmp|svg)(\?.*)?$/i.test(url) ||
+             (/\.((jpg|jpeg|png|gif|webp|bmp|svg)(\?.*)?)$/i.test(url) ||
               url.startsWith('data:image/'));
     })
     .map(url => ({


### PR DESCRIPTION
## Summary

Implement social media-style swipeable image viewing for snaps. When a user taps an image in a snap, they can now swipe left/right to view all images from that snap, just like Instagram, Twitter, and other social media apps.

## Changes

### New Files
- **`utils/imageGallery.ts`** - Shared utility for extracting and managing image galleries from snap bodies

### Modified Files
- **`app/components/Snap.tsx`** - Updated `onImagePress` callback to pass snap body for gallery extraction
- **`app/screens/FeedScreen.tsx`** - Enhanced `handleImagePress` to build full gallery from snap body
- **`app/screens/ConversationScreen.tsx`** - Enhanced `handleImagePress` to build full gallery from snap body

## Features

✅ **Horizontal swipe navigation** - Swipe left/right between images in same snap  
✅ **Image counter indicator** - Shows "2 / 5" in top-left when multiple images exist  
✅ **Backward compatible** - Optional `snapBody` parameter, no breaking changes  
✅ **Graceful fallback** - Falls back to single-image view if extraction fails  
✅ **TypeScript safe** - Zero compilation errors  
✅ **Reuses existing components** - Leverages `react-native-image-viewing`'s built-in multi-image support (no new dependencies)

## Technical Details

- Leverages existing `react-native-image-viewing` library (v0.2.2) which already supports multi-image swipe
- Extracts both markdown images (`![alt](url)`) and raw image URLs from snap body
- Deduplicates images and proxies URLs through existing `proxyImageUrl` utility
- Finds correct starting index when user taps a specific image
- Maintains existing swipe-down-to-close gesture

## Testing

- [ ] Test tapping an image in feed and swiping between multiple images
- [ ] Test image counter displays correctly
- [ ] Test conversation/replies screen image gallery
- [ ] Test snaps with single images (should work as before)
- [ ] Test mixed content snaps (images + videos + text)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When tapping an image in a conversation or feed, users can now browse all images from that message with an on-screen counter (e.g., "2 / 5") indicating the current position, enhancing the image viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->