### PR TITLE
fix: reduce trending shelf in Newest feed, spread rest at low cadence

### DIFF
--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -1203,7 +1203,7 @@ const FeedScreenRefactored = () => {
               Loading snaps...
             </Text>
           </View>
-        ) : filteredSnaps.length === 0 ? (
+        ) : snapsWithWaves.length === 0 ? (
           <View style={{
             alignItems: 'center',
             marginTop: EMPTY_STATE_MARGIN_TOP,

--- a/app/screens/FeedScreen.tsx
+++ b/app/screens/FeedScreen.tsx
@@ -246,11 +246,13 @@ const FeedScreenRefactored = () => {
     return filtered;
   }, [snaps, mutedList]);
 
-  // Promote trending/resurrected snaps to the top of the Newest feed — a fixed
-  // "what's hot right now" shelf, not spread through the scroll like waves.
+  // Surface trending/resurrected snaps in the Newest feed without letting them
+  // dominate the top: one gets a small "shelf" right at the front, the rest
+  // trickle in at a low cadence further down instead of stacking up front.
   // Newest tab only: Following has its own curated scope, and the existing
   // 'trending' FeedFilter tab is a separate, unrelated payout-based Hive sort.
-  const TRENDING_PROMOTE_COUNT = 5;
+  const TRENDING_PROMOTE_COUNT = 1;
+  const TRENDING_SPLICE_CADENCE = 15;
   const feedWithTrending = useMemo(() => {
     if (activeFeed !== 'snaps' || currentFilter !== 'newest' || trending.length === 0) return filteredSnaps;
     const eligibleTrending = trending.filter(t => !mutedList || !mutedList.includes(t.author));
@@ -258,12 +260,15 @@ const FeedScreenRefactored = () => {
     // A trending snap is real recent content — it may already be organically visible
     // in filteredSnaps. promoteToTopOrMerge badges it in place instead of dropping the
     // flag when it's a duplicate; only genuinely new-to-this-page items get promoted.
-    return promoteToTopOrMerge(
+    const promoted = promoteToTopOrMerge(
       filteredSnaps,
       eligibleTrending,
       { count: TRENDING_PROMOTE_COUNT },
       (snap, extra) => ({ ...snap, isDiscovery: true, discoveryReason: extra.discoveryReason })
     ) as typeof filteredSnaps;
+    // Remaining trending items (already merged or promoted above) are deduped
+    // out automatically by interleave — this only splices in what's left.
+    return interleave(promoted, eligibleTrending, { every: TRENDING_SPLICE_CADENCE }) as typeof filteredSnaps;
   }, [filteredSnaps, trending, activeFeed, currentFilter, mutedList]);
 
   // Splice waves into the (now trending-promoted) snaps feed. Independent


### PR DESCRIPTION
## Summary
- Trending/resurrected snaps promoted to the top of the Newest feed were too intrusive at 5 items stacked up front.
- `TRENDING_PROMOTE_COUNT` dropped from 5 to 1 — just a small taste at the very top.
- The rest of the eligible trending items now splice into the feed via `interleave()` (same mechanism waves already uses), one every 15 posts, instead of piling at the front.

## Test plan
- [x] Manual verification of the splice logic via existing `utils/interleave.ts` behavior (dedupe against base already covered by existing tests)
- [ ] Manual check in the running app: Newest tab shows only 1 trending item at top, remaining trending items appear scattered further down the scroll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Newest snaps feed so trending and resurrected snaps are distributed more naturally instead of appearing all at the top.
  * Preserved muted-author filtering and existing feed-scope restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->