### PR TITLE
feat: patron tier badges on snap cards

### DIFF
--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -63,6 +63,7 @@ import { renderHiveToHtml } from '../../utils/renderHive';
 import { linkifyMentions } from '../../utils/linkifyMentions';
 import { linkifyUrls } from '../../utils/linkifyUrls';
 import { detectLanguage, translateText, getLanguageName } from '../../services/translationService';
+import { getPatronTier, PatronTier } from '../../services/patronService';
 
 interface SnapProps {
   snap: SnapData;
@@ -133,6 +134,22 @@ const renderMp4Video = (uri: string, key?: string | number) => (
     />
   </View>
 );
+
+const PATRON_TIER_CONFIG: Record<PatronTier, { bg: string; border: string; color: string; label: string }> = {
+  'snap-master': { bg: 'rgba(245,158,11,0.15)', border: '#F59E0B', color: '#F59E0B', label: 'SNAP MASTER' },
+  'snapian':     { bg: 'rgba(96,165,250,0.15)',  border: '#60A5FA', color: '#60A5FA', label: 'SNAPIAN' },
+  'snaperino':   { bg: 'rgba(148,163,184,0.15)', border: '#94A3B8', color: '#94A3B8', label: 'SNAPERINO' },
+};
+
+const PatronBadge: React.FC<{ tier: PatronTier }> = ({ tier }) => {
+  const { bg, border, color, label } = PATRON_TIER_CONFIG[tier];
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: bg, borderWidth: 1, borderColor: border, borderRadius: 10, paddingHorizontal: 6, paddingVertical: 2, marginLeft: 6 }}>
+      <FontAwesome name='star' size={9} color={color} style={{ marginRight: 3 }} />
+      <Text style={{ color, fontSize: 9, fontWeight: '700', letterSpacing: 0.5 }}>{label}</Text>
+    </View>
+  );
+};
 
 // Custom markdown rules for mp4 and video support
 
@@ -600,6 +617,13 @@ const Snap: React.FC<SnapProps> = ({
   const [translatedBody, setTranslatedBody] = useState<string | null>(null);
   const [showingTranslation, setShowingTranslation] = useState(false);
 
+  // Patron badge
+  const [patronTier, setPatronTier] = useState<PatronTier | null>(null);
+  useEffect(() => {
+    if (!showAuthor && !isReply) return;
+    getPatronTier(author).then(tier => setPatronTier(tier)).catch(() => {});
+  }, [author, showAuthor, isReply]);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (compactMode || isReply || !permlink) return;
@@ -759,6 +783,7 @@ const Snap: React.FC<SnapProps> = ({
                 {author}
               </Text>
             </Pressable>
+            {patronTier && <PatronBadge tier={patronTier} />}
             <View style={styles.topRightCluster}>
               {viaHiveSnaps && (
                 <ExpoImage

--- a/app/components/Snap.tsx
+++ b/app/components/Snap.tsx
@@ -621,7 +621,12 @@ const Snap: React.FC<SnapProps> = ({
   const [patronTier, setPatronTier] = useState<PatronTier | null>(null);
   useEffect(() => {
     if (!showAuthor && !isReply) return;
-    getPatronTier(author).then(tier => setPatronTier(tier)).catch(() => {});
+    setPatronTier(null);
+    let cancelled = false;
+    getPatronTier(author).then(tier => {
+      if (!cancelled) setPatronTier(tier);
+    }).catch(() => {});
+    return () => { cancelled = true; };
   }, [author, showAuthor, isReply]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/services/patronService.ts
+++ b/services/patronService.ts
@@ -1,5 +1,7 @@
 const PATRONS_URL = 'https://snapie.io/api/patrons';
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CACHE_TTL_MS = 60 * 60 * 1000;       // 1 hour on success
+const ERROR_RETRY_TTL_MS = 5 * 60 * 1000;  // 5 min backoff on failure
+const FETCH_TIMEOUT_MS = 10_000;
 
 export type PatronTier = 'snap-master' | 'snapian' | 'snaperino';
 
@@ -14,14 +16,20 @@ let cacheExpiry = 0;
 let inflight: Promise<Map<string, PatronTier>> | null = null;
 
 async function fetchPatrons(): Promise<Map<string, PatronTier>> {
-  const res = await fetch(PATRONS_URL);
-  if (!res.ok) throw new Error(`Patrons fetch failed: ${res.status}`);
-  const data: { patrons: Patron[] } = await res.json();
-  const map = new Map<string, PatronTier>();
-  for (const p of data.patrons) {
-    map.set(p.account, p.tier);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(PATRONS_URL, { signal: controller.signal });
+    if (!res.ok) throw new Error(`Patrons fetch failed: ${res.status}`);
+    const data: { patrons: Patron[] } = await res.json();
+    const map = new Map<string, PatronTier>();
+    for (const p of data.patrons) {
+      map.set(p.account, p.tier);
+    }
+    return map;
+  } finally {
+    clearTimeout(timer);
   }
-  return map;
 }
 
 function loadPatrons(): Promise<Map<string, PatronTier>> {
@@ -37,7 +45,10 @@ function loadPatrons(): Promise<Map<string, PatronTier>> {
     })
     .catch(() => {
       inflight = null;
-      return cachedMap ?? new Map<string, PatronTier>();
+      // Back off 5 min so we don't hammer the endpoint during an outage.
+      cachedMap ??= new Map<string, PatronTier>();
+      cacheExpiry = Date.now() + ERROR_RETRY_TTL_MS;
+      return cachedMap;
     });
 
   return inflight;

--- a/services/patronService.ts
+++ b/services/patronService.ts
@@ -1,0 +1,49 @@
+const PATRONS_URL = 'https://snapie.io/api/patrons';
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export type PatronTier = 'snap-master' | 'snapian' | 'snaperino';
+
+interface Patron {
+  account: string;
+  tier: PatronTier;
+  via?: string;
+}
+
+let cachedMap: Map<string, PatronTier> | null = null;
+let cacheExpiry = 0;
+let inflight: Promise<Map<string, PatronTier>> | null = null;
+
+async function fetchPatrons(): Promise<Map<string, PatronTier>> {
+  const res = await fetch(PATRONS_URL);
+  if (!res.ok) throw new Error(`Patrons fetch failed: ${res.status}`);
+  const data: { patrons: Patron[] } = await res.json();
+  const map = new Map<string, PatronTier>();
+  for (const p of data.patrons) {
+    map.set(p.account, p.tier);
+  }
+  return map;
+}
+
+function loadPatrons(): Promise<Map<string, PatronTier>> {
+  if (cachedMap && Date.now() < cacheExpiry) return Promise.resolve(cachedMap);
+  if (inflight) return inflight;
+
+  inflight = fetchPatrons()
+    .then(map => {
+      cachedMap = map;
+      cacheExpiry = Date.now() + CACHE_TTL_MS;
+      inflight = null;
+      return map;
+    })
+    .catch(() => {
+      inflight = null;
+      return cachedMap ?? new Map<string, PatronTier>();
+    });
+
+  return inflight;
+}
+
+export async function getPatronTier(account: string): Promise<PatronTier | null> {
+  const map = await loadPatrons();
+  return map.get(account) ?? null;
+}


### PR DESCRIPTION
## Summary

- Fetches `https://snapie.io/api/patrons` at most once per hour — result is cached in memory, inflight requests are deduplicated, and errors fall back to stale cache (or empty map) silently
- For any snap whose author is a patron, a small pill badge appears next to their username in the snap header
- Three tiers, three styles:
  - 🟡 **SNAP MASTER** — gold border/text
  - 🔵 **SNAPIAN** — blue border/text
  - ⚪ **SNAPERINO** — slate border/text
- Badge only renders when the author row is visible (skipped for feed items without `showAuthor`)

## What changed

- `services/patronService.ts` — new service: `getPatronTier(account)`, 1-hour in-memory cache, graceful error handling
- `app/components/Snap.tsx` — `PatronBadge` inline component, `patronTier` state + fetch effect, badge rendered between username and right-side cluster

## Test plan

- [ ] Open feed — snap-master accounts (jongolson, meno, starkerz, tibfox, joseamenac) should show gold badge
- [ ] Snapian accounts (jacobtothe, ankapolo) should show blue badge
- [ ] Snaperino accounts (wildwhispore, bushcraftbites, tonyz, ph1102, epodcaster, mondoshawan, ankalagonchik) should show slate badge
- [ ] Non-patron accounts show no badge
- [ ] Kill and reopen app — only one network request fires per hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added patron badges to snap authors when available.
  * Snap author badges now appear automatically in the top row for eligible posts.
  * Improved support for showing creator status while browsing snaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->