### PR TITLE
fix: correct GitHub Pages URLs for Google Play child safety compliance

### DIFF
--- a/docs/child-safety-standards.html
+++ b/docs/child-safety-standards.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Child Safety Standards - HiveSnaps - Snapie</title>
     <meta name="description" content="HiveSnaps Child Sexual Abuse and Exploitation (CSAE) Safety Standards and Prevention Measures">
-    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="icon" type="image/png" href="https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png">
     <style>
         * {
             margin: 0;
@@ -225,7 +225,7 @@
     <header class="header">
         <nav class="nav container">
             <a href="index.html" class="logo">
-                <img src="../assets/images/logo.png" alt="HiveSnaps Logo">
+                <img src="https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png" alt="HiveSnaps Logo">
                 HiveSnaps
             </a>
             <a href="index.html" class="back-link">← Back to Home</a>
@@ -235,7 +235,7 @@
     <div class="container">
         <div class="content">
             <h1>Child Safety Standards</h1>
-            <p class="last-updated">Last updated: November 21, 2025</p>
+            <p class="last-updated">Last updated: April 23, 2026</p>
             
             <div class="critical-notice">
                 <strong>Zero Tolerance Policy:</strong> HiveSnaps has absolutely zero tolerance for Child Sexual Abuse and Exploitation (CSAE) content. We are committed to protecting children and maintaining a safe platform for all users.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HiveSnaps - Decentralized Social Media on Hive Blockchain</title>
     <meta name="description" content="Share photos and videos on the Hive blockchain with HiveSnaps. Decentralized, secure, and community-driven social media.">
-    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="icon" type="image/png" href="https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png">
     <style>
         * {
             margin: 0;
@@ -230,7 +230,7 @@
     <header class="header">
         <nav class="nav container">
             <div class="logo">
-                <img src="../assets/images/logo.png" alt="HiveSnaps Logo">
+                <img src="https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png" alt="HiveSnaps Logo">
                 HiveSnaps
             </div>
             <ul class="nav-links">

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - HiveSnaps</title>
     <meta name="description" content="Privacy Policy for HiveSnaps - Snapie - Decentralized social media app on Hive blockchain">
-    <link rel="icon" type="image/png" href="../assets/images/logo.png">
+    <link rel="icon" type="image/png" href="https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png">
     <style>
         * {
             margin: 0;
@@ -136,7 +136,7 @@
     <header class="header">
         <nav class="nav container">
             <a href="index.html" class="logo">
-                <img src="../assets/images/logo.png" alt="HiveSnaps Logo">
+                <img src="https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png" alt="HiveSnaps Logo">
                 HiveSnaps
             </a>
             <a href="index.html" class="back-link">← Back to Home</a>


### PR DESCRIPTION
## Summary

- Fixed broken `../assets/images/logo.png` relative paths in `docs/index.html`, `docs/privacy-policy.html`, and `docs/child-safety-standards.html` — these paths resolve outside the `/docs` folder and return 404s when served from GitHub Pages
- Replaced with absolute `https://mantequilla-soft.github.io/hivesnaps/assets/images/logo.png` URLs
- Updated the child safety standards page "Last updated" date to April 23, 2026

## Why

Google Play issued a compliance violation against the Child Safety Standards policy. The root cause is that the URL submitted to Google Play (`https://mantequilla-soft.github.io/hivesnaps/child-safety-standards.html`) may have been loading with errors due to the broken image paths. Google requires the published standards page to be "functional (loads without error)".

## After merging

1. Confirm GitHub Pages is enabled in repo Settings → Pages → Source: `main` branch, `/docs` folder
2. Verify the page loads at: `https://mantequilla-soft.github.io/hivesnaps/child-safety-standards.html`
3. Update the Safety Standards URL in Google Play Console → Policy → App Content → Child Safety
4. Submit for review before April 30, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated asset delivery infrastructure across documentation pages
* Refreshed documentation timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->