### PR TITLE
Add game entry point via @mantequilla-soft/cuarenta

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@mantequilla-soft:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "hivesnaps",
     "owner": "menobass",
     "slug": "hivesnaps",
-    "version": "1.1.3",
+    "version": "1.3.1",
     "orientation": "portrait",
     "platforms": [
       "ios",
@@ -21,14 +21,16 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.jose.antonio.mena.hivesnaps",
-      "buildNumber": "1.1.3",
+      "buildNumber": "1.3.1",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSCameraUsageDescription": "This app uses the camera to take photos and record videos for your posts.",
         "NSMicrophoneUsageDescription": "This app needs access to the microphone to record audio for your videos and hangouts.",
         "NSPhotoLibraryUsageDescription": "This app uses the photo library to select photos and videos to share in your posts.",
         "NSFaceIDUsageDescription": "This app uses Face ID to verify your identity.",
-        "UIBackgroundModes": ["audio"]
+        "UIBackgroundModes": [
+          "audio"
+        ]
       }
     },
     "android": {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -98,6 +98,7 @@ function RootLayoutNav() {
                 <Stack.Screen name='screens/WalletScreen' />
                 <Stack.Screen name='screens/HangoutsLobbyScreen' />
                 <Stack.Screen name='screens/HangoutsRoomScreen' />
+                <Stack.Screen name='screens/GameScreen' />
                 <Stack.Screen name='modal' options={{ presentation: 'modal' }} />
               </Stack>
             </TOSWrapper>

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -1011,6 +1011,16 @@ const FeedScreenRefactored = () => {
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <TouchableOpacity
               style={[styles.searchBtn, { marginRight: 12 }]}
+              onPress={() => router.push('/screens/GameScreen')}
+              accessibilityLabel='Play game'
+              accessibilityRole='button'
+              accessibilityHint='Navigates to the game screen'
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <FontAwesome name='gamepad' size={22} color={colors.icon} />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.searchBtn, { marginRight: 12 }]}
               onPress={() => router.push('/screens/HangoutsLobbyScreen')}
               accessibilityLabel='Open Hangouts'
               accessibilityRole='button'

--- a/app/screens/GameScreen.tsx
+++ b/app/screens/GameScreen.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { FontAwesome } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { CuarentaView, type GameEvent } from '@mantequilla-soft/cuarenta';
+import { getTheme } from '../../constants/Colors';
+import { useColorScheme } from '../../components/useColorScheme';
+
+export default function GameScreen() {
+  const colorScheme = useColorScheme();
+  const theme = getTheme(colorScheme);
+  const router = useRouter();
+  const [lastEvent, setLastEvent] = useState<GameEvent | null>(null);
+
+  const closeGame = () => {
+    router.canGoBack() ? router.back() : router.replace('/screens/FeedScreen');
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+      <Text style={[styles.title, { color: theme.text }]}>Cuarenta</Text>
+      <CuarentaView
+        color="#32a852"
+        style={styles.game}
+        onGameEvent={(e) => setLastEvent(e.nativeEvent)}
+      />
+      <Text style={[styles.status, { color: theme.text }]}>
+        {lastEvent ? `${lastEvent.type}: ${lastEvent.payload}` : 'Tap the game'}
+      </Text>
+      <TouchableOpacity
+        onPress={closeGame}
+        style={[styles.closeButton, { backgroundColor: theme.buttonSecondary }]}
+        accessibilityLabel='Close game'
+        accessibilityRole='button'
+      >
+        <FontAwesome name='times' size={16} color={theme.buttonSecondaryText} />
+        <Text style={[styles.closeButtonText, { color: theme.buttonSecondaryText }]}>
+          Close Game
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 24,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  closeButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  game: {
+    width: 200,
+    height: 200,
+  },
+  status: {
+    marginTop: 16,
+  },
+});

--- a/app/screens/GameScreen.tsx
+++ b/app/screens/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { FontAwesome } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
@@ -8,7 +8,7 @@ import { getTheme } from '../../constants/Colors';
 import { useColorScheme } from '../../components/useColorScheme';
 
 export default function GameScreen() {
-  const colorScheme = useColorScheme();
+  const colorScheme = useColorScheme() || 'light';
   const theme = getTheme(colorScheme);
   const router = useRouter();
   const [lastEvent, setLastEvent] = useState<GameEvent | null>(null);
@@ -21,7 +21,7 @@ export default function GameScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
       <Text style={[styles.title, { color: theme.text }]}>Cuarenta</Text>
       <CuarentaView
-        color="#32a852"
+        color={theme.success}
         style={styles.game}
         onGameEvent={(e) => setLastEvent(e.nativeEvent)}
       />

--- a/docs/ADDING_NATIVE_MODULES.md
+++ b/docs/ADDING_NATIVE_MODULES.md
@@ -43,6 +43,11 @@ Autolinking (via `expo-modules-autolinking`, which wraps standard RN community
 autolinking) picks up any package with a valid podspec/`build.gradle` automatically —
 no manual registration needed for either platform.
 
+Note: `@mantequilla-soft/cuarenta` currently only ships a real (SpriteKit-backed)
+implementation on iOS. Reusing this example for Android depends on the library
+providing a working `build.gradle` implementation there too — check the library's
+own docs/README for current platform support before assuming both platforms work.
+
 ## 3. Rebuild the dev client
 
 Native code changes are invisible to Fast Refresh. After installing or updating a native
@@ -60,7 +65,7 @@ Import and render like any other component:
 ```tsx
 import { CuarentaView } from '@mantequilla-soft/cuarenta';
 
-<CuarentaView color="#32a852" style={{ width: 200, height: 200 }} />
+<CuarentaView color={theme.success} style={{ width: 200, height: 200 }} />
 ```
 
 ## Developing against an unpublished library (local `file:` dependency)
@@ -85,6 +90,9 @@ config.watchFolders = [...(config.watchFolders || []), libRoot];
 // The linked library ships its own node_modules (react/react-native, for its own
 // example app) — without blocking these, Metro tries to bundle a second copy of
 // react-native and gets confused running RN's own codegen against it.
+const existingBlockList = config.resolver.blockList
+  ? [].concat(config.resolver.blockList)
+  : [];
 config.resolver.blockList = [
   ...existingBlockList,
   new RegExp(`${libRoot}/node_modules/.*`),

--- a/docs/ADDING_NATIVE_MODULES.md
+++ b/docs/ADDING_NATIVE_MODULES.md
@@ -1,0 +1,112 @@
+# Adding a native (non-Expo-Go) library to hivesnaps
+
+hivesnaps runs on a **custom Expo dev client** (`expo-dev-client`), not Expo Go, and
+commits its native `ios/` and `android/` folders. That means any React Native library
+with native (Swift/ObjC/Kotlin/Java) code can be added — it isn't restricted to Expo's
+Expo-Go-compatible module list. The tradeoff: adding or changing a native library always
+requires a full native rebuild of the dev client, not just a JS reload.
+
+This doc walks through the steps using the real example of adding
+[`@mantequilla-soft/cuarenta`](https://github.com/Mantequilla-Soft/cuarenta), a native
+Fabric view (SpriteKit-backed on iOS) — plus the gotchas hit along the way.
+
+## 1. Install the package
+
+Same as any npm dependency:
+
+```
+npm install <package-name>
+```
+
+If the library is published to a **scoped registry** other than the default npm registry
+(e.g. GitHub Packages, as with `@mantequilla-soft/*`), the project needs a `.npmrc`
+mapping that scope to the right registry, plus an auth token — GitHub Packages requires
+authentication to install even for public packages:
+
+```ini
+# .npmrc (safe to commit — no secret in it)
+@mantequilla-soft:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Each developer (and CI) needs a `GITHUB_TOKEN` env var set locally with at least
+`read:packages` scope on a GitHub PAT. **Never commit the literal token** — only the
+`${GITHUB_TOKEN}` placeholder belongs in the repo.
+
+## 2. Link the native code
+
+```
+cd ios && pod install
+```
+
+Autolinking (via `expo-modules-autolinking`, which wraps standard RN community
+autolinking) picks up any package with a valid podspec/`build.gradle` automatically —
+no manual registration needed for either platform.
+
+## 3. Rebuild the dev client
+
+Native code changes are invisible to Fast Refresh. After installing or updating a native
+dependency, do a full rebuild:
+
+```
+npx expo run:ios
+npx expo run:android
+```
+
+## 4. Use it
+
+Import and render like any other component:
+
+```tsx
+import { CuarentaView } from '@mantequilla-soft/cuarenta';
+
+<CuarentaView color="#32a852" style={{ width: 200, height: 200 }} />
+```
+
+## Developing against an unpublished library (local `file:` dependency)
+
+While a native library is still under active development and not yet published, you can
+link it locally instead:
+
+```
+npm install ../path-to-library
+```
+
+This works, but Metro needs extra configuration because the linked package lives
+**outside** the project root:
+
+```js
+// metro.config.js
+const path = require('path');
+const libRoot = path.resolve(__dirname, '../path-to-library');
+
+config.watchFolders = [...(config.watchFolders || []), libRoot];
+
+// The linked library ships its own node_modules (react/react-native, for its own
+// example app) — without blocking these, Metro tries to bundle a second copy of
+// react-native and gets confused running RN's own codegen against it.
+config.resolver.blockList = [
+  ...existingBlockList,
+  new RegExp(`${libRoot}/node_modules/.*`),
+  new RegExp(`${libRoot}/example/.*`), // or wherever its own example app lives
+];
+
+config.resolver.extraNodeModules = {
+  react: path.resolve(__dirname, 'node_modules/react'),
+  'react-native': path.resolve(__dirname, 'node_modules/react-native'),
+};
+```
+
+**Remove all of this once the library is published for real** and installed as a normal
+registry dependency — none of it is needed at that point, and leaving it in is just
+confusing dead weight.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Unable to resolve module <lib> ... could not be found within the project or in these directories: node_modules` | Metro doesn't know about a locally-symlinked package outside the project root | Add its path to `config.watchFolders` |
+| `Unable to determine event arguments for "..."` (codegen babel error, pointing into `<lib>/node_modules/react-native/...`) | Metro is bundling the linked library's own (differently-versioned) copy of react-native | Add `<lib>/node_modules/.*` to `config.resolver.blockList` and set `extraNodeModules` to force resolution to the host app's react/react-native |
+| `401 Unauthorized ... unauthenticated: User cannot be authenticated` on install | Missing/invalid GitHub Packages auth token | Confirm `GITHUB_TOKEN` is set and has `read:packages`; `npm whoami --registry=<registry>` to verify |
+| Stale/wrong bundle after switching a dependency between local `file:` and a published version | Metro cache | Restart Metro with `--clear` |
+| Native code change has no effect | Fast Refresh doesn't reload native code | Full rebuild: `npx expo run:ios` / `npx expo run:android` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hiveio/dhive": "^1.3.2",
         "@livekit/react-native": "^2.10.0",
         "@livekit/react-native-webrtc": "^144.0.0",
+        "@mantequilla-soft/cuarenta": "^0.1.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/slider": "5.0.1",
         "@react-navigation/native": "^7.1.6",
@@ -76,6 +77,41 @@
         "prettier": "^3.6.2",
         "react-test-renderer": "19.0.0",
         "typescript": "~5.8.3"
+      }
+    },
+    "../cuarenta": {
+      "name": "@mantequilla-soft/cuarenta",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "devDependencies": {
+        "@eslint/compat": "^2.1.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "^10.0.1",
+        "@jest/globals": "^29.7.0",
+        "@react-native/babel-preset": "0.85.0",
+        "@react-native/eslint-config": "0.85.0",
+        "@react-native/jest-preset": "0.85.0",
+        "@types/react": "^19.2.0",
+        "del-cli": "^7.0.0",
+        "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-ft-flow": "^3.0.11",
+        "eslint-plugin-prettier": "^5.5.6",
+        "jest": "^29.7.0",
+        "prettier": "^3.8.3",
+        "react": "19.2.3",
+        "react-native": "0.85.0",
+        "react-native-builder-bob": "^0.43.0",
+        "turbo": "^2.9.16",
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -3718,6 +3754,16 @@
         "@livekit/krisp-noise-filter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mantequilla-soft/cuarenta": {
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@mantequilla-soft/cuarenta/0.1.0/ca0ac2e63916f2ee5abcac6a0b256513162bb09c",
+      "integrity": "sha512-skIlJikQ6bJRvpUhkHFUfRgyd/PPEKEhBLjsVsZryqDqrvQ8i5d4JpuwZSiZXFU7mvwjGD4oAn/pRnSMBgzl9g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@native-html/css-processor": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@hiveio/dhive": "^1.3.2",
     "@livekit/react-native": "^2.10.0",
     "@livekit/react-native-webrtc": "^144.0.0",
+    "@mantequilla-soft/cuarenta": "^0.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/slider": "5.0.1",
     "@react-navigation/native": "^7.1.6",


### PR DESCRIPTION
Adds a gamepad icon to the Feed screen that opens a new GameScreen rendering CuarentaView, a native SpriteKit-backed Fabric component published to GitHub Packages. Includes docs/ADDING_NATIVE_MODULES.md describing how to add native RN libraries to this project going forward.

Installing this dependency requires a GITHUB_TOKEN env var with read:packages scope (see .npmrc and the new doc for details) — CI will need this secret added separately.

## Description
 Setup required

  Installing @mantequilla-soft/cuarenta requires a GITHUB_TOKEN env var with read:packages scope (GitHub Packages requires auth even for public packages).
  This is referenced via .npmrc (no secret committed). CI will need this secret added separately before this branch can build there.

  Test plan

  - [x] npm install, pod install, npx expo run:ios — dev client builds clean against the published npm dependency
  - [x] Tap the gamepad icon on the Feed screen → GameScreen opens, CuarentaView renders (SpriteKit view, tap increments score via onGameEvent)
  - [x] "Close Game" button navigates back to Feed (handles both push-history and cold-launch/state-restoration cases via router.canGoBack())
  - [ ] Android (not yet implemented — iOS-only for now)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to a new Cuarenta game from the Feed screen.
  * Added a dedicated game screen showing the latest game event and controls to close the game.
  * Added navigation and accessibility support for the game action.

* **Documentation**
  * Added guidance for integrating native React Native libraries, including setup, authentication, rebuilding, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->