### PR TITLE
chore: ignore APK/AAB build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ yarn-error.*
 # Windows
 Thumbs.db
 
+# Android build artifacts
+*.apk
+*.aab
+
 # local env files
 .env*.local
 .env


### PR DESCRIPTION
## Summary
- Adds `*.apk` and `*.aab` to `.gitignore`.
- A stray local APK build output (172MB) accidentally got swept into a recent commit and was rejected by GitHub's 100MB file size limit, blocking a push. This prevents it from happening again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)