### PR TITLE
feat: add snap translation via Snapie LibreTranslate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ EXPO_PUBLIC_TENOR_API_KEY=your_tenor_api_key_here
 # Hive Hangouts (required for audio room features)
 EXPO_PUBLIC_HANGOUTS_API_URL=https://hangout-api.3speak.tv
 EXPO_PUBLIC_LIVEKIT_URL=wss://livekit.3speak.tv
+
+# Snapie Translation API (self-hosted LibreTranslate)
+EXPO_PUBLIC_LIBRETRANSLATE_URL=https://translate.snapie.io
+EXPO_PUBLIC_LIBRETRANSLATE_KEY=your_libretranslate_key_here

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -603,13 +603,24 @@ const Snap: React.FC<SnapProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (compactMode || isReply || !permlink) return;
-    if (body.trim().length < 20) return;
-    detectLanguage(permlink, body.slice(0, 300)).then(lang => {
-      if (lang && lang !== deviceLang) setDetectedLang(lang);
-    }).catch(() => {});
-  }, [permlink]);
 
-  const handleTranslate = async () => {
+    // Reset stale translation state whenever the snap body changes.
+    setDetectedLang(null);
+    setTranslatedBody(null);
+    setShowingTranslation(false);
+    setTranslationState('idle');
+
+    if (body.trim().length < 20) return;
+
+    let cancelled = false;
+    detectLanguage(permlink, body.slice(0, 300)).then(lang => {
+      if (!cancelled && lang && lang !== deviceLang) setDetectedLang(lang);
+    }).catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [permlink, body]);
+
+  const handleTranslate = async (): Promise<void> => {
     if (!permlink) return;
     if (translatedBody) {
       setShowingTranslation(true);
@@ -621,8 +632,12 @@ const Snap: React.FC<SnapProps> = ({
       setTranslatedBody(result);
       setShowingTranslation(true);
       setTranslationState('done');
-    } catch (err: any) {
-      const is503 = err?.message?.includes('503') || err?.code === 503;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '';
+      const code = typeof err === 'object' && err !== null && 'code' in err
+        ? (err as { code: unknown }).code
+        : undefined;
+      const is503 = msg.includes('503') || code === 503;
       Alert.alert(
         'Translation',
         is503 ? 'Translation unavailable right now.' : 'Translation failed. Please try again.',

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -8,6 +8,7 @@ import {
   Pressable,
   Modal,
   TouchableOpacity,
+  ActivityIndicator,
   Dimensions,
   Alert,
   Share,
@@ -61,6 +62,7 @@ import { preprocessForMarkdown } from '../../utils/htmlPreprocessing';
 import { renderHiveToHtml } from '../../utils/renderHive';
 import { linkifyMentions } from '../../utils/linkifyMentions';
 import { linkifyUrls } from '../../utils/linkifyUrls';
+import { detectLanguage, translateText, getLanguageName } from '../../services/translationService';
 
 interface SnapProps {
   snap: SnapData;
@@ -585,6 +587,50 @@ const Snap: React.FC<SnapProps> = ({
   // Overflow (three-dots) menu
   const [moreMenuVisible, setMoreMenuVisible] = useState(false);
 
+  // Translation
+  const deviceLang = useMemo(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().locale.split('-')[0] ?? 'en';
+    } catch {
+      return 'en';
+    }
+  }, []);
+  const [detectedLang, setDetectedLang] = useState<string | null>(null);
+  const [translationState, setTranslationState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [translatedBody, setTranslatedBody] = useState<string | null>(null);
+  const [showingTranslation, setShowingTranslation] = useState(false);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (compactMode || isReply || !permlink) return;
+    if (body.trim().length < 20) return;
+    detectLanguage(permlink, body.slice(0, 300)).then(lang => {
+      if (lang && lang !== deviceLang) setDetectedLang(lang);
+    }).catch(() => {});
+  }, [permlink]);
+
+  const handleTranslate = async () => {
+    if (!permlink) return;
+    if (translatedBody) {
+      setShowingTranslation(true);
+      return;
+    }
+    setTranslationState('loading');
+    try {
+      const result = await translateText(permlink, body.slice(0, 8000), deviceLang);
+      setTranslatedBody(result);
+      setShowingTranslation(true);
+      setTranslationState('done');
+    } catch (err: any) {
+      const is503 = err?.message?.includes('503') || err?.code === 503;
+      Alert.alert(
+        'Translation',
+        is503 ? 'Translation unavailable right now.' : 'Translation failed. Please try again.',
+      );
+      setTranslationState('idle');
+    }
+  };
+
   // Remove global side-effects previously used for handlers
   // (globalThis references deleted)
 
@@ -836,6 +882,23 @@ const Snap: React.FC<SnapProps> = ({
         {/* Body */}
         {cleanTextBody.length > 0 &&
           (() => {
+            if (showingTranslation && translatedBody) {
+              const translatedContent = (
+                <Text style={{ color: colors.text, fontSize: isReply ? 14 : 15, marginBottom: 8, lineHeight: isReply ? 20 : 22 }}>
+                  {translatedBody}
+                </Text>
+              );
+              return onContentPress ? (
+                <Pressable
+                  onPress={onContentPress}
+                  style={({ pressed }) => [{ opacity: pressed ? 0.8 : 1 }]}
+                  accessibilityRole='button'
+                  accessibilityLabel='View conversation'
+                >
+                  {translatedContent}
+                </Pressable>
+              ) : translatedContent;
+            }
             if (onContentPress) {
               return (
                 <Pressable
@@ -951,6 +1014,21 @@ const Snap: React.FC<SnapProps> = ({
               );
             }
           })()}
+        {/* Translation attribution footer */}
+        {showingTranslation && detectedLang && (
+          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6, marginTop: -4 }}>
+            <FontAwesome name='globe' size={11} color={colors.icon} style={{ opacity: 0.6, marginRight: 4 }} />
+            <Text style={{ color: colors.icon, fontSize: 12, opacity: 0.6 }}>
+              {'Translated from ' + getLanguageName(detectedLang) + ' · '}
+            </Text>
+            <Text
+              onPress={() => setShowingTranslation(false)}
+              style={{ color: colors.icon, fontSize: 12, opacity: 0.8, textDecorationLine: 'underline' }}
+            >
+              Original
+            </Text>
+          </View>
+        )}
         {/* VoteReplyBar - different layouts for compact mode (replies) vs normal mode */}
         {compactMode || isReply ? (
           // Compact mode for replies
@@ -1114,6 +1192,22 @@ const Snap: React.FC<SnapProps> = ({
               >
                 <FontAwesome name='retweet' size={18} color={colors.icon} />
               </Pressable>
+            )}
+            {/* Translate button - only when content is in a different language */}
+            {detectedLang !== null && !showingTranslation && translationState !== 'loading' && (
+              <TouchableOpacity
+                onPress={handleTranslate}
+                style={{ marginLeft: 12, padding: 4 }}
+                accessibilityRole='button'
+                accessibilityLabel='Translate this snap'
+              >
+                <FontAwesome name='globe' size={18} color={colors.icon} />
+              </TouchableOpacity>
+            )}
+            {translationState === 'loading' && (
+              <View style={{ marginLeft: 12, padding: 4 }}>
+                <ActivityIndicator size='small' color={colors.icon} />
+              </View>
             )}
             <View style={{ flex: 1 }} />
             <Text style={[styles.payout, { color: colors.payout }]}>

--- a/services/translationService.ts
+++ b/services/translationService.ts
@@ -1,5 +1,6 @@
 const TRANSLATE_URL = process.env.EXPO_PUBLIC_LIBRETRANSLATE_URL ?? 'https://translate.snapie.io';
 const TRANSLATE_KEY = process.env.EXPO_PUBLIC_LIBRETRANSLATE_KEY ?? '';
+const REQUEST_TIMEOUT_MS = 10_000;
 
 const detectCache = new Map<string, string>();
 const translateCache = new Map<string, string>();
@@ -23,25 +24,41 @@ export function getLanguageName(code: string): string {
   return LANG_NAMES[code] ?? code.toUpperCase();
 }
 
+// Short fingerprint so edits to the same permlink invalidate stale cache entries.
+function textFingerprint(text: string): string {
+  return `${text.length}:${text.slice(0, 16)}:${text.slice(-16)}`;
+}
+
+function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  return fetch(url, { ...init, signal: controller.signal }).finally(() => clearTimeout(timer));
+}
+
 export async function detectLanguage(permlink: string, text: string): Promise<string | null> {
-  if (detectCache.has(permlink)) return detectCache.get(permlink)!;
+  const cacheKey = `${permlink}:${textFingerprint(text)}`;
+  if (detectCache.has(cacheKey)) return detectCache.get(cacheKey)!;
 
-  const res = await fetch(`${TRANSLATE_URL}/detect`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ q: text, api_key: TRANSLATE_KEY }),
-  });
+  try {
+    const res = await fetchWithTimeout(`${TRANSLATE_URL}/detect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, api_key: TRANSLATE_KEY }),
+    });
 
-  if (!res.ok) return null;
+    if (!res.ok) return null;
 
-  const data: Array<{ language: string; confidence: number }> = await res.json();
-  const top = data[0]?.language ?? null;
-  if (top) detectCache.set(permlink, top);
-  return top;
+    const data: Array<{ language: string; confidence: number }> = await res.json();
+    const top = data[0]?.language ?? null;
+    if (top) detectCache.set(cacheKey, top);
+    return top;
+  } catch {
+    return null;
+  }
 }
 
 async function doTranslateRequest(text: string, targetLang: string): Promise<string> {
-  const res = await fetch(`${TRANSLATE_URL}/translate`, {
+  const res = await fetchWithTimeout(`${TRANSLATE_URL}/translate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -61,14 +78,17 @@ async function doTranslateRequest(text: string, targetLang: string): Promise<str
 }
 
 export async function translateText(permlink: string, text: string, targetLang: string): Promise<string> {
-  const cacheKey = `${permlink}:${targetLang}`;
+  const cacheKey = `${permlink}:${targetLang}:${textFingerprint(text)}`;
   if (translateCache.has(cacheKey)) return translateCache.get(cacheKey)!;
 
   let result: string;
   try {
     result = await doTranslateRequest(text, targetLang);
-  } catch (err: any) {
-    if (err.code === 429) {
+  } catch (err: unknown) {
+    const code = typeof err === 'object' && err !== null && 'code' in err
+      ? (err as { code: unknown }).code
+      : undefined;
+    if (code === 429) {
       await new Promise(resolve => setTimeout(resolve, 2000));
       result = await doTranslateRequest(text, targetLang);
     } else {

--- a/services/translationService.ts
+++ b/services/translationService.ts
@@ -1,0 +1,81 @@
+const TRANSLATE_URL = process.env.EXPO_PUBLIC_LIBRETRANSLATE_URL ?? 'https://translate.snapie.io';
+const TRANSLATE_KEY = process.env.EXPO_PUBLIC_LIBRETRANSLATE_KEY ?? '';
+
+const detectCache = new Map<string, string>();
+const translateCache = new Map<string, string>();
+
+const LANG_NAMES: Record<string, string> = {
+  en: 'English',
+  es: 'Spanish',
+  fr: 'French',
+  pt: 'Portuguese',
+  de: 'German',
+  it: 'Italian',
+  nl: 'Dutch',
+  zh: 'Chinese',
+  ja: 'Japanese',
+  ko: 'Korean',
+  ar: 'Arabic',
+  ru: 'Russian',
+};
+
+export function getLanguageName(code: string): string {
+  return LANG_NAMES[code] ?? code.toUpperCase();
+}
+
+export async function detectLanguage(permlink: string, text: string): Promise<string | null> {
+  if (detectCache.has(permlink)) return detectCache.get(permlink)!;
+
+  const res = await fetch(`${TRANSLATE_URL}/detect`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, api_key: TRANSLATE_KEY }),
+  });
+
+  if (!res.ok) return null;
+
+  const data: Array<{ language: string; confidence: number }> = await res.json();
+  const top = data[0]?.language ?? null;
+  if (top) detectCache.set(permlink, top);
+  return top;
+}
+
+async function doTranslateRequest(text: string, targetLang: string): Promise<string> {
+  const res = await fetch(`${TRANSLATE_URL}/translate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      q: text,
+      source: 'auto',
+      target: targetLang,
+      api_key: TRANSLATE_KEY,
+    }),
+  });
+
+  if (res.status === 429) throw Object.assign(new Error('Rate limited'), { code: 429 });
+  if (res.status === 503) throw Object.assign(new Error('Translation service unavailable'), { code: 503 });
+  if (!res.ok) throw new Error(`Translation error: ${res.status}`);
+
+  const data = await res.json();
+  return data.translatedText as string;
+}
+
+export async function translateText(permlink: string, text: string, targetLang: string): Promise<string> {
+  const cacheKey = `${permlink}:${targetLang}`;
+  if (translateCache.has(cacheKey)) return translateCache.get(cacheKey)!;
+
+  let result: string;
+  try {
+    result = await doTranslateRequest(text, targetLang);
+  } catch (err: any) {
+    if (err.code === 429) {
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      result = await doTranslateRequest(text, targetLang);
+    } else {
+      throw err;
+    }
+  }
+
+  translateCache.set(cacheKey, result);
+  return result;
+}


### PR DESCRIPTION
## Summary

- Adds a **Translate** globe button to snap cards that appears only when the snap's detected language differs from the device language
- Translations are served by our self-hosted LibreTranslate at `translate.snapie.io` — no third-party cost or data leakage
- Translated body replaces the snap text with a **"Translated from [Language] · Original"** footer that lets users toggle back
- Both language detection and translation results are cached in-memory per permlink, so re-viewing a snap costs zero extra requests

## What changed

- `services/translationService.ts` — new service with `detectLanguage`, `translateText`, `getLanguageName`; in-memory caches; 429 auto-retry
- `app/components/Snap.tsx` — detection effect on mount (skipped for compact/reply mode and text < 20 chars), translate button in action bar, translated body rendering, attribution footer
- `.env.example` — documents the two new `EXPO_PUBLIC_LIBRETRANSLATE_*` variables

## Before shipping

- [ ] Add `EXPO_PUBLIC_LIBRETRANSLATE_URL` and `EXPO_PUBLIC_LIBRETRANSLATE_KEY` to EAS secrets
- [ ] Smoke test on a feed with foreign-language snaps (globe button should appear)
- [ ] Smoke test on a feed with same-language snaps (globe button should NOT appear)
- [ ] Tap Translate → verify translated text appears with attribution footer
- [ ] Tap Original → verify original text restores
- [ ] Scroll away and back → verify no re-fetch (cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-device translation controls for snaps, including automatic language detection and a one-tap option to view translated content.
  * Added a clear way to switch back to the original text and see the detected source language.
* **Bug Fixes**
  * Improved translation error handling with better feedback when the translation service is unavailable or rate-limited.
* **Chores**
  * Updated sample environment settings to include translation service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->