### PR TITLE
fix: disable autoplay for IPFS/StakeHive videos

### DIFF
--- a/app/components/IPFSVideoPlayer.tsx
+++ b/app/components/IPFSVideoPlayer.tsx
@@ -48,8 +48,7 @@ const IPFSVideoPlayer: React.FC<IPFSVideoPlayerProps> = ({
           javaScriptEnabled
           domStorageEnabled
           onLoad={handleVideoLoad}
-          // For IPFS videos, we'll let them autoplay once user clicks
-          mediaPlaybackRequiresUserAction={false}
+          mediaPlaybackRequiresUserAction={true}
           allowsInlineMediaPlayback={true}
         />
         {/* Loading indicator */}


### PR DESCRIPTION
## Summary
- IPFS-hosted videos (StakeHive embeds) were starting playback automatically once the WebView loaded, even after the user tapped through the play-button thumbnail gate.
- Sets `mediaPlaybackRequiresUserAction={true}` on `IPFSVideoPlayer`'s WebView, matching the existing behavior of `YouTubeEmbed`, `TwitterEmbed`, and `InstagramEmbed`.

## Test plan
- [ ] Open a snap/post containing an IPFS/StakeHive video embed
- [ ] Tap the thumbnail "Play Video" button
- [ ] Confirm the video no longer starts playing on its own — playback requires an explicit tap inside the loaded page
- [ ] Confirm other embeds (YouTube, Twitter, Instagram) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted IPFS video player to require explicit user action before media playback begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->