### PR TITLE
feat: integrate Snapie Points earning and display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ EXPO_PUBLIC_LIVEKIT_URL=wss://livekit.3speak.tv
 # Snapie Translation API (self-hosted LibreTranslate)
 EXPO_PUBLIC_LIBRETRANSLATE_URL=https://translate.snapie.io
 EXPO_PUBLIC_LIBRETRANSLATE_KEY=your_libretranslate_key_here
+
+# Snapie Points (ship-dark feature flag — set to "true" to enable earning/display)
+EXPO_PUBLIC_ENABLE_POINTS=false

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import { HivePostPreviewProvider } from '../context/HivePostPreviewContext';
 import { ShareProvider } from '../context/ShareContext';
 import { AppProvider } from '../store/context';
 import TOSWrapper from '../components/TOSWrapper';
+import { PointsToast } from './components/points/PointsToast';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -98,8 +99,10 @@ function RootLayoutNav() {
                 <Stack.Screen name='screens/WalletScreen' />
                 <Stack.Screen name='screens/HangoutsLobbyScreen' />
                 <Stack.Screen name='screens/HangoutsRoomScreen' />
+                <Stack.Screen name='screens/PointsLeaderboardScreen' />
                 <Stack.Screen name='modal' options={{ presentation: 'modal' }} />
               </Stack>
+              <PointsToast />
             </TOSWrapper>
           </ThemeProvider>
         </HivePostPreviewProvider>

--- a/app/components/points/PointsToast.tsx
+++ b/app/components/points/PointsToast.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet, Text, useColorScheme } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { getTheme } from '../../../constants/Colors';
+import { onPointsEarned } from '../../../utils/pointsEvents';
+
+const VISIBLE_MS = 2500;
+const ANIM_MS = 200;
+
+// Mounted once at the app root (app/_layout.tsx) — earning can happen from
+// the feed (vote), the compose flow (snap), or a reply modal, so this needs
+// to render regardless of which screen is currently active.
+export const PointsToast: React.FC = () => {
+  const colorScheme = useColorScheme() || 'light';
+  const theme = getTheme(colorScheme === 'dark' ? 'dark' : 'light');
+  const [awarded, setAwarded] = useState<number | null>(null);
+  const translateY = useRef(new Animated.Value(-80)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return onPointsEarned(detail => {
+      if (hideTimer.current) clearTimeout(hideTimer.current);
+      setAwarded(detail.awarded);
+
+      Animated.parallel([
+        Animated.timing(translateY, { toValue: 0, duration: ANIM_MS, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 1, duration: ANIM_MS, useNativeDriver: true }),
+      ]).start();
+
+      hideTimer.current = setTimeout(() => {
+        Animated.parallel([
+          Animated.timing(translateY, { toValue: -80, duration: ANIM_MS, useNativeDriver: true }),
+          Animated.timing(opacity, { toValue: 0, duration: ANIM_MS, useNativeDriver: true }),
+        ]).start(() => setAwarded(null));
+      }, VISIBLE_MS);
+    });
+  }, [translateY, opacity]);
+
+  useEffect(() => {
+    return () => {
+      if (hideTimer.current) clearTimeout(hideTimer.current);
+    };
+  }, []);
+
+  if (awarded === null) return null;
+
+  return (
+    <SafeAreaView style={styles.safeArea} pointerEvents="none">
+      <Animated.View
+        style={[
+          styles.toast,
+          { backgroundColor: theme.bubble, borderColor: theme.border, transform: [{ translateY }], opacity },
+        ]}
+      >
+        <Text style={[styles.text, { color: theme.text }]}>+{awarded} points</Text>
+      </Animated.View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 1000,
+  },
+  toast: {
+    marginTop: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 20,
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});

--- a/app/components/profile/PointsSection.tsx
+++ b/app/components/profile/PointsSection.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import type { Href } from 'expo-router';
+import { usePointsSummary } from '../../../hooks/usePointsSummary';
+import { isPointsEnabled } from '../../../utils/pointsConfig';
+
+interface PointsSectionProps {
+    isOwnProfile: boolean;
+    /** Whose points to display — the profile currently being viewed. */
+    profileUsername: string | null | undefined;
+    /** Logged-in viewer — used only for the feature-flag gate, not to pick whose stats show. */
+    viewerUsername: string | null | undefined;
+    colors: {
+        text: string;
+        textSecondary: string;
+        bubble: string;
+        border: string;
+        icon: string;
+        button: string;
+        buttonText: string;
+    };
+}
+
+export const PointsSection: React.FC<PointsSectionProps> = ({ isOwnProfile, profileUsername, viewerUsername, colors }) => {
+    const router = useRouter();
+    const enabled = isPointsEnabled(viewerUsername);
+    const { summary, loading } = usePointsSummary(enabled ? profileUsername : null);
+
+    if (!enabled) return null;
+    if (!loading && !summary) return null;
+
+    return (
+        <View style={[localStyles.container, { backgroundColor: colors.bubble, borderColor: colors.border }]}>
+            <View style={localStyles.headerRow}>
+                <FontAwesome name="star" size={13} color={colors.textSecondary} />
+                <Text style={[localStyles.sectionTitle, { color: colors.textSecondary }]}>SNAPIE POINTS</Text>
+            </View>
+
+            {/* Balance is a spendable amount — only meaningful/shown on the account owner's own view. */}
+            {isOwnProfile && (
+                <View style={localStyles.balanceRow}>
+                    <Text style={[localStyles.balanceLabel, { color: colors.textSecondary }]}>Balance</Text>
+                    <Text style={[localStyles.balanceValue, { color: colors.text }]}>{summary?.balance ?? '–'}</Text>
+                </View>
+            )}
+            <View style={localStyles.balanceRow}>
+                <Text style={[localStyles.balanceLabel, { color: colors.textSecondary }]}>Lifetime Earned</Text>
+                <Text style={[localStyles.balanceValue, { color: colors.text }]}>{summary?.lifetimeEarned ?? '–'}</Text>
+            </View>
+            {summary?.rank != null && (
+                <View style={localStyles.balanceRow}>
+                    <Text style={[localStyles.balanceLabel, { color: colors.textSecondary }]}>Rank</Text>
+                    <Text style={[localStyles.balanceValue, { color: colors.text }]}>#{summary.rank}</Text>
+                </View>
+            )}
+
+            <TouchableOpacity
+                style={[localStyles.leaderboardButton, { backgroundColor: colors.button }]}
+                onPress={() => router.push('/screens/PointsLeaderboardScreen' as Href)}
+                accessibilityRole="button"
+                accessibilityLabel="View points leaderboard"
+            >
+                <Text style={[localStyles.leaderboardButtonText, { color: colors.buttonText }]}>Leaderboard</Text>
+                <FontAwesome name="chevron-right" size={11} color={colors.buttonText} />
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+const localStyles = StyleSheet.create({
+    container: {
+        borderRadius: 12,
+        borderWidth: 1,
+        padding: 16,
+        marginHorizontal: 16,
+        marginBottom: 12,
+    },
+    headerRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        marginBottom: 12,
+    },
+    sectionTitle: {
+        fontSize: 11,
+        fontWeight: '600',
+        letterSpacing: 0.8,
+    },
+    balanceRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingVertical: 6,
+    },
+    balanceLabel: {
+        fontSize: 15,
+        fontWeight: '500',
+    },
+    balanceValue: {
+        fontSize: 15,
+        fontWeight: '700',
+    },
+    leaderboardButton: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 6,
+        paddingVertical: 12,
+        paddingHorizontal: 24,
+        borderRadius: 8,
+        marginTop: 12,
+    },
+    leaderboardButtonText: {
+        fontSize: 14,
+        fontWeight: '600',
+    },
+});

--- a/app/screens/PointsLeaderboardScreen.tsx
+++ b/app/screens/PointsLeaderboardScreen.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { FontAwesome } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useTheme } from '../../hooks/useTheme';
+import { useAuth } from '../../store/context';
+import { fetchLeaderboard, LeaderboardEntry } from '../../services/pointsService';
+
+const PAGE_SIZE = 50;
+
+const PointsLeaderboardScreen = (): React.JSX.Element => {
+  const theme = useTheme();
+  const router = useRouter();
+  const { currentUsername } = useAuth();
+
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const page = await fetchLeaderboard(PAGE_SIZE, 0);
+      if (cancelled) return;
+      setEntries(page.entries);
+      setHasMore(page.hasMore);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    const page = await fetchLeaderboard(PAGE_SIZE, entries.length);
+    setEntries(prev => [...prev, ...page.entries]);
+    setHasMore(page.hasMore);
+    setLoadingMore(false);
+  }, [loadingMore, hasMore, entries.length]);
+
+  const renderItem = useCallback(({ item }: { item: LeaderboardEntry }) => {
+    const isSelf = item.username === currentUsername;
+    return (
+      <View
+        style={[
+          styles.row,
+          { borderBottomColor: theme.border },
+          isSelf && { backgroundColor: theme.bubble },
+        ]}
+      >
+        <Text style={[styles.rank, { color: theme.textSecondary }]}>#{item.rank}</Text>
+        <Text style={[styles.username, { color: theme.text }]} numberOfLines={1}>@{item.username}</Text>
+        <Text style={[styles.points, { color: theme.text }]}>{item.lifetimeEarned}</Text>
+      </View>
+    );
+  }, [currentUsername, theme]);
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <TouchableOpacity onPress={() => router.back()} accessibilityRole="button" accessibilityLabel="Go back">
+          <FontAwesome name="chevron-left" size={18} color={theme.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: theme.text }]}>Points Leaderboard</Text>
+        <View style={{ width: 18 }} />
+      </View>
+
+      {loading ? (
+        <ActivityIndicator style={styles.loadingIndicator} color={theme.icon} />
+      ) : (
+        <FlatList
+          data={entries}
+          keyExtractor={item => item.username}
+          renderItem={renderItem}
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={loadingMore ? <ActivityIndicator style={styles.loadingIndicator} color={theme.icon} /> : null}
+          ListEmptyComponent={
+            <Text style={[styles.emptyText, { color: theme.textSecondary }]}>No one has earned points yet.</Text>
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+};
+
+export default PointsLeaderboardScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    gap: 12,
+  },
+  rank: {
+    width: 40,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  username: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  points: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  loadingIndicator: {
+    marginTop: 24,
+  },
+  emptyText: {
+    textAlign: 'center',
+    marginTop: 32,
+    fontSize: 14,
+  },
+});

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -25,6 +25,7 @@ import { ActiveKeyModal } from '../components/profile/ActiveKeyModal';
 import { ProfileHeader } from '../components/profile/ProfileHeader';
 import { RewardsSection } from '../components/profile/RewardsSection';
 import { WalletSection } from '../components/profile/WalletSection';
+import { PointsSection } from '../components/profile/PointsSection';
 import { ProfileSnaps } from '../components/profile/ProfileSnaps';
 // ContentModal removed - now using ComposeScreen for edit
 
@@ -364,6 +365,14 @@ const ProfileScreen = () => {
               colors={colors}
               styles={styles}
               handleClaimRewards={handleClaimRewards}
+            />
+
+            {/* Snapie Points Section */}
+            <PointsSection
+              isOwnProfile={isOwnProfile}
+              profileUsername={profile.username}
+              viewerUsername={currentUsername}
+              colors={colors}
             />
 
             {/* Wallet Section — only shown when active key stored AND device auth available */}

--- a/hooks/__tests__/useAuth.test.ts
+++ b/hooks/__tests__/useAuth.test.ts
@@ -23,6 +23,10 @@ jest.mock('../../services/AuthService', () => ({
     },
 }));
 
+jest.mock('../../services/pointsAuthService', () => ({
+    clearPointsAuthToken: jest.fn(),
+}));
+
 jest.mock('../../store/context', () => ({
     useAppStore: jest.fn(),
 }));

--- a/hooks/__tests__/usePointsSummary.test.tsx
+++ b/hooks/__tests__/usePointsSummary.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for usePointsSummary — fetches a user's points summary on mount/
+ * username change, and reacts live to a pointsEvents "earned" notification
+ * with an optimistic bump followed by a refetch.
+ */
+
+jest.mock('../../services/pointsService', () => ({
+  fetchPointsSummary: jest.fn(),
+}));
+
+jest.mock('../../utils/pointsEvents', () => ({
+  onPointsEarned: jest.fn(),
+}));
+
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { usePointsSummary, UsePointsSummaryResult } from '../usePointsSummary';
+import { fetchPointsSummary } from '../../services/pointsService';
+import { onPointsEarned } from '../../utils/pointsEvents';
+
+const mockFetchPointsSummary = fetchPointsSummary as jest.Mock;
+const mockOnPointsEarned = onPointsEarned as jest.Mock;
+
+// `container` is mutated in place on every re-render, so callers must read
+// `container.result` fresh after each `act()` rather than destructuring it
+// once — the hook returns a new object per render.
+function renderUsePointsSummary(username: string | null | undefined): { result: UsePointsSummaryResult } {
+  const container: { result: UsePointsSummaryResult } = { result: null as unknown as UsePointsSummaryResult };
+  const TestComponent = () => { container.result = usePointsSummary(username); return null; };
+  act(() => { create(React.createElement(TestComponent)); });
+  return container;
+}
+
+describe('usePointsSummary', () => {
+  let earnedListener: ((detail: { awarded: number; balance: number }) => void) | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    earnedListener = null;
+    mockOnPointsEarned.mockImplementation((cb: (detail: { awarded: number; balance: number }) => void) => {
+      earnedListener = cb;
+      return () => { earnedListener = null; };
+    });
+  });
+
+  it('fetches and returns the summary on mount', async () => {
+    mockFetchPointsSummary.mockResolvedValueOnce({ username: 'alice', balance: 10, lifetimeEarned: 25, rank: 3 });
+
+    const hook = renderUsePointsSummary('alice');
+    await act(async () => { await Promise.resolve(); });
+
+    expect(hook.result.summary).toEqual({ username: 'alice', balance: 10, lifetimeEarned: 25, rank: 3 });
+    expect(hook.result.loading).toBe(false);
+    expect(hook.result.error).toBeNull();
+    expect(mockFetchPointsSummary).toHaveBeenCalledWith('alice');
+  });
+
+  it('returns a null summary and does not call the service when there is no username', async () => {
+    const hook = renderUsePointsSummary(null);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(hook.result.summary).toBeNull();
+    expect(mockFetchPointsSummary).not.toHaveBeenCalled();
+  });
+
+  it('sets an error and leaves summary null when the fetch fails', async () => {
+    mockFetchPointsSummary.mockResolvedValueOnce(null);
+
+    const hook = renderUsePointsSummary('alice');
+    await act(async () => { await Promise.resolve(); });
+
+    expect(hook.result.summary).toBeNull();
+    expect(hook.result.error).toBe('Failed to load points summary');
+  });
+
+  it('optimistically bumps balance/lifetimeEarned on a pointsEarned notification, then refetches', async () => {
+    mockFetchPointsSummary.mockResolvedValueOnce({ username: 'alice', balance: 10, lifetimeEarned: 25, rank: 3 });
+    const hook = renderUsePointsSummary('alice');
+    await act(async () => { await Promise.resolve(); });
+
+    mockFetchPointsSummary.mockResolvedValueOnce({ username: 'alice', balance: 11, lifetimeEarned: 26, rank: 3 });
+
+    expect(earnedListener).not.toBeNull();
+    await act(async () => {
+      earnedListener!({ awarded: 1, balance: 11 });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hook.result.summary?.balance).toBe(11);
+    expect(hook.result.summary?.lifetimeEarned).toBe(26);
+    expect(mockFetchPointsSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribes from pointsEvents on unmount', async () => {
+    const unsubscribe = jest.fn();
+    mockOnPointsEarned.mockImplementation(() => unsubscribe);
+    mockFetchPointsSummary.mockResolvedValueOnce({ username: 'alice', balance: 10, lifetimeEarned: 25, rank: 3 });
+
+    let renderer: ReturnType<typeof create> | null = null;
+    const TestComponent = () => { usePointsSummary('alice'); return null; };
+    act(() => { renderer = create(React.createElement(TestComponent)); });
+    await act(async () => { await Promise.resolve(); });
+
+    act(() => { renderer!.unmount(); });
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -7,6 +7,7 @@ import { useRouter } from 'expo-router';
 import { useAppStore } from '../store/context';
 import { authService } from '../services/AuthService';
 import { accountStorageService } from '../services/AccountStorageService';
+import { clearPointsAuthToken } from '../services/pointsAuthService';
 
 export const useAuth = () => {
   const router = useRouter();
@@ -74,6 +75,7 @@ export const useAuth = () => {
       throw error;
     }
     authService.logout();
+    void clearPointsAuthToken();
     clearAuth();
     setCurrentUser(null);
     setHasActiveKey(false);
@@ -89,6 +91,7 @@ export const useAuth = () => {
       throw new Error(`No keys found for account @${username}`);
     }
     await accountStorageService.setCurrentAccountUsername(username);
+    void clearPointsAuthToken(); // previous account's cached JWT must not leak onto the new one
     setCurrentUser(username);
     setHasActiveKey(!!keys.activeKey);
     // Best-effort JWT — don't block the switch if it fails

--- a/hooks/useCompose.ts
+++ b/hooks/useCompose.ts
@@ -14,6 +14,8 @@ import { useReply } from './useReply';
 import { useEdit } from './useEdit';
 import { useGifPicker } from './useGifPickerV2';
 import { uploadAudioTo3Speak } from '../services/audioUploadService';
+import { awardPoints } from '../services/pointsService';
+import { isPointsEnabled } from '../utils/pointsConfig';
 
 const client = getClient();
 
@@ -728,6 +730,10 @@ export function useCompose({
                 },
                 postingKey
             );
+
+            if (isPointsEnabled(state.currentUsername)) {
+                awardPoints('snap', state.currentUsername, state.currentUsername, permlink);
+            }
 
             console.log('[useCompose] Post published successfully');
 

--- a/hooks/usePointsSummary.ts
+++ b/hooks/usePointsSummary.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { fetchPointsSummary, PointsSummary } from '../services/pointsService';
+import { onPointsEarned, PointsEarnedDetail } from '../utils/pointsEvents';
+
+export interface UsePointsSummaryResult {
+  summary: PointsSummary | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+// Fetches a user's points summary and keeps it live: refetches on username
+// change and optimistically bumps balance/lifetimeEarned the instant THIS
+// device earns (pointsEvents carries the fresh balance). Rank depends on
+// every other account, so it can't be computed optimistically — a real
+// refetch follows shortly after to correct it.
+export function usePointsSummary(username: string | null | undefined): UsePointsSummaryResult {
+  const [summary, setSummary] = useState<PointsSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => { isMountedRef.current = false; };
+  }, []);
+
+  const refetch = useCallback(async (): Promise<void> => {
+    if (!username) {
+      if (isMountedRef.current) setSummary(null);
+      return;
+    }
+    if (isMountedRef.current) { setLoading(true); setError(null); }
+    try {
+      const result = await fetchPointsSummary(username);
+      if (!isMountedRef.current) return;
+      if (result) {
+        setSummary(result);
+      } else {
+        setError('Failed to load points summary');
+      }
+    } finally {
+      if (isMountedRef.current) setLoading(false);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  useEffect(() => {
+    return onPointsEarned((detail: PointsEarnedDetail) => {
+      setSummary(prev =>
+        prev
+          ? { ...prev, balance: detail.balance, lifetimeEarned: prev.lifetimeEarned + detail.awarded }
+          : prev
+      );
+      void refetch();
+    });
+  }, [refetch]);
+
+  return { summary, loading, error, refetch };
+}

--- a/hooks/useReply.ts
+++ b/hooks/useReply.ts
@@ -5,6 +5,8 @@ import { accountStorageService } from '../services/AccountStorageService';
 import { uploadImageSmart } from '../utils/imageUploadService';
 import * as ImagePicker from 'expo-image-picker';
 import { convertImageSmart } from '../utils/imageConverter';
+import { awardPoints } from '../services/pointsService';
+import { isPointsEnabled } from '../utils/pointsConfig';
 
 const client = getClient();
 
@@ -283,6 +285,10 @@ export const useReply = (
         },
         postingKey
       );
+
+      if (isPointsEnabled(author)) {
+        awardPoints('comment', author, author, permlink);
+      }
 
       // Close modal and reset state
       closeReplyModal();

--- a/hooks/useUpvote.ts
+++ b/hooks/useUpvote.ts
@@ -6,6 +6,8 @@ import * as Haptics from 'expo-haptics';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { calculateVoteValue } from '../utils/calculateVoteValue';
 import { useOptimisticUpdates } from './useOptimisticUpdates';
+import { awardPoints } from '../services/pointsService';
+import { isPointsEnabled } from '../utils/pointsConfig';
 
 const client = getClient();
 
@@ -187,6 +189,10 @@ export const useUpvote = (
         },
         postingKey
       );
+
+      if (isPointsEnabled(username)) {
+        awardPoints('vote', username, upvoteTarget.author, upvoteTarget.permlink);
+      }
 
       // Persist the vote weight after successful vote
       await AsyncStorage.setItem('hivesnaps_vote_weight', String(voteWeight));

--- a/services/__tests__/pointsAuthService.test.ts
+++ b/services/__tests__/pointsAuthService.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for pointsAuthService — silent challenge/sign/verify against
+ * snapie.io's chat auth endpoints, with an AsyncStorage-cached JWT.
+ * bs58/elliptic/js-sha256 run for real (deterministic, no network) — only
+ * AsyncStorage, AccountStorageService, and fetch are mocked.
+ */
+
+import bs58 from 'bs58';
+
+const TEST_USERNAME = 'alice';
+// Any valid base58 string ≥33 bytes works — signChallenge only slices bytes
+// 1..33 as the private key scalar, it doesn't checksum-validate the WIF.
+const TEST_POSTING_KEY = bs58.encode(Buffer.alloc(37, 1));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+jest.mock('../AccountStorageService', () => ({
+  accountStorageService: {
+    getCurrentAccountUsername: jest.fn(),
+    getCurrentPostingKey: jest.fn(),
+  },
+}));
+
+type PointsAuthServiceModule = typeof import('../pointsAuthService');
+
+function mockFetchOnce(body: unknown, ok = true) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'Error',
+    json: () => Promise.resolve(body),
+  });
+}
+
+// Minimal unsigned JWT with a given exp claim (signature not verified client-side).
+function fakeJwt(expSecondsFromNow: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64');
+  const payload = Buffer.from(JSON.stringify({ sub: TEST_USERNAME, exp: Math.floor(Date.now() / 1000) + expSecondsFromNow })).toString('base64');
+  return `${header}.${payload}.sig`;
+}
+
+describe('pointsAuthService', () => {
+  let pointsAuthService: PointsAuthServiceModule;
+  let AsyncStorage: { getItem: jest.Mock; setItem: jest.Mock; removeItem: jest.Mock };
+  let accountStorageService: { getCurrentAccountUsername: jest.Mock; getCurrentPostingKey: jest.Mock };
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.fetch = jest.fn();
+
+    pointsAuthService = require('../pointsAuthService');
+    AsyncStorage = require('@react-native-async-storage/async-storage').default;
+    accountStorageService = require('../AccountStorageService').accountStorageService;
+
+    accountStorageService.getCurrentAccountUsername.mockResolvedValue(TEST_USERNAME);
+    accountStorageService.getCurrentPostingKey.mockResolvedValue(TEST_POSTING_KEY);
+    AsyncStorage.getItem.mockResolvedValue(null);
+  });
+
+  it('returns null with no accounts stored, minting nothing', async () => {
+    accountStorageService.getCurrentAccountUsername.mockResolvedValue(null);
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns a cached, still-fresh token from AsyncStorage without minting a new one', async () => {
+    const cachedToken = fakeJwt(3600);
+    AsyncStorage.getItem.mockResolvedValue(cachedToken);
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBe(cachedToken);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('mints a fresh token via challenge/sign/verify when nothing is cached', async () => {
+    mockFetchOnce({ challenge: 'nonce-123' });
+    mockFetchOnce({ token: 'fresh-jwt' });
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBe('fresh-jwt');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    const [challengeUrl, challengeInit] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(challengeUrl).toBe('https://snapie.io/api/chat/auth/challenge');
+    expect(JSON.parse(challengeInit.body)).toEqual({ username: TEST_USERNAME });
+
+    const [verifyUrl, verifyInit] = (global.fetch as jest.Mock).mock.calls[1];
+    expect(verifyUrl).toBe('https://snapie.io/api/chat/auth/verify');
+    const verifyBody = JSON.parse(verifyInit.body);
+    expect(verifyBody.username).toBe(TEST_USERNAME);
+    expect(verifyBody.challenge).toBe('nonce-123');
+    expect(typeof verifyBody.signature).toBe('string');
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('snapie-points-token', 'fresh-jwt');
+  });
+
+  it('discards an expired cached token and mints a fresh one', async () => {
+    AsyncStorage.getItem.mockResolvedValue(fakeJwt(-10));
+    mockFetchOnce({ challenge: 'nonce-123' });
+    mockFetchOnce({ token: 'fresh-jwt' });
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBe('fresh-jwt');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('snapie-points-token');
+  });
+
+  it('returns null (no throw) when there is no posting key to sign with', async () => {
+    accountStorageService.getCurrentPostingKey.mockResolvedValue(null);
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns null (no throw) when the challenge request fails', async () => {
+    mockFetchOnce({}, false);
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBeNull();
+  });
+
+  it('returns null (no throw) when the verify request fails', async () => {
+    mockFetchOnce({ challenge: 'nonce-123' });
+    mockFetchOnce({}, false);
+
+    const token = await pointsAuthService.getPointsAuthToken();
+
+    expect(token).toBeNull();
+  });
+
+  it('dedupes concurrent mint attempts for the same user into a single mint', async () => {
+    mockFetchOnce({ challenge: 'nonce-123' });
+    mockFetchOnce({ token: 'fresh-jwt' });
+
+    const [t1, t2] = await Promise.all([
+      pointsAuthService.getPointsAuthToken(),
+      pointsAuthService.getPointsAuthToken(),
+    ]);
+
+    expect(t1).toBe('fresh-jwt');
+    expect(t2).toBe('fresh-jwt');
+    expect(global.fetch).toHaveBeenCalledTimes(2); // one challenge + one verify, not two
+  });
+
+  it('clearPointsAuthToken removes the cached token', async () => {
+    await pointsAuthService.clearPointsAuthToken();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('snapie-points-token');
+  });
+});

--- a/services/__tests__/pointsService.test.ts
+++ b/services/__tests__/pointsService.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for pointsService — public reads (summary/leaderboard) plus the
+ * fire-and-forget award call.
+ */
+
+type PointsServiceModule = typeof import('../pointsService');
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function mockFetchOnce(body: unknown, ok = true, status = 200, statusText = 'OK') {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok,
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+  });
+}
+
+describe('pointsService', () => {
+  let pointsService: PointsServiceModule;
+  let getPointsAuthToken: jest.Mock;
+  let emitPointsEarned: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.fetch = jest.fn();
+
+    jest.doMock('../pointsAuthService', () => ({
+      getPointsAuthToken: jest.fn(),
+    }));
+    jest.doMock('../../utils/pointsEvents', () => ({
+      emitPointsEarned: jest.fn(),
+    }));
+
+    pointsService = require('../pointsService');
+    getPointsAuthToken = require('../pointsAuthService').getPointsAuthToken;
+    emitPointsEarned = require('../../utils/pointsEvents').emitPointsEarned;
+  });
+
+  describe('fetchPointsSummary', () => {
+    it('returns the summary from a successful fetch', async () => {
+      mockFetchOnce({ username: 'alice', balance: 10, lifetimeEarned: 25, rank: 3 });
+
+      const result = await pointsService.fetchPointsSummary('alice');
+
+      expect(result).toEqual({ username: 'alice', balance: 10, lifetimeEarned: 25, rank: 3 });
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('https://snapie.io/api/points/summary?username=alice');
+    });
+
+    it('returns null and does not throw on fetch failure', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network down'));
+
+      const result = await pointsService.fetchPointsSummary('alice');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on a non-OK HTTP response', async () => {
+      mockFetchOnce({}, false, 503, 'Service Unavailable');
+
+      const result = await pointsService.fetchPointsSummary('alice');
+
+      expect(result).toBeNull();
+    });
+
+    it('enters a cooldown after a failure and suppresses the next call without hitting fetch', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network down'));
+      await pointsService.fetchPointsSummary('alice');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const result = await pointsService.fetchPointsSummary('alice');
+
+      expect(global.fetch).toHaveBeenCalledTimes(1); // no second attempt while on cooldown
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchLeaderboard', () => {
+    it('returns the leaderboard page from a successful fetch', async () => {
+      const page = { entries: [{ rank: 1, username: 'alice', lifetimeEarned: 100, balance: 90 }], hasMore: true };
+      mockFetchOnce(page);
+
+      const result = await pointsService.fetchLeaderboard(50, 0);
+
+      expect(result).toEqual(page);
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('limit=50');
+      expect(calledUrl).toContain('offset=0');
+    });
+
+    it('returns an empty page and does not throw on fetch failure', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network down'));
+
+      const result = await pointsService.fetchLeaderboard();
+
+      expect(result).toEqual({ entries: [], hasMore: false });
+    });
+  });
+
+  describe('awardPoints', () => {
+    it('does nothing (no fetch) when no auth token is available', async () => {
+      getPointsAuthToken.mockResolvedValueOnce(null);
+
+      pointsService.awardPoints('vote', 'alice', 'bob', 'post-1');
+      await flushMicrotasks();
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(emitPointsEarned).not.toHaveBeenCalled();
+    });
+
+    it('posts the award and emits pointsEarned on a real award', async () => {
+      getPointsAuthToken.mockResolvedValueOnce('jwt-token');
+      mockFetchOnce({ status: 'awarded', awarded: 1, balance: 11 });
+
+      pointsService.awardPoints('vote', 'alice', 'bob', 'post-1');
+      await flushMicrotasks();
+
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toBe('https://snapie.io/api/points/award');
+      expect(init.headers.Authorization).toBe('Bearer jwt-token');
+      expect(JSON.parse(init.body)).toEqual({ actionType: 'vote', author: 'bob', permlink: 'post-1' });
+      expect(emitPointsEarned).toHaveBeenCalledWith({ awarded: 1, balance: 11 });
+    });
+
+    it('does not emit when the server rejects the award (capped/ineligible/muted)', async () => {
+      getPointsAuthToken.mockResolvedValueOnce('jwt-token');
+      mockFetchOnce({}, false, 403, 'Forbidden');
+
+      pointsService.awardPoints('vote', 'alice', 'bob', 'post-1');
+      await flushMicrotasks();
+
+      expect(emitPointsEarned).not.toHaveBeenCalled();
+    });
+
+    it('swallows a network error without throwing', async () => {
+      getPointsAuthToken.mockResolvedValueOnce('jwt-token');
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network down'));
+
+      expect(() => pointsService.awardPoints('vote', 'alice', 'bob', 'post-1')).not.toThrow();
+      await flushMicrotasks();
+
+      expect(emitPointsEarned).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/pointsAuthService.ts
+++ b/services/pointsAuthService.ts
@@ -1,0 +1,143 @@
+/**
+ * Snapie Points Authentication Service
+ * Silently authenticates with snapie.io using the locally stored posting key,
+ * to obtain the Bearer JWT the points award endpoint requires.
+ * Signing is copied verbatim from HangoutsAuthService.ts (bs58/elliptic, not
+ * dhive PrivateKey.sign) — snapie.io's verifyHiveSignature (lib/chat/auth.ts)
+ * already accepts this exact wire format.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Buffer } from 'buffer';
+import { sha256 } from 'js-sha256';
+import bs58 from 'bs58';
+import { ec as EC } from 'elliptic';
+import { accountStorageService } from './AccountStorageService';
+
+const SNAPIE_API_URL = 'https://snapie.io';
+const TOKEN_STORAGE_KEY = 'snapie-points-token';
+// Mirrors snapie.io's own client-side buffer (lib/points/client.ts) so a
+// token that's about to expire gets refreshed rather than used right up to
+// the wire and rejected mid-request.
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+const ec = new EC('secp256k1');
+
+/**
+ * Sign a challenge string with the posting key.
+ * snapie.io's chat auth verifies just the raw challenge (matching Keychain's
+ * requestSignBuffer behavior). Output format: [recoveryParam+31, r(32), s(32)]
+ * as hex — dhive Signature.fromString()/fromBuffer() wire format.
+ */
+function signChallenge(challenge: string, postingKey: string): string {
+  const decoded = bs58.decode(postingKey);
+  const privateKeyBytes = decoded.slice(1, 33);
+  const key = ec.keyFromPrivate(privateKeyBytes);
+  const hashHex = sha256(challenge).toString();
+  const hashBuffer = Buffer.from(hashHex, 'hex');
+  const sigObj = key.sign(hashBuffer, { canonical: true });
+  const recoveryParam = sigObj.recoveryParam ?? 0;
+  return Buffer.concat([
+    Buffer.from([recoveryParam + 31]),
+    sigObj.r.toArrayLike(Buffer, 'be', 32),
+    sigObj.s.toArrayLike(Buffer, 'be', 32),
+  ]).toString('hex');
+}
+
+/** Reads a JWT's `exp` claim without verifying the signature — a client-side
+ *  freshness hint only. Returns null if unreadable, in which case the caller
+ *  treats the token as still usable (the server is the real check). */
+function jwtExpiryMs(token: string): number | null {
+  try {
+    const payload = token.split('.')[1];
+    const json = JSON.parse(Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+    return typeof json.exp === 'number' ? json.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+// Deduplicates concurrent mint attempts, keyed by username so a mid-flight
+// account switch doesn't hand the new user a token minted for the old one.
+let tokenMintInFlight: { username: string; promise: Promise<string | null> } | null = null;
+
+async function mintToken(username: string, postingKey: string): Promise<string | null> {
+  const challengeRes = await fetch(`${SNAPIE_API_URL}/api/chat/auth/challenge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username }),
+  });
+  if (!challengeRes.ok) return null;
+  const { challenge } = (await challengeRes.json()) as { challenge?: string };
+  if (!challenge) return null;
+
+  const signature = signChallenge(challenge, postingKey);
+
+  const verifyRes = await fetch(`${SNAPIE_API_URL}/api/chat/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, challenge, signature }),
+  });
+  if (!verifyRes.ok) return null;
+  const { token } = (await verifyRes.json()) as { token?: string };
+  return token ?? null;
+}
+
+/** Returns a usable Bearer token for the points API — a cached one from
+ *  AsyncStorage if it's still fresh, otherwise silently mints a new one via
+ *  the challenge/sign/verify flow. Never throws; returns null on any failure
+ *  (no stored account, signing failure, network error) so callers can treat
+ *  "no token" the same as "points temporarily unavailable". */
+export async function getPointsAuthToken(): Promise<string | null> {
+  const username = await accountStorageService.getCurrentAccountUsername();
+  if (!username) return null;
+
+  try {
+    const cached = await AsyncStorage.getItem(TOKEN_STORAGE_KEY);
+    if (cached) {
+      const exp = jwtExpiryMs(cached);
+      if (exp === null || exp > Date.now() + TOKEN_EXPIRY_BUFFER_MS) return cached;
+      await AsyncStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  } catch {
+    // Storage unavailable — fall through to minting a fresh token.
+  }
+
+  if (tokenMintInFlight?.username === username) return tokenMintInFlight.promise;
+
+  const promise = (async () => {
+    try {
+      const postingKey = await accountStorageService.getCurrentPostingKey();
+      if (!postingKey) return null;
+
+      const token = await mintToken(username, postingKey);
+      if (token) {
+        try {
+          await AsyncStorage.setItem(TOKEN_STORAGE_KEY, token);
+        } catch {
+          // Non-fatal — the token still works for this session, just won't persist.
+        }
+      }
+      return token;
+    } catch (error) {
+      // Log message only — never log the full error object (may contain key material in stack traces)
+      console.warn('[pointsAuthService] Authentication failed:', error instanceof Error ? error.message : 'Unknown error');
+      return null;
+    } finally {
+      tokenMintInFlight = null;
+    }
+  })();
+
+  tokenMintInFlight = { username, promise };
+  return promise;
+}
+
+/** Clears the cached token — call on logout/account switch so a stale JWT
+ *  never leaks across accounts. */
+export async function clearPointsAuthToken(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TOKEN_STORAGE_KEY);
+  } catch {
+    // Nothing to clean up if storage isn't available.
+  }
+}

--- a/services/pointsService.ts
+++ b/services/pointsService.ts
@@ -1,0 +1,121 @@
+// Snapie Points — off-chain rewards for on-chain Hive actions, shared with
+// the snapie.io web app (same Hive username = same points account there).
+// Read endpoints are public; awarding requires the Bearer JWT from
+// pointsAuthService.ts, obtained by signing a challenge with the posting key.
+
+import { getPointsAuthToken } from './pointsAuthService';
+import { emitPointsEarned } from '../utils/pointsEvents';
+
+const SNAPIE_API_URL = 'https://snapie.io';
+const FETCH_TIMEOUT_MS = 10_000;
+const ERROR_RETRY_TTL_MS = 5 * 60 * 1000; // backoff after a failure
+
+export type PointsActionType = 'snap' | 'comment' | 'vote';
+
+export interface PointsSummary {
+  username: string;
+  balance: number;
+  lifetimeEarned: number;
+  rank: number | null;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  username: string;
+  lifetimeEarned: number;
+  balance: number;
+}
+
+export interface LeaderboardPage {
+  entries: LeaderboardEntry[];
+  hasMore: boolean;
+}
+
+let summaryCooldownUntil = 0;
+let leaderboardCooldownUntil = 0;
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchPointsSummary(username: string): Promise<PointsSummary | null> {
+  if (Date.now() < summaryCooldownUntil) return null;
+
+  try {
+    const res = await fetchWithTimeout(
+      `${SNAPIE_API_URL}/api/points/summary?username=${encodeURIComponent(username)}`
+    );
+    if (!res.ok) {
+      throw new Error(`Points summary fetch failed: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as PointsSummary;
+  } catch (error) {
+    console.error('[pointsService] Error fetching points summary:', error);
+    summaryCooldownUntil = Date.now() + ERROR_RETRY_TTL_MS;
+    return null;
+  }
+}
+
+export async function fetchLeaderboard(limit = 50, offset = 0): Promise<LeaderboardPage> {
+  const empty: LeaderboardPage = { entries: [], hasMore: false };
+  if (Date.now() < leaderboardCooldownUntil) return empty;
+
+  const params = new URLSearchParams({ limit: limit.toString(), offset: offset.toString() });
+
+  try {
+    const res = await fetchWithTimeout(`${SNAPIE_API_URL}/api/points/leaderboard?${params.toString()}`);
+    if (!res.ok) {
+      throw new Error(`Leaderboard fetch failed: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as LeaderboardPage;
+  } catch (error) {
+    console.error('[pointsService] Error fetching leaderboard:', error);
+    leaderboardCooldownUntil = Date.now() + ERROR_RETRY_TTL_MS;
+    return empty;
+  }
+}
+
+/** Fire-and-forget award report. Points must NEVER disrupt the underlying user
+ *  action, so this is non-blocking and swallows every error. On a real award
+ *  it emits via pointsEvents so the toast + any live balance display can react. */
+export function awardPoints(
+  actionType: PointsActionType,
+  username: string,
+  targetAuthor: string,
+  targetPermlink: string
+): void {
+  void (async () => {
+    try {
+      const token = await getPointsAuthToken();
+      if (!token) return; // no session (e.g. no stored posting key) — nothing about this should surface to the user
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      let awardRes: Response;
+      try {
+        awardRes = await fetch(`${SNAPIE_API_URL}/api/points/award`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ actionType, author: targetAuthor, permlink: targetPermlink }),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+      if (!awardRes.ok) return; // server rejected (ineligible, capped, muted, etc.) — silent by design
+
+      const data = (await awardRes.json()) as { status?: string; awarded?: number; balance?: number };
+      if (data?.status === 'awarded' && (data.awarded ?? 0) > 0) {
+        emitPointsEarned({ awarded: data.awarded!, balance: data.balance ?? 0 });
+      }
+    } catch {
+      // Swallow — nothing about points should ever surface to the user.
+    }
+  })();
+}

--- a/utils/pointsConfig.ts
+++ b/utils/pointsConfig.ts
@@ -1,0 +1,10 @@
+// Snapie Points gating — mirrors snapie.io's own lib/points/config.ts ship-dark
+// pattern. The award endpoint is server-authoritative regardless (eligibility,
+// mutes, daily caps are all enforced there); this flag only controls whether
+// hivesnaps shows points UI and signs/sends award calls at all.
+
+const POINTS_FEATURE_FLAG = process.env.EXPO_PUBLIC_ENABLE_POINTS === 'true';
+
+export function isPointsEnabled(username?: string | null): boolean {
+  return POINTS_FEATURE_FLAG && !!username;
+}

--- a/utils/pointsEvents.ts
+++ b/utils/pointsEvents.ts
@@ -1,0 +1,21 @@
+// RN has no window.dispatchEvent/CustomEvent — this is the mobile stand-in
+// for the DOM CustomEvent snapie.io's web client uses to notify the toast
+// and any live balance display the instant an award lands on this device.
+
+export interface PointsEarnedDetail {
+  awarded: number;
+  balance: number;
+}
+
+type Listener = (detail: PointsEarnedDetail) => void;
+
+const listeners = new Set<Listener>();
+
+export function onPointsEarned(cb: Listener): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+export function emitPointsEarned(detail: PointsEarnedDetail): void {
+  listeners.forEach(cb => cb(detail));
+}


### PR DESCRIPTION
## Summary
- Brings the existing snapie.io "Snapie Points" off-chain rewards system into hivesnaps — previously only earnable/visible via the snapie.io web app, even though hivesnaps users perform the same rewarded actions (snap, comment, vote). Same backend, same balance per Hive username.
- Auth: silent challenge/sign/verify against snapie.io using the already-stored posting key (reuses the exact signing routine from `HangoutsAuthService.ts`), JWT cached in AsyncStorage.
- Earning: fire-and-forget award calls wired in right after a snap post (`useCompose.ts`), reply (`useReply.ts`), and vote (`useUpvote.ts`) broadcast succeeds — never blocks or disrupts the underlying action on failure.
- Display: new points section on `ProfileScreen` (balance/lifetime earned/rank — balance shown only on your own profile, lifetime earned + rank shown on anyone's), linking to a new `PointsLeaderboardScreen`. A lightweight toast fires on award.
- Shipped dark behind `EXPO_PUBLIC_ENABLE_POINTS` (defaults false in `.env.example`) — the snapie.io server remains authoritative on eligibility either way.
- `useAuth.ts` clears the cached points JWT on logout/account switch so it can't leak across accounts.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest --watchAll=false` — 217 tests passing across 16 suites, including new coverage for `pointsService`, `pointsAuthService`, and `usePointsSummary`
- [ ] Manual, with `EXPO_PUBLIC_ENABLE_POINTS=true` and a real Hive account: post a snap / reply / vote, confirm the toast fires and the balance on `ProfileScreen` moves; cross-check `GET https://snapie.io/api/points/summary?username=<test>` shows the same increase (proves the shared backend actually recorded it, not just local state)
- [ ] Manual: kill/relaunch the app, confirm the cached JWT survives silently (no re-signature prompt); log out and switch accounts, confirm no stale balance/token leaks across accounts